### PR TITLE
Add conservative cubed-sphere hierarchy

### DIFF
--- a/docs/specs/02_topology.md
+++ b/docs/specs/02_topology.md
@@ -76,18 +76,30 @@ cell corners. On the unit sphere:
 
 Physical area is canonical steradian area multiplied by planet radius squared.
 
-## Multi-Resolution Requirements
+## Multi-Resolution Operations
 
-Later levels use face resolutions related by powers of two. Required operations:
+Levels use integer refinement factors, with powers of two as the normal
+production hierarchy. Refinement never changes a cell's face. Children are
+ordered row-major within each parent, and global IDs remain local to a specific
+resolution.
 
-- Parent/child global-ID mapping.
-- Area-conserving restriction for extensive quantities.
-- Area-weighted restriction for intensive quantities.
-- Constrained interpolation for refinement priors.
-- Cross-face halo exchange with no duplicated authoritative cells.
+The native topology library provides coarse-buffer operations for:
 
-These operations remain pending; the current milestone establishes only the
-single-resolution geometry and D4 graph they depend on.
+- Fine-cell to parent and parent to child global-ID mappings.
+- Restriction of extensive quantities by summing children.
+- Restriction of intensive quantities by spherical-area-weighted mean.
+- Constant prolongation that copies a parent prior to all children.
+- Width-one float32/float64 D4 face halos sourced through canonical cross-face
+  neighbors without dtype narrowing.
+
+Restriction rejects non-finite values and non-positive or non-finite areas.
+It also rejects accumulation overflow instead of publishing non-finite parent
+fields.
+Constant prolongation is a prior transfer, not the final constrained
+interpolation needed for detailed terrain refinement. Halo interiors and edges
+are populated, while the four cube-corner diagonals are `NaN` until D8 and
+vector-basis transport define their semantics. Authoritative state remains the
+unhaloed six-face field.
 
 ## Diagnostics
 
@@ -111,6 +123,10 @@ The cube net is a topology diagnostic, not an atlas projection.
 - Maximum/minimum cell area ratio is below `1.5` for the equiangular grid.
 - Maximum/minimum D4 angular-spacing ratio is below `1.5`.
 - The fixed cube-net diagnostic has no discontinuity on touching face edges.
+- Parent and child maps are inverse under every tested refinement factor.
+- Extensive totals and area-weighted intensive integrals survive restriction.
+- Restricted fine-cell areas match directly generated parent-cell areas.
+- D4 halo edges exactly match canonical cross-face neighbor values.
 - Native generation remains a coarse call and does not compile during import.
 
 ## Migration Boundary

--- a/src/map_maker/pipeline/_cubed_sphere_native.py
+++ b/src/map_maker/pipeline/_cubed_sphere_native.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import numpy as np
 from cffi import FFI
 
-from .._native import native_library_info, native_library_path
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
 
 FACE_COUNT = 6
 D4_NEIGHBORS = 4
+HIERARCHY_ABI_VERSION = 1
 
 _CDEF = """
 int32_t cubed_sphere_generate(
@@ -19,22 +20,101 @@ int32_t cubed_sphere_generate(
     double* area,
     int32_t* neighbors
 );
+int32_t cubed_sphere_parent_map(
+    int32_t fine_resolution,
+    int32_t factor,
+    int32_t* parent
+);
+int32_t cubed_sphere_children_map(
+    int32_t coarse_resolution,
+    int32_t factor,
+    int32_t* children
+);
+int32_t cubed_sphere_restrict_extensive_f64(
+    int32_t fine_resolution,
+    int32_t factor,
+    const double* fine_values,
+    double* coarse_values
+);
+int32_t cubed_sphere_restrict_intensive_f64(
+    int32_t fine_resolution,
+    int32_t factor,
+    const double* fine_values,
+    const double* fine_areas,
+    double* coarse_values
+);
+int32_t cubed_sphere_prolongate_constant_f64(
+    int32_t coarse_resolution,
+    int32_t factor,
+    const double* coarse_values,
+    double* fine_values
+);
+int32_t cubed_sphere_fill_d4_halo_f32(
+    int32_t face_resolution,
+    const float* values,
+    float* halo
+);
+int32_t cubed_sphere_fill_d4_halo_f64(
+    int32_t face_resolution,
+    const double* values,
+    double* halo
+);
+uint32_t cubed_sphere_hierarchy_abi_version(void);
 """
 
 _ffi = FFI()
 _ffi.cdef(_CDEF)
 native_library_info("topology_native")
 _lib = _ffi.dlopen(str(native_library_path("topology_native")))
+try:
+    _hierarchy_abi_version = int(_lib.cubed_sphere_hierarchy_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "topology_native lacks the cubed-sphere hierarchy API; rebuild native libraries"
+    ) from exc
+if _hierarchy_abi_version != HIERARCHY_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "topology_native cubed-sphere hierarchy ABI "
+        f"{_hierarchy_abi_version} does not match expected {HIERARCHY_ABI_VERSION}"
+    )
 
 
-def generate_cubed_sphere(
-    face_resolution: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def _cell_count(face_resolution: int) -> int:
     if face_resolution <= 0:
         raise ValueError("face_resolution must be positive")
     cells = FACE_COUNT * face_resolution * face_resolution
     if cells > np.iinfo(np.int32).max:
         raise ValueError("face_resolution exceeds int32 global-index capacity")
+    return cells
+
+
+def _validate_factor(face_resolution: int, factor: int, *, require_divisible: bool) -> None:
+    if factor <= 1:
+        raise ValueError("factor must be greater than one")
+    if require_divisible and face_resolution % factor != 0:
+        raise ValueError("factor must divide face_resolution exactly")
+
+
+def _face_field(values: np.ndarray, dtype: np.dtype, *, name: str) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim != 3 or array.shape[0] != FACE_COUNT or array.shape[1] != array.shape[2]:
+        raise ValueError(f"{name} must have shape (6, n, n)")
+    _cell_count(array.shape[1])
+    return np.ascontiguousarray(array, dtype=dtype)
+
+
+def _raise_for_status(operation: str, status: int) -> None:
+    if status == 0:
+        return
+    if status == 3:
+        raise ValueError(f"{operation} requires finite values and positive finite cell areas")
+    raise RuntimeError(f"{operation} kernel failed with status {status}")
+
+
+def generate_cubed_sphere(
+    face_resolution: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    _cell_count(face_resolution)
     xyz = np.empty((FACE_COUNT, face_resolution, face_resolution, 3), dtype=np.float32)
     longitude = np.empty((FACE_COUNT, face_resolution, face_resolution), dtype=np.float64)
     latitude = np.empty_like(longitude)
@@ -50,9 +130,125 @@ def generate_cubed_sphere(
         _ffi.cast("double*", _ffi.from_buffer("double[]", area)),
         _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", neighbors)),
     )
-    if status != 0:
-        raise RuntimeError(f"cubed-sphere kernel failed with status {status}")
+    _raise_for_status("cubed-sphere generation", status)
     return xyz, longitude, latitude, area, neighbors
 
 
-__all__ = ["D4_NEIGHBORS", "FACE_COUNT", "generate_cubed_sphere"]
+def parent_map(fine_resolution: int, factor: int) -> np.ndarray:
+    _cell_count(fine_resolution)
+    _validate_factor(fine_resolution, factor, require_divisible=True)
+    parents = np.empty((FACE_COUNT, fine_resolution, fine_resolution), dtype=np.int32)
+    status = _lib.cubed_sphere_parent_map(
+        fine_resolution,
+        factor,
+        _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", parents)),
+    )
+    _raise_for_status("cubed-sphere parent mapping", status)
+    return parents
+
+
+def children_map(coarse_resolution: int, factor: int) -> np.ndarray:
+    _cell_count(coarse_resolution)
+    _validate_factor(coarse_resolution, factor, require_divisible=False)
+    fine_resolution = coarse_resolution * factor
+    _cell_count(fine_resolution)
+    children = np.empty(
+        (FACE_COUNT, coarse_resolution, coarse_resolution, factor * factor), dtype=np.int32
+    )
+    status = _lib.cubed_sphere_children_map(
+        coarse_resolution,
+        factor,
+        _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", children)),
+    )
+    _raise_for_status("cubed-sphere children mapping", status)
+    return children
+
+
+def restrict_extensive(values: np.ndarray, factor: int) -> np.ndarray:
+    fine = _face_field(values, np.dtype(np.float64), name="values")
+    fine_resolution = fine.shape[1]
+    _validate_factor(fine_resolution, factor, require_divisible=True)
+    coarse_resolution = fine_resolution // factor
+    coarse = np.empty((FACE_COUNT, coarse_resolution, coarse_resolution), dtype=np.float64)
+    status = _lib.cubed_sphere_restrict_extensive_f64(
+        fine_resolution,
+        factor,
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", fine)),
+        _ffi.cast("double*", _ffi.from_buffer("double[]", coarse)),
+    )
+    _raise_for_status("cubed-sphere extensive restriction", status)
+    return coarse
+
+
+def restrict_intensive(values: np.ndarray, areas: np.ndarray, factor: int) -> np.ndarray:
+    fine = _face_field(values, np.dtype(np.float64), name="values")
+    fine_areas = _face_field(areas, np.dtype(np.float64), name="areas")
+    if fine.shape != fine_areas.shape:
+        raise ValueError("values and areas must have the same shape")
+    fine_resolution = fine.shape[1]
+    _validate_factor(fine_resolution, factor, require_divisible=True)
+    coarse_resolution = fine_resolution // factor
+    coarse = np.empty((FACE_COUNT, coarse_resolution, coarse_resolution), dtype=np.float64)
+    status = _lib.cubed_sphere_restrict_intensive_f64(
+        fine_resolution,
+        factor,
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", fine)),
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", fine_areas)),
+        _ffi.cast("double*", _ffi.from_buffer("double[]", coarse)),
+    )
+    _raise_for_status("cubed-sphere intensive restriction", status)
+    return coarse
+
+
+def prolongate_constant(values: np.ndarray, factor: int) -> np.ndarray:
+    coarse = _face_field(values, np.dtype(np.float64), name="values")
+    coarse_resolution = coarse.shape[1]
+    _validate_factor(coarse_resolution, factor, require_divisible=False)
+    fine_resolution = coarse_resolution * factor
+    _cell_count(fine_resolution)
+    fine = np.empty((FACE_COUNT, fine_resolution, fine_resolution), dtype=np.float64)
+    status = _lib.cubed_sphere_prolongate_constant_f64(
+        coarse_resolution,
+        factor,
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", coarse)),
+        _ffi.cast("double*", _ffi.from_buffer("double[]", fine)),
+    )
+    _raise_for_status("cubed-sphere constant prolongation", status)
+    return fine
+
+
+def fill_d4_halo(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values)
+    if array.dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+        raise TypeError("values must use float32 or float64 for D4 halo exchange")
+    field = _face_field(array, array.dtype, name="values")
+    resolution = field.shape[1]
+    halo = np.empty((FACE_COUNT, resolution + 2, resolution + 2), dtype=field.dtype)
+    if field.dtype == np.dtype(np.float32):
+        status = _lib.cubed_sphere_fill_d4_halo_f32(
+            resolution,
+            _ffi.cast("const float*", _ffi.from_buffer("float[]", field)),
+            _ffi.cast("float*", _ffi.from_buffer("float[]", halo)),
+        )
+    else:
+        status = _lib.cubed_sphere_fill_d4_halo_f64(
+            resolution,
+            _ffi.cast("const double*", _ffi.from_buffer("double[]", field)),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", halo)),
+        )
+    _raise_for_status("cubed-sphere D4 halo", status)
+    return halo
+
+
+__all__ = [
+    "D4_NEIGHBORS",
+    "FACE_COUNT",
+    "HIERARCHY_ABI_VERSION",
+    "children_map",
+    "fill_d4_halo",
+    "generate_cubed_sphere",
+    "parent_map",
+    "prolongate_constant",
+    "restrict_extensive",
+    "restrict_intensive",
+]

--- a/src/map_maker/pipeline/cubed_sphere.py
+++ b/src/map_maker/pipeline/cubed_sphere.py
@@ -11,7 +11,17 @@ import numpy as np
 from PIL import Image
 
 from .._native import native_library_info
-from ._cubed_sphere_native import D4_NEIGHBORS, FACE_COUNT, generate_cubed_sphere
+from ._cubed_sphere_native import (
+    D4_NEIGHBORS,
+    FACE_COUNT,
+    children_map as native_children_map,
+    fill_d4_halo as native_fill_d4_halo,
+    generate_cubed_sphere,
+    parent_map as native_parent_map,
+    prolongate_constant as native_prolongate_constant,
+    restrict_extensive as native_restrict_extensive,
+    restrict_intensive as native_restrict_intensive,
+)
 
 FACE_NAMES = ("+X", "-X", "+Y", "-Y", "+Z", "-Z")
 
@@ -68,6 +78,46 @@ class CubedSphereGrid:
         vector_b = self.xyz[face_b, row_b, col_b]
         dot = float(np.clip(np.dot(vector_a, vector_b), -1.0, 1.0))
         return math.acos(dot)
+
+    def _require_field(self, values: np.ndarray, *, name: str = "values") -> np.ndarray:
+        array = np.asarray(values)
+        if array.shape != self.face_shape:
+            raise ValueError(f"{name} must have shape {self.face_shape}, got {array.shape}")
+        return array
+
+    def parent_map(self, factor: int = 2) -> np.ndarray:
+        """Return the same-face coarse parent global ID for every cell."""
+
+        parents = native_parent_map(self.face_resolution, factor)
+        parents.setflags(write=False)
+        return parents
+
+    def children_map(self, factor: int = 2) -> np.ndarray:
+        """Return row-major child global IDs, treating this grid as coarse."""
+
+        children = native_children_map(self.face_resolution, factor)
+        children.setflags(write=False)
+        return children
+
+    def restrict_extensive(self, values: np.ndarray, factor: int = 2) -> np.ndarray:
+        """Sum child quantities into same-face parent cells."""
+
+        return native_restrict_extensive(self._require_field(values), factor)
+
+    def restrict_intensive(self, values: np.ndarray, factor: int = 2) -> np.ndarray:
+        """Area-weight child values into same-face parent cells."""
+
+        return native_restrict_intensive(self._require_field(values), self.cell_areas, factor)
+
+    def prolongate_constant(self, values: np.ndarray, factor: int = 2) -> np.ndarray:
+        """Copy each coarse prior to its row-major same-face children."""
+
+        return native_prolongate_constant(self._require_field(values), factor)
+
+    def with_d4_halo(self, values: np.ndarray) -> np.ndarray:
+        """Add topology-aware width-one edge halos with undefined corners."""
+
+        return native_fill_d4_halo(self._require_field(values))
 
 
 def _direction_colors(grid: CubedSphereGrid) -> np.ndarray:

--- a/src/map_maker/pipeline/native/topology/src/lib.rs
+++ b/src/map_maker/pipeline/native/topology/src/lib.rs
@@ -1,10 +1,16 @@
 use std::f64::consts::FRAC_PI_2;
+use std::mem::size_of;
 
 const FACE_COUNT: usize = 6;
 const D4_NEIGHBORS: usize = 4;
 
 #[no_mangle]
 pub extern "C" fn topology_native_abi_version() -> u32 {
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_hierarchy_abi_version() -> u32 {
     1
 }
 
@@ -173,6 +179,30 @@ fn global_index(face: Face, row: usize, col: usize, resolution: usize) -> usize 
     face as usize * resolution * resolution + row * resolution + col
 }
 
+fn checked_cell_count(resolution: usize) -> Option<usize> {
+    resolution
+        .checked_mul(resolution)
+        .and_then(|face_cells| face_cells.checked_mul(FACE_COUNT))
+        .filter(|cells| *cells <= i32::MAX as usize)
+}
+
+fn checked_slice_len<T>(len: usize) -> Option<usize> {
+    len.checked_mul(size_of::<T>())
+        .filter(|bytes| *bytes <= isize::MAX as usize)
+        .map(|_| len)
+}
+
+fn hierarchy_resolutions(fine_resolution: i32, factor: i32) -> Option<(usize, usize)> {
+    if fine_resolution <= 0 || factor <= 1 || fine_resolution % factor != 0 {
+        return None;
+    }
+    let fine = fine_resolution as usize;
+    let coarse = (fine_resolution / factor) as usize;
+    checked_cell_count(fine)?;
+    checked_cell_count(coarse)?;
+    Some((fine, coarse))
+}
+
 fn neighbor_index(
     face: Face,
     row: usize,
@@ -222,6 +252,73 @@ fn generate(
     }
 }
 
+fn build_parent_map(fine_resolution: usize, factor: usize, output: &mut [i32]) {
+    let coarse_resolution = fine_resolution / factor;
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        for row in 0..fine_resolution {
+            for col in 0..fine_resolution {
+                let fine_index = global_index(face, row, col, fine_resolution);
+                output[fine_index] =
+                    global_index(face, row / factor, col / factor, coarse_resolution) as i32;
+            }
+        }
+    }
+}
+
+fn build_children_map(coarse_resolution: usize, factor: usize, output: &mut [i32]) {
+    let fine_resolution = coarse_resolution * factor;
+    let children_per_parent = factor * factor;
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        for row in 0..coarse_resolution {
+            for col in 0..coarse_resolution {
+                let parent = global_index(face, row, col, coarse_resolution);
+                for child_row in 0..factor {
+                    for child_col in 0..factor {
+                        let slot = child_row * factor + child_col;
+                        output[parent * children_per_parent + slot] = global_index(
+                            face,
+                            row * factor + child_row,
+                            col * factor + child_col,
+                            fine_resolution,
+                        )
+                            as i32;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn fill_d4_halo<T: Copy>(values: &[T], resolution: usize, halo: &mut [T], corner: T) {
+    let halo_resolution = resolution + 2;
+    halo.fill(corner);
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        let halo_face_offset = face_index * halo_resolution * halo_resolution;
+        for row in 0..resolution {
+            for col in 0..resolution {
+                let source = global_index(face, row, col, resolution);
+                let target = halo_face_offset + (row + 1) * halo_resolution + col + 1;
+                halo[target] = values[source];
+            }
+        }
+        for offset in 0..resolution {
+            let north = neighbor_index(face, 0, offset, -1, 0, resolution);
+            let south = neighbor_index(face, resolution - 1, offset, 1, 0, resolution);
+            let west = neighbor_index(face, offset, 0, 0, -1, resolution);
+            let east = neighbor_index(face, offset, resolution - 1, 0, 1, resolution);
+            halo[halo_face_offset + offset + 1] = values[north];
+            halo[halo_face_offset + (halo_resolution - 1) * halo_resolution + offset + 1] =
+                values[south];
+            halo[halo_face_offset + (offset + 1) * halo_resolution] = values[west];
+            halo[halo_face_offset + (offset + 1) * halo_resolution + halo_resolution - 1] =
+                values[east];
+        }
+    }
+}
+
 #[no_mangle]
 /// Populate cubed-sphere coordinate, area, and D4-neighbor buffers.
 ///
@@ -248,21 +345,331 @@ pub unsafe extern "C" fn cubed_sphere_generate(
         return 1;
     }
     let resolution = face_resolution as usize;
-    let Some(cells) = resolution
-        .checked_mul(resolution)
+    let Some(cells) = checked_cell_count(resolution) else {
+        return 2;
+    };
+    let Some(xyz_len) = cells.checked_mul(3).and_then(checked_slice_len::<f32>) else {
+        return 2;
+    };
+    let Some(neighbor_len) = cells
+        .checked_mul(D4_NEIGHBORS)
+        .and_then(checked_slice_len::<i32>)
+    else {
+        return 2;
+    };
+    if checked_slice_len::<f64>(cells).is_none() {
+        return 2;
+    }
+    let xyz = std::slice::from_raw_parts_mut(xyz_ptr, xyz_len);
+    let longitude = std::slice::from_raw_parts_mut(longitude_ptr, cells);
+    let latitude = std::slice::from_raw_parts_mut(latitude_ptr, cells);
+    let areas = std::slice::from_raw_parts_mut(area_ptr, cells);
+    let neighbors = std::slice::from_raw_parts_mut(neighbors_ptr, neighbor_len);
+    generate(resolution, xyz, longitude, latitude, areas, neighbors);
+    0
+}
+
+#[no_mangle]
+/// Map every fine cell to a same-face parent global ID.
+///
+/// # Safety
+///
+/// `parent_ptr` must reference `6*fine_resolution*fine_resolution` writable
+/// `i32` values and must not alias another active buffer.
+pub unsafe extern "C" fn cubed_sphere_parent_map(
+    fine_resolution: i32,
+    factor: i32,
+    parent_ptr: *mut i32,
+) -> i32 {
+    if parent_ptr.is_null() {
+        return 1;
+    }
+    let Some((fine, _coarse)) = hierarchy_resolutions(fine_resolution, factor) else {
+        return 2;
+    };
+    let cells = checked_cell_count(fine).expect("validated fine resolution");
+    if checked_slice_len::<i32>(cells).is_none() {
+        return 2;
+    }
+    let output = std::slice::from_raw_parts_mut(parent_ptr, cells);
+    build_parent_map(fine, factor as usize, output);
+    0
+}
+
+#[no_mangle]
+/// Map every coarse cell to its row-major same-face child global IDs.
+///
+/// # Safety
+///
+/// `children_ptr` must reference `6*coarse_resolution*coarse_resolution*factor^2`
+/// writable `i32` values and must not alias another active buffer.
+pub unsafe extern "C" fn cubed_sphere_children_map(
+    coarse_resolution: i32,
+    factor: i32,
+    children_ptr: *mut i32,
+) -> i32 {
+    if coarse_resolution <= 0 || factor <= 1 || children_ptr.is_null() {
+        return 1;
+    }
+    let Some(fine_resolution) = coarse_resolution.checked_mul(factor) else {
+        return 2;
+    };
+    let Some((fine, coarse)) = hierarchy_resolutions(fine_resolution, factor) else {
+        return 2;
+    };
+    let output_len = checked_cell_count(fine).expect("validated fine resolution");
+    if checked_slice_len::<i32>(output_len).is_none() {
+        return 2;
+    }
+    let output = std::slice::from_raw_parts_mut(children_ptr, output_len);
+    build_children_map(coarse, factor as usize, output);
+    0
+}
+
+#[no_mangle]
+/// Restrict an extensive field by summing same-parent children.
+///
+/// # Safety
+///
+/// `fine_values_ptr` must reference one `f64` per fine cell and `coarse_values_ptr`
+/// one writable `f64` per coarse cell. The buffers must not overlap.
+pub unsafe extern "C" fn cubed_sphere_restrict_extensive_f64(
+    fine_resolution: i32,
+    factor: i32,
+    fine_values_ptr: *const f64,
+    coarse_values_ptr: *mut f64,
+) -> i32 {
+    if fine_values_ptr.is_null() || coarse_values_ptr.is_null() {
+        return 1;
+    }
+    let Some((fine, coarse)) = hierarchy_resolutions(fine_resolution, factor) else {
+        return 2;
+    };
+    let fine_cells = checked_cell_count(fine).expect("validated fine resolution");
+    let coarse_cells = checked_cell_count(coarse).expect("validated coarse resolution");
+    if checked_slice_len::<f64>(fine_cells).is_none()
+        || checked_slice_len::<f64>(coarse_cells).is_none()
+    {
+        return 2;
+    }
+    let fine_values = std::slice::from_raw_parts(fine_values_ptr, fine_cells);
+    let coarse_values = std::slice::from_raw_parts_mut(coarse_values_ptr, coarse_cells);
+    coarse_values.fill(0.0);
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        for row in 0..fine {
+            for col in 0..fine {
+                let fine_index = global_index(face, row, col, fine);
+                let value = fine_values[fine_index];
+                if !value.is_finite() {
+                    return 3;
+                }
+                let coarse_index =
+                    global_index(face, row / factor as usize, col / factor as usize, coarse);
+                coarse_values[coarse_index] += value;
+                if !coarse_values[coarse_index].is_finite() {
+                    return 3;
+                }
+            }
+        }
+    }
+    0
+}
+
+#[no_mangle]
+/// Restrict an intensive field by spherical-area-weighted averaging.
+///
+/// # Safety
+///
+/// Fine value and area pointers must each reference one `f64` per fine cell;
+/// the coarse output must reference one writable `f64` per coarse cell. Buffers
+/// must not overlap.
+pub unsafe extern "C" fn cubed_sphere_restrict_intensive_f64(
+    fine_resolution: i32,
+    factor: i32,
+    fine_values_ptr: *const f64,
+    fine_areas_ptr: *const f64,
+    coarse_values_ptr: *mut f64,
+) -> i32 {
+    if fine_values_ptr.is_null() || fine_areas_ptr.is_null() || coarse_values_ptr.is_null() {
+        return 1;
+    }
+    let Some((fine, coarse)) = hierarchy_resolutions(fine_resolution, factor) else {
+        return 2;
+    };
+    let fine_cells = checked_cell_count(fine).expect("validated fine resolution");
+    let coarse_cells = checked_cell_count(coarse).expect("validated coarse resolution");
+    if checked_slice_len::<f64>(fine_cells).is_none()
+        || checked_slice_len::<f64>(coarse_cells).is_none()
+    {
+        return 2;
+    }
+    let fine_values = std::slice::from_raw_parts(fine_values_ptr, fine_cells);
+    let fine_areas = std::slice::from_raw_parts(fine_areas_ptr, fine_cells);
+    let coarse_values = std::slice::from_raw_parts_mut(coarse_values_ptr, coarse_cells);
+    coarse_values.fill(0.0);
+    let mut coarse_areas = vec![0.0f64; coarse_cells];
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        for row in 0..fine {
+            for col in 0..fine {
+                let fine_index = global_index(face, row, col, fine);
+                let area = fine_areas[fine_index];
+                if !area.is_finite() || area <= 0.0 || !fine_values[fine_index].is_finite() {
+                    return 3;
+                }
+                let coarse_index =
+                    global_index(face, row / factor as usize, col / factor as usize, coarse);
+                let previous_area = coarse_areas[coarse_index];
+                let combined_area = previous_area + area;
+                if !combined_area.is_finite() || combined_area <= previous_area {
+                    return 3;
+                }
+                if previous_area == 0.0 {
+                    coarse_values[coarse_index] = fine_values[fine_index];
+                } else if coarse_values[coarse_index] != fine_values[fine_index] {
+                    let previous_weight = previous_area / combined_area;
+                    let new_weight = area / combined_area;
+                    let previous_value = coarse_values[coarse_index];
+                    let new_value = fine_values[fine_index];
+                    let combined_value =
+                        if previous_value.is_sign_positive() == new_value.is_sign_positive() {
+                            previous_value + (new_value - previous_value) * new_weight
+                        } else {
+                            previous_value * previous_weight + new_value * new_weight
+                        };
+                    if !combined_value.is_finite() {
+                        return 3;
+                    }
+                    coarse_values[coarse_index] = combined_value;
+                }
+                coarse_areas[coarse_index] = combined_area;
+            }
+        }
+    }
+    0
+}
+
+#[no_mangle]
+/// Prolongate a coarse prior by copying each parent value to all children.
+///
+/// # Safety
+///
+/// The coarse pointer must reference one `f64` per coarse cell and the fine
+/// output one writable `f64` per fine cell. Buffers must not overlap.
+pub unsafe extern "C" fn cubed_sphere_prolongate_constant_f64(
+    coarse_resolution: i32,
+    factor: i32,
+    coarse_values_ptr: *const f64,
+    fine_values_ptr: *mut f64,
+) -> i32 {
+    if coarse_resolution <= 0
+        || factor <= 1
+        || coarse_values_ptr.is_null()
+        || fine_values_ptr.is_null()
+    {
+        return 1;
+    }
+    let Some(fine_resolution) = coarse_resolution.checked_mul(factor) else {
+        return 2;
+    };
+    let Some((fine, coarse)) = hierarchy_resolutions(fine_resolution, factor) else {
+        return 2;
+    };
+    let coarse_cells = checked_cell_count(coarse).expect("validated coarse resolution");
+    let fine_cells = checked_cell_count(fine).expect("validated fine resolution");
+    if checked_slice_len::<f64>(coarse_cells).is_none()
+        || checked_slice_len::<f64>(fine_cells).is_none()
+    {
+        return 2;
+    }
+    let coarse_values = std::slice::from_raw_parts(coarse_values_ptr, coarse_cells);
+    let fine_values = std::slice::from_raw_parts_mut(fine_values_ptr, fine_cells);
+    for face_index in 0..FACE_COUNT {
+        let face = Face::from_index(face_index);
+        for row in 0..fine {
+            for col in 0..fine {
+                let fine_index = global_index(face, row, col, fine);
+                let coarse_index =
+                    global_index(face, row / factor as usize, col / factor as usize, coarse);
+                fine_values[fine_index] = coarse_values[coarse_index];
+            }
+        }
+    }
+    0
+}
+
+#[no_mangle]
+/// Fill a width-one D4 face halo; the four ambiguous corners remain NaN.
+///
+/// # Safety
+///
+/// `values_ptr` must reference one `f32` per canonical cell and `halo_ptr` must
+/// reference `6*(resolution+2)^2` writable `f32` values. Buffers must not overlap.
+pub unsafe extern "C" fn cubed_sphere_fill_d4_halo_f32(
+    face_resolution: i32,
+    values_ptr: *const f32,
+    halo_ptr: *mut f32,
+) -> i32 {
+    if face_resolution <= 0 || values_ptr.is_null() || halo_ptr.is_null() {
+        return 1;
+    }
+    let resolution = face_resolution as usize;
+    let Some(cells) = checked_cell_count(resolution) else {
+        return 2;
+    };
+    let Some(halo_resolution) = resolution.checked_add(2) else {
+        return 2;
+    };
+    let Some(halo_cells) = halo_resolution
+        .checked_mul(halo_resolution)
         .and_then(|face_cells| face_cells.checked_mul(FACE_COUNT))
     else {
         return 2;
     };
-    if cells > i32::MAX as usize {
+    if checked_slice_len::<f32>(cells).is_none() || checked_slice_len::<f32>(halo_cells).is_none() {
         return 2;
     }
-    let xyz = std::slice::from_raw_parts_mut(xyz_ptr, cells * 3);
-    let longitude = std::slice::from_raw_parts_mut(longitude_ptr, cells);
-    let latitude = std::slice::from_raw_parts_mut(latitude_ptr, cells);
-    let areas = std::slice::from_raw_parts_mut(area_ptr, cells);
-    let neighbors = std::slice::from_raw_parts_mut(neighbors_ptr, cells * D4_NEIGHBORS);
-    generate(resolution, xyz, longitude, latitude, areas, neighbors);
+    let values = std::slice::from_raw_parts(values_ptr, cells);
+    let halo = std::slice::from_raw_parts_mut(halo_ptr, halo_cells);
+    fill_d4_halo(values, resolution, halo, f32::NAN);
+    0
+}
+
+#[no_mangle]
+/// Fill a width-one D4 `f64` face halo; the four ambiguous corners remain NaN.
+///
+/// # Safety
+///
+/// `values_ptr` must reference one `f64` per canonical cell and `halo_ptr` must
+/// reference `6*(resolution+2)^2` writable `f64` values. Buffers must not overlap.
+pub unsafe extern "C" fn cubed_sphere_fill_d4_halo_f64(
+    face_resolution: i32,
+    values_ptr: *const f64,
+    halo_ptr: *mut f64,
+) -> i32 {
+    if face_resolution <= 0 || values_ptr.is_null() || halo_ptr.is_null() {
+        return 1;
+    }
+    let resolution = face_resolution as usize;
+    let Some(cells) = checked_cell_count(resolution) else {
+        return 2;
+    };
+    let Some(halo_resolution) = resolution.checked_add(2) else {
+        return 2;
+    };
+    let Some(halo_cells) = halo_resolution
+        .checked_mul(halo_resolution)
+        .and_then(|face_cells| face_cells.checked_mul(FACE_COUNT))
+    else {
+        return 2;
+    };
+    if checked_slice_len::<f64>(cells).is_none() || checked_slice_len::<f64>(halo_cells).is_none() {
+        return 2;
+    }
+    let values = std::slice::from_raw_parts(values_ptr, cells);
+    let halo = std::slice::from_raw_parts_mut(halo_ptr, halo_cells);
+    fill_d4_halo(values, resolution, halo, f64::NAN);
     0
 }
 
@@ -371,5 +778,209 @@ mod tests {
             )
         };
         assert_eq!(status, 2);
+    }
+
+    #[test]
+    fn parent_and_children_maps_are_inverse_and_row_major() {
+        let fine = 6usize;
+        let coarse = 3usize;
+        let factor = 2usize;
+        let fine_cells = FACE_COUNT * fine * fine;
+        let coarse_cells = FACE_COUNT * coarse * coarse;
+        let mut parents = vec![-1i32; fine_cells];
+        let mut children = vec![-1i32; fine_cells];
+        build_parent_map(fine, factor, &mut parents);
+        build_children_map(coarse, factor, &mut children);
+
+        for parent in 0..coarse_cells {
+            let child_ids = &children[parent * factor * factor..(parent + 1) * factor * factor];
+            assert_eq!(child_ids.len(), factor * factor);
+            for &child in child_ids {
+                assert_eq!(parents[child as usize], parent as i32);
+            }
+        }
+
+        let parent = global_index(Face::PositiveY, 1, 2, coarse);
+        assert_eq!(
+            &children[parent * 4..parent * 4 + 4],
+            &[
+                global_index(Face::PositiveY, 2, 4, fine) as i32,
+                global_index(Face::PositiveY, 2, 5, fine) as i32,
+                global_index(Face::PositiveY, 3, 4, fine) as i32,
+                global_index(Face::PositiveY, 3, 5, fine) as i32,
+            ]
+        );
+    }
+
+    #[test]
+    fn restriction_conserves_extensive_and_area_weighted_fields() {
+        let fine = 8usize;
+        let factor = 2usize;
+        let coarse = fine / factor;
+        let fine_cells = FACE_COUNT * fine * fine;
+        let coarse_cells = FACE_COUNT * coarse * coarse;
+        let (_, areas, _) = generated(fine);
+        let values: Vec<f64> = (0..fine_cells).map(|index| index as f64 + 1.0).collect();
+
+        let mut extensive = vec![0.0f64; coarse_cells];
+        let status = unsafe {
+            cubed_sphere_restrict_extensive_f64(
+                fine as i32,
+                factor as i32,
+                values.as_ptr(),
+                extensive.as_mut_ptr(),
+            )
+        };
+        assert_eq!(status, 0);
+        assert_eq!(values.iter().sum::<f64>(), extensive.iter().sum::<f64>());
+
+        let mut intensive = vec![0.0f64; coarse_cells];
+        let status = unsafe {
+            cubed_sphere_restrict_intensive_f64(
+                fine as i32,
+                factor as i32,
+                values.as_ptr(),
+                areas.as_ptr(),
+                intensive.as_mut_ptr(),
+            )
+        };
+        assert_eq!(status, 0);
+        let fine_integral: f64 = values
+            .iter()
+            .zip(areas.iter())
+            .map(|(value, area)| value * area)
+            .sum();
+        let mut coarse_areas = vec![0.0f64; coarse_cells];
+        let area_status = unsafe {
+            cubed_sphere_restrict_extensive_f64(
+                fine as i32,
+                factor as i32,
+                areas.as_ptr(),
+                coarse_areas.as_mut_ptr(),
+            )
+        };
+        assert_eq!(area_status, 0);
+        let coarse_integral: f64 = intensive
+            .iter()
+            .zip(coarse_areas.iter())
+            .map(|(value, area)| value * area)
+            .sum();
+        assert!((fine_integral - coarse_integral).abs() < 1e-10);
+        assert!((coarse_areas.iter().sum::<f64>() - 4.0 * std::f64::consts::PI).abs() < 1e-12);
+    }
+
+    #[test]
+    fn prolongation_copies_each_parent_to_all_children() {
+        let coarse = 3usize;
+        let factor = 2usize;
+        let fine = coarse * factor;
+        let coarse_cells = FACE_COUNT * coarse * coarse;
+        let fine_cells = FACE_COUNT * fine * fine;
+        let coarse_values: Vec<f64> = (0..coarse_cells).map(|index| index as f64).collect();
+        let mut fine_values = vec![f64::NAN; fine_cells];
+        let status = unsafe {
+            cubed_sphere_prolongate_constant_f64(
+                coarse as i32,
+                factor as i32,
+                coarse_values.as_ptr(),
+                fine_values.as_mut_ptr(),
+            )
+        };
+        assert_eq!(status, 0);
+        let mut parents = vec![-1i32; fine_cells];
+        build_parent_map(fine, factor, &mut parents);
+        for (child, &parent) in parents.iter().enumerate() {
+            assert_eq!(fine_values[child], coarse_values[parent as usize]);
+        }
+    }
+
+    #[test]
+    fn d4_halo_uses_topology_neighbors_and_leaves_corners_undefined() {
+        let resolution = 7usize;
+        let cells = FACE_COUNT * resolution * resolution;
+        let values: Vec<f32> = (0..cells).map(|index| index as f32).collect();
+        let halo_resolution = resolution + 2;
+        let mut halo = vec![0.0f32; FACE_COUNT * halo_resolution * halo_resolution];
+        fill_d4_halo(&values, resolution, &mut halo, f32::NAN);
+
+        for face_index in 0..FACE_COUNT {
+            let face = Face::from_index(face_index);
+            let offset = face_index * halo_resolution * halo_resolution;
+            for row in 0..resolution {
+                for col in 0..resolution {
+                    assert_eq!(
+                        halo[offset + (row + 1) * halo_resolution + col + 1],
+                        values[global_index(face, row, col, resolution)]
+                    );
+                }
+            }
+            for edge_offset in 0..resolution {
+                assert_eq!(
+                    halo[offset + edge_offset + 1],
+                    values[neighbor_index(face, 0, edge_offset, -1, 0, resolution)]
+                );
+                assert_eq!(
+                    halo[offset + (halo_resolution - 1) * halo_resolution + edge_offset + 1],
+                    values[neighbor_index(face, resolution - 1, edge_offset, 1, 0, resolution)]
+                );
+                assert_eq!(
+                    halo[offset + (edge_offset + 1) * halo_resolution],
+                    values[neighbor_index(face, edge_offset, 0, 0, -1, resolution)]
+                );
+                assert_eq!(
+                    halo[offset + (edge_offset + 1) * halo_resolution + halo_resolution - 1],
+                    values[neighbor_index(face, edge_offset, resolution - 1, 0, 1, resolution)]
+                );
+            }
+            for corner in [
+                offset,
+                offset + halo_resolution - 1,
+                offset + (halo_resolution - 1) * halo_resolution,
+                offset + halo_resolution * halo_resolution - 1,
+            ] {
+                assert!(halo[corner].is_nan());
+            }
+        }
+    }
+
+    #[test]
+    fn hierarchy_ffi_rejects_invalid_factors_and_non_finite_fields() {
+        let values = vec![1.0f64; FACE_COUNT * 4 * 4];
+        let mut coarse = vec![0.0f64; FACE_COUNT * 2 * 2];
+        let invalid_factor = unsafe {
+            cubed_sphere_restrict_extensive_f64(4, 3, values.as_ptr(), coarse.as_mut_ptr())
+        };
+        assert_eq!(invalid_factor, 2);
+
+        let mut invalid_values = values;
+        invalid_values[3] = f64::NAN;
+        let non_finite = unsafe {
+            cubed_sphere_restrict_extensive_f64(4, 2, invalid_values.as_ptr(), coarse.as_mut_ptr())
+        };
+        assert_eq!(non_finite, 3);
+
+        let maximum_values = vec![f64::MAX; FACE_COUNT * 4 * 4];
+        let overflow = unsafe {
+            cubed_sphere_restrict_extensive_f64(4, 2, maximum_values.as_ptr(), coarse.as_mut_ptr())
+        };
+        assert_eq!(overflow, 3);
+    }
+
+    #[test]
+    fn intensive_restriction_handles_extreme_finite_constant_values() {
+        let values = vec![f64::MAX; FACE_COUNT * 4 * 4];
+        let areas = vec![f64::MAX / 4.0; FACE_COUNT * 4 * 4];
+        let mut coarse = vec![0.0f64; FACE_COUNT * 2 * 2];
+        let status = unsafe {
+            cubed_sphere_restrict_intensive_f64(
+                4,
+                2,
+                values.as_ptr(),
+                areas.as_ptr(),
+                coarse.as_mut_ptr(),
+            )
+        };
+        assert_eq!(status, 0);
+        assert!(coarse.iter().all(|value| *value == f64::MAX));
     }
 }

--- a/tests/test_cubed_sphere.py
+++ b/tests/test_cubed_sphere.py
@@ -68,6 +68,149 @@ def test_global_index_round_trip_and_read_only_arrays(grid: CubedSphereGrid):
         generate_cubed_sphere(20_000)
 
 
+def test_parent_children_maps_are_inverse_and_row_major():
+    coarse = CubedSphereGrid.create(5)
+    fine = CubedSphereGrid.create(10)
+    parents = fine.parent_map(factor=2).reshape(-1)
+    children = coarse.children_map(factor=2).reshape(coarse.cell_count, 4)
+
+    assert not fine.parent_map().flags.writeable
+    assert not coarse.children_map().flags.writeable
+    for parent, child_ids in enumerate(children):
+        np.testing.assert_array_equal(parents[child_ids], parent)
+
+    parent = coarse.global_index(2, 1, 3)
+    np.testing.assert_array_equal(
+        children[parent],
+        [
+            fine.global_index(2, 2, 6),
+            fine.global_index(2, 2, 7),
+            fine.global_index(2, 3, 6),
+            fine.global_index(2, 3, 7),
+        ],
+    )
+
+
+def test_restriction_conserves_area_extensive_and_intensive_fields():
+    fine = CubedSphereGrid.create(16)
+    coarse = CubedSphereGrid.create(8)
+    rng = np.random.default_rng(42)
+    extensive = rng.random(fine.face_shape)
+    restricted_extensive = fine.restrict_extensive(extensive)
+    assert math.isclose(
+        float(np.sum(restricted_extensive)), float(np.sum(extensive)), abs_tol=1e-12
+    )
+
+    restricted_areas = fine.restrict_extensive(fine.cell_areas)
+    np.testing.assert_allclose(restricted_areas, coarse.cell_areas, rtol=0.0, atol=1e-15)
+
+    intensive = rng.normal(size=fine.face_shape)
+    restricted_intensive = fine.restrict_intensive(intensive)
+    fine_integral = float(np.sum(intensive * fine.cell_areas))
+    coarse_integral = float(np.sum(restricted_intensive * coarse.cell_areas))
+    assert math.isclose(fine_integral, coarse_integral, abs_tol=1e-14)
+    np.testing.assert_allclose(fine.restrict_intensive(np.full(fine.face_shape, 7.5)), 7.5)
+
+
+def test_constant_prolongation_copies_parent_values():
+    coarse = CubedSphereGrid.create(6)
+    fine = CubedSphereGrid.create(18)
+    values = np.arange(coarse.cell_count, dtype=np.float64).reshape(coarse.face_shape)
+    prolonged = coarse.prolongate_constant(values, factor=3)
+    assert prolonged.shape == fine.face_shape
+    np.testing.assert_array_equal(
+        prolonged.reshape(-1), values.reshape(-1)[fine.parent_map(3).reshape(-1)]
+    )
+
+
+def test_d4_halo_matches_cross_face_neighbors_and_has_nan_corners(grid: CubedSphereGrid):
+    values = np.arange(grid.cell_count, dtype=np.float32).reshape(grid.face_shape)
+    halo = grid.with_d4_halo(values)
+    resolution = grid.face_resolution
+    flat_values = values.reshape(-1)
+
+    assert halo.shape == (6, resolution + 2, resolution + 2)
+    np.testing.assert_array_equal(halo[:, 1:-1, 1:-1], values)
+    for face in range(6):
+        np.testing.assert_array_equal(
+            halo[face, 0, 1:-1], flat_values[grid.neighbor_indices[face, 0, :, 0]]
+        )
+        np.testing.assert_array_equal(
+            halo[face, -1, 1:-1], flat_values[grid.neighbor_indices[face, -1, :, 1]]
+        )
+        np.testing.assert_array_equal(
+            halo[face, 1:-1, 0], flat_values[grid.neighbor_indices[face, :, 0, 2]]
+        )
+        np.testing.assert_array_equal(
+            halo[face, 1:-1, -1], flat_values[grid.neighbor_indices[face, :, -1, 3]]
+        )
+    assert np.isnan(halo[:, (0, 0, -1, -1), (0, -1, 0, -1)]).all()
+
+    precise_values = values.astype(np.float64) + 2**40
+    precise_halo = grid.with_d4_halo(precise_values)
+    assert precise_halo.dtype == np.float64
+    np.testing.assert_array_equal(precise_halo[:, 1:-1, 1:-1], precise_values)
+
+
+def test_cross_face_edge_orientation_matches_explicit_cube_contract():
+    grid = CubedSphereGrid.create(4)
+    # Per source face, entries are N/S/W/E: target face, target edge, reversed.
+    expected = (
+        ((4, "S", False), (5, "N", False), (3, "E", False), (2, "W", False)),
+        ((4, "N", True), (5, "S", True), (2, "E", False), (3, "W", False)),
+        ((4, "E", True), (5, "E", False), (0, "E", False), (1, "W", False)),
+        ((4, "W", False), (5, "W", True), (1, "E", False), (0, "W", False)),
+        ((1, "N", True), (0, "N", False), (3, "N", False), (2, "N", True)),
+        ((0, "S", False), (1, "S", True), (3, "S", True), (2, "S", False)),
+    )
+
+    def source_edges(face: int) -> tuple[np.ndarray, ...]:
+        return (
+            grid.neighbor_indices[face, 0, :, 0],
+            grid.neighbor_indices[face, -1, :, 1],
+            grid.neighbor_indices[face, :, 0, 2],
+            grid.neighbor_indices[face, :, -1, 3],
+        )
+
+    for face, contracts in enumerate(expected):
+        for ids, (target_face, target_edge, reversed_order) in zip(
+            source_edges(face), contracts, strict=True
+        ):
+            offsets = list(range(grid.face_resolution))
+            if reversed_order:
+                offsets.reverse()
+            if target_edge == "N":
+                coordinates = [(target_face, 0, offset) for offset in offsets]
+            elif target_edge == "S":
+                coordinates = [
+                    (target_face, grid.face_resolution - 1, offset) for offset in offsets
+                ]
+            elif target_edge == "W":
+                coordinates = [(target_face, offset, 0) for offset in offsets]
+            else:
+                coordinates = [
+                    (target_face, offset, grid.face_resolution - 1) for offset in offsets
+                ]
+            assert [grid.decode_index(int(index)) for index in ids] == coordinates
+
+
+def test_hierarchy_rejects_invalid_shapes_factors_and_values(grid: CubedSphereGrid):
+    with pytest.raises(ValueError, match="must divide"):
+        grid.parent_map(5)
+    with pytest.raises(ValueError, match="greater than one"):
+        grid.children_map(1)
+    with pytest.raises(ValueError, match="must have shape"):
+        grid.restrict_extensive(np.zeros((24, 24)))
+    values = np.ones(grid.face_shape)
+    values[0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite values"):
+        grid.restrict_intensive(values)
+    with pytest.raises(ValueError, match="finite values"):
+        grid.restrict_extensive(np.full(grid.face_shape, np.finfo(np.float64).max))
+    with pytest.raises(TypeError, match="float32 or float64"):
+        grid.with_d4_halo(np.ones(grid.face_shape, dtype=np.int32))
+
+
 def test_diagnostic_writes_cube_net_and_report(tmp_path: Path):
     net_path, report_path = run_cubed_sphere_diagnostic(face_resolution=16, output_dir=tmp_path)
 


### PR DESCRIPTION
## Summary
- add same-face parent/child mappings and conservative restriction/prolongation kernels
- add topology-owned float32/float64 D4 halos with explicit undefined cube corners
- expose validated Python APIs and document the multi-resolution contract
- harden hierarchy ABI detection, overflow handling, and native slice bounds

## Validation
- `uv run pytest -q` (58 passed)
- `cargo test --workspace --locked` (16 passed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `uv run ruff check src tests`
- Black check on changed Python files
- `uv run map-maker validate --config configs/validation.yaml` (6 worlds passed)
- `uv build`
- face-resolution 512 hierarchy smoke: 1,572,864 cells in 0.29 seconds

## Review
Independent subagent review completed; all five findings were addressed before publication.