### PR TITLE
Initialize canonical cubed-sphere crust state

### DIFF
--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -1,0 +1,23 @@
+topology: cubed_sphere
+resolutions:
+  - face_resolution: 128
+rng_seed: 42
+run_id: cubed-sphere-crust-state-42
+output_dir: out
+cache_dir: out/cache
+log_dir: out/logs
+stage_overrides:
+  tectonics:
+    num_plates: 24
+    continental_fraction: 0.35
+    lloyd_iterations: 4
+    velocity_scale: 1.0
+    drift_bias: 0.15
+    hotspot_density: 0.02
+    subduction_bias: 0.5
+  world_age:
+    world_age: 4.1
+    thermal_decay_half_life: 1.8
+    hotspot_scale: 0.9
+    isostasy_factor: 0.6
+    radiogenic_heat_scale: 1.0

--- a/docs/specs/05_world_age.md
+++ b/docs/specs/05_world_age.md
@@ -1,39 +1,102 @@
-# Stage 4 – World Age & Thermal Adjustments
+# Stage 4: Age-Conditioned Crust State
 
-## Purpose
-- Modify tectonic outputs based on planetary age to influence crust thickness, elevation baseline, and hotspot frequency.
+## Status and purpose
+
+This stage initializes a plausible present-day crust state from the canonical
+cubed-sphere tectonic fields. It is not yet a geological history simulation.
+It does not advance plates through billions of years, conserve mantle heat, or
+solve flexure. Its purpose is narrower: provide deterministic, globally closed
+inputs for the first elevation and surface-process stages while preserving the
+causal direction from crust type and tectonic setting to terrain potential.
+
+The rectangular implementation remains available for compatibility. The
+cubed-sphere path is the canonical implementation.
 
 ## Inputs
-- `PlateField`, `BoundaryField`, `HotspotMap`.
-- Config: `world_age` (in Ga), `thermal_decay_half_life`, `hotspot_scale`, `isostasy_factor`, `radiogenic_heat_scale` (proxy for uranium/thorium abundance).
 
-## Procedure (Rust SIMD implementation)
-1. **Thermal Decay & Heat Budget**
-   - Compute normalized age factor `f = exp(-world_age / half_life)` using vectorized math over SoA buffers.
-   - Scale convective vigor by `radiogenic_heat_scale` (higher heat → faster plate speeds, more hotspots) and feed that back to plate velocities.
-   - Update crust thickness in-place for continental vs oceanic plates using cache-friendly strided loops.
-2. **Isostatic Compensation**
-   - Apply Airy isostasy model: thicker crust -> higher elevation baseline.
-   - Generate `IsostaticOffset` field in the shared arena (float32).
-3. **Mantle Plumes & Hotspots**
-   - Rescale hotspot density by `hotspot_scale * (1 - f) * radiogenic_heat_scale`.
-   - Generate stochastic hotspot events (Poisson process) entirely in Rust with deterministic RNG; store events in Arrow table (SoA) for zero-copy transfer.
-4. **Dynamic Uplift/Subsidence**
-   - Combine boundary convergence and thermal contraction to produce `UpliftRate` and `SubsidenceRate` fields; keep SoA layout for vectorization.
-5. **Outputs**
-   - `CrustThickness`, `IsostaticOffset`, `HotspotEvents`, `UpliftRate`, `SubsidenceRate`.
+- `PlateField`: plate ID, crust class, base thickness, density, and global XYZ
+  tangent velocity.
+- `BoundaryConvergence`, `BoundaryDivergence`, `BoundarySubduction`, and
+  `BoundaryShear`.
+- `HotspotMap`.
+- Exact spherical cell areas and global D4 neighbor IDs from the geometry stage.
+- `world_age` in Ga, `thermal_decay_half_life`, `hotspot_scale`,
+  `isostasy_factor`, and `radiogenic_heat_scale`.
 
-## Performance
-- Entire stage runs in Rust with SIMD intrinsics and Rayon parallelism; target runtime <0.2 s for 8 k grid.
-- Python orchestrator only sees handles; no NumPy large-array manipulation.
-- Hotspot sampling uses Rust RNG; Python parity tests call into the same library.
+## Canonical approximation
 
-## Logging
-- Average crust thickness, uplift/subsidence mean/std (logged via staging API) plus convective vigor scalar.
-- Number of hotspots, total uplift mass, heat budget parameters.
- - Produce debug CSV/JSON for events if profiling enabled.
+1. Compute residual primordial heat as `exp(-ln(2) * age / half_life)` and combine it
+   with the radiogenic scale to obtain an age-conditioned convective heat proxy.
+   Older worlds therefore have less residual heat and, all else equal, fewer
+   thermal-anomaly events. This stage does not feed the proxy back into plate velocities.
+2. Adjust continental and oceanic base crust thickness separately. Oceanic crust
+   becomes thinner as the heat proxy declines; cooled lithosphere becomes
+   stiffer.
+3. Compute an Airy-like buoyancy potential from thickness and density. Remove
+   its exact spherical-area-weighted global mean so `IsostaticOffset` closes to
+   zero over the planet.
+4. Combine convergence, divergence, subduction, shear, and hotspot intensity
+   into bounded uplift, subsidence, compression, extension, and stiffness
+   proxies. D4 diffusion uses global neighbor IDs, crosses cube-face seams, and
+   derives local diffusion weights from spherical cell area so its approximate
+   angular width does not shrink with increasing resolution.
+5. Measure area-derived angular graph distance from continental/oceanic crust transitions. The
+   compatibility artifact `CoastalExposure` is currently this continental
+   margin proximity, not exposure to a solved coastline.
+6. Draw a global, resolution-independent Poisson count of tectonic thermal-anomaly
+   events. Sample
+   locations by hotspot intensity times exact cell area and store canonical
+   global cell IDs plus decoded face, row, and column coordinates.
 
-## Testing
-- Verify older worlds have thinner oceanic crust and more hotspots.
-- Ensure isostatic offset integrates to zero mean when expected (precision tests using area weights).
-- Check deterministic hotspot generation under fixed seed across Rust/Python boundaries.
+## Outputs and semantics
+
+- `CrustThickness`: age-adjusted crust thickness proxy.
+- `IsostaticOffset`: globally closed buoyancy/elevation potential.
+- `UpliftRate` and `SubsidenceRate`: relative process-rate proxies.
+- `TectonicCompression`, `TectonicExtension`, and `ShearMagnitude`.
+- `LithosphereStiffness`: bounded relative stiffness proxy.
+- `CoastalExposure`: compatibility name for continental-margin proximity.
+- `BaseOceanMask`: compatibility name for oceanic-crust candidates. It is not a
+  water mask; sea level and connected ocean basins remain unsolved.
+- `HotspotEvents`: compatibility name for tectonic thermal-anomaly events, with
+  global cell ID, face, row, column, strength, and `plume_factor`. Neither the
+  event name nor `plume_factor` establishes a modeled mantle plume.
+- `WorldAgeMetadata`: parameters, area-weighted diagnostics, model identifier,
+  and explicit semantic labels for compatibility artifacts. Canonical metadata
+  exposes `proto_ocean_area_fraction`; `water_fraction` survives only inside the
+  shared native ABI and is not published by the spherical stage.
+
+## Determinism and storage
+
+Identical topology, tectonic artifacts, configuration, RNG seed, and native ABI
+produce identical arrays and events. All large fields remain arena-backed and
+are persisted by the normal stage dataset writer. Event coordinates are stable
+within a fixed cubed-sphere resolution.
+
+## Validation
+
+- All spherical output fields have shape `(6, n, n)`, finite `float32` values,
+  and deterministic contents.
+- `IsostaticOffset` has near-zero spherical-area-weighted mean.
+- Continental-margin distance and shear diffusion cross face boundaries through
+  global D4 neighbors.
+- Hotspot event IDs decode to valid face, row, and column coordinates.
+- Event expectation depends on global area averages, not cell count, so changing
+  resolution does not multiply event density.
+- Older canonical runs have lower residual heat and convective-vigor diagnostics,
+  thinner oceanic crust, greater mean stiffness, and no more thermal-anomaly events for a
+  fixed deterministic random stream.
+- Python validates dtype, shape, alignment, writability, and non-overlap before
+  entering the native FFI.
+
+## Known limitations
+
+- This is structural initialization, not time-stepped crust production,
+  subduction recycling, rifting, terrane accretion, or sediment history.
+- `UpliftRate` and `SubsidenceRate` are relative model fields without calibrated
+  physical units.
+- Margin proximity is not a coastline, and oceanic crust is not necessarily
+  submerged.
+- Glaciation, true flexural isostasy, sea level, erosion, and sediment loading
+  belong to later stages.
+- The kernel is scalar Rust today. No SIMD or Rayon performance claim is made.

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ The native build is explicit. Importing `map_maker` never invokes Cargo or a
 C++ compiler. To load native libraries built elsewhere, set
 `MAP_MAKER_NATIVE_LIB_DIR` to their containing directory.
 
-Every native library exposes ABI version `1`. `map-maker doctor` verifies that
+Every native library currently exposes ABI version `2`. `map-maker doctor` verifies that
 ABI and reports the binary SHA-256 fingerprint. Simulation-library fingerprints
 are included in stage cache keys and run manifests, so replacing a native binary
 cannot silently reuse outputs from different code.
@@ -93,9 +93,9 @@ uv run map-maker topology --face-resolution 96 --output-dir out/topology
 ```
 
 This writes a globally continuous XYZ-colored cube net and a geometry report.
-The canonical tectonic snapshot now runs directly on cubed-sphere neighbor
-IDs. World-age and erosion remain on the provisional two-dimensional path and
-must not consume flattened six-face fields.
+The canonical tectonic snapshot and age-conditioned crust state now run directly
+on cubed-sphere neighbor IDs. Erosion remains on the provisional two-dimensional
+path and explicitly rejects six-face fields.
 
 Run the previous procedural generator for comparison:
 
@@ -110,6 +110,9 @@ uv run map-maker-pipeline --stage tectonics --width 256 --height 128
 
 # Canonical six-face tectonic snapshot
 uv run map-maker-pipeline --stage tectonics --config configs/cubed_sphere_tectonics.yaml
+
+# Canonical age-conditioned crust state
+uv run map-maker-pipeline --stage world_age --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/pipeline/_world_age_native.py
+++ b/src/map_maker/pipeline/_world_age_native.py
@@ -8,12 +8,22 @@ import numpy as np
 import pyarrow as pa
 from cffi import FFI
 
-from .._native import native_library_info, native_library_path
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+CUBED_SPHERE_WORLD_AGE_ABI_VERSION = 1
 
 HOTSPOT_EVENT_DTYPE = np.dtype(
     [
         ("row", "<i4"),
         ("col", "<i4"),
+        ("strength", "<f4"),
+        ("plume_factor", "<f4"),
+    ]
+)
+
+SPHERICAL_HOTSPOT_EVENT_DTYPE = np.dtype(
+    [
+        ("global_cell_id", "<i4"),
         ("strength", "<f4"),
         ("plume_factor", "<f4"),
     ]
@@ -31,6 +41,17 @@ typedef struct {
     HotspotEvent* data;
     size_t len;
 } HotspotEventArray;
+
+typedef struct {
+    int32_t global_cell_id;
+    float strength;
+    float plume_factor;
+} SphericalHotspotEvent;
+
+typedef struct {
+    SphericalHotspotEvent* data;
+    size_t len;
+} SphericalHotspotEventArray;
 
 typedef struct {
     float convective_vigor;
@@ -82,6 +103,38 @@ int32_t world_age_run(
 );
 
 void world_age_free_events(HotspotEventArray array);
+uint32_t cubed_sphere_world_age_abi_version(void);
+int32_t world_age_run_cubed_sphere(
+    int32_t cell_count,
+    uint64_t seed,
+    float world_age,
+    float thermal_decay_half_life,
+    float hotspot_scale,
+    float isostasy_factor,
+    float radiogenic_heat_scale,
+    int32_t plate_components,
+    const double* area,
+    const int32_t* neighbors,
+    const float* plate_field,
+    const float* convergence_field,
+    const float* divergence_field,
+    const float* subduction_field,
+    const float* shear_field,
+    const float* hotspot_field,
+    float* crust_thickness_out,
+    float* isostasy_out,
+    float* uplift_out,
+    float* subsidence_out,
+    float* compression_out,
+    float* extension_out,
+    float* shear_out,
+    float* margin_proximity_out,
+    float* lithosphere_stiffness_out,
+    float* proto_ocean_mask_out,
+    SphericalHotspotEventArray* events_out,
+    WorldAgeStats* stats_out
+);
+void world_age_free_spherical_events(SphericalHotspotEventArray array);
 """
 
 
@@ -91,6 +144,8 @@ def _as_read_array(array: np.ndarray, *, name: str) -> np.ndarray:
         raise ValueError(f"{name} must be float32, got {arr.dtype}")
     if not arr.flags["C_CONTIGUOUS"]:
         raise ValueError(f"{name} must be contiguous")
+    if not arr.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
     return arr
 
 
@@ -100,15 +155,36 @@ def _as_write_array(array: np.ndarray, *, name: str) -> np.ndarray:
         raise ValueError(f"{name} must be float32, got {arr.dtype}")
     if not arr.flags["C_CONTIGUOUS"]:
         raise ValueError(f"{name} must be contiguous")
+    if not arr.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
     if not arr.flags.writeable:
         raise ValueError(f"{name} must be writable")
     return arr
+
+
+def _require_disjoint(buffers: dict[str, np.ndarray]) -> None:
+    items = list(buffers.items())
+    for index, (first_name, first) in enumerate(items):
+        for second_name, second in items[index + 1 :]:
+            if np.shares_memory(first, second):
+                raise ValueError(f"{first_name} and {second_name} buffers must not overlap")
 
 
 _ffi = FFI()
 _ffi.cdef(_CDEF)
 native_library_info("world_age_native")
 _lib = _ffi.dlopen(str(native_library_path("world_age_native")))
+try:
+    _cubed_sphere_abi = int(_lib.cubed_sphere_world_age_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "world_age_native lacks the cubed-sphere API; rebuild native libraries"
+    ) from exc
+if _cubed_sphere_abi != CUBED_SPHERE_WORLD_AGE_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "world_age_native cubed-sphere ABI "
+        f"{_cubed_sphere_abi} does not match expected {CUBED_SPHERE_WORLD_AGE_ABI_VERSION}"
+    )
 
 
 def _events_to_arrow(event_struct: Any, *, free_after: bool = True) -> pa.Table:
@@ -137,6 +213,62 @@ def _events_to_arrow(event_struct: Any, *, free_after: bool = True) -> pa.Table:
             "plume_factor": pa.array(events_np["plume_factor"], type=pa.float32()),
         }
     )
+
+
+def _spherical_events_to_arrow(event_struct: Any, *, face_resolution: int) -> pa.Table:
+    length = int(event_struct.len)
+    if length <= 0 or int(_ffi.cast("uintptr_t", event_struct.data)) == 0:
+        _lib.world_age_free_spherical_events(event_struct)
+        return pa.table(
+            {
+                "global_cell_id": pa.array([], type=pa.int32()),
+                "face": pa.array([], type=pa.int8()),
+                "row": pa.array([], type=pa.int32()),
+                "col": pa.array([], type=pa.int32()),
+                "strength": pa.array([], type=pa.float32()),
+                "plume_factor": pa.array([], type=pa.float32()),
+            }
+        )
+    buffer = _ffi.buffer(event_struct.data, length * SPHERICAL_HOTSPOT_EVENT_DTYPE.itemsize)
+    events = np.frombuffer(buffer, dtype=SPHERICAL_HOTSPOT_EVENT_DTYPE, count=length).copy()
+    _lib.world_age_free_spherical_events(event_struct)
+    global_ids = events["global_cell_id"]
+    face_size = face_resolution * face_resolution
+    faces = (global_ids // face_size).astype(np.int8)
+    within_face = global_ids % face_size
+    rows = (within_face // face_resolution).astype(np.int32)
+    cols = (within_face % face_resolution).astype(np.int32)
+    return pa.table(
+        {
+            "global_cell_id": pa.array(global_ids, type=pa.int32()),
+            "face": pa.array(faces, type=pa.int8()),
+            "row": pa.array(rows, type=pa.int32()),
+            "col": pa.array(cols, type=pa.int32()),
+            "strength": pa.array(events["strength"], type=pa.float32()),
+            "plume_factor": pa.array(events["plume_factor"], type=pa.float32()),
+        }
+    )
+
+
+def _stats_metadata(stats: Any) -> Dict[str, Any]:
+    return {
+        "convective_vigor": float(stats.convective_vigor),
+        "mean_crust_thickness": float(stats.mean_crust_thickness),
+        "std_crust_thickness": float(stats.std_crust_thickness),
+        "mean_isostatic_offset": float(stats.mean_isostatic_offset),
+        "hotspot_count": int(stats.hotspot_count),
+        "uplift_mean": float(stats.uplift_mean),
+        "subsidence_mean": float(stats.subsidence_mean),
+        "thermal_decay_factor": float(stats.thermal_decay_factor),
+        "water_fraction": float(stats.water_fraction),
+        "uplift_sigma_gt1": float(stats.uplift_sigma_gt1),
+        "uplift_sigma_gt2": float(stats.uplift_sigma_gt2),
+        "uplift_sigma_gt3": float(stats.uplift_sigma_gt3),
+        "subsidence_sigma_gt1": float(stats.subsidence_sigma_gt1),
+        "subsidence_sigma_gt2": float(stats.subsidence_sigma_gt2),
+        "subsidence_sigma_gt3": float(stats.subsidence_sigma_gt3),
+        "hotspot_density": float(stats.hotspot_density),
+    }
 
 
 def run_world_age_kernels(
@@ -215,6 +347,27 @@ def run_world_age_kernels(
         if arr.shape != expected_grid:
             raise ValueError(f"{name} expected shape {expected_grid}, got {arr.shape}")
 
+    _require_disjoint(
+        {
+            "plate_field": plate_arr,
+            "convergence_field": convergence_arr,
+            "divergence_field": divergence_arr,
+            "subduction_field": subduction_arr,
+            "shear_field": shear_arr,
+            "hotspot_field": hotspot_arr,
+            "crust_thickness_out": crust_arr,
+            "isostatic_offset_out": isostasy_arr,
+            "uplift_out": uplift_arr,
+            "subsidence_out": subsidence_arr,
+            "compression_out": compression_arr,
+            "extension_out": extension_arr,
+            "shear_out": shear_out_arr,
+            "coastal_exposure_out": coastal_exposure_arr,
+            "lithosphere_stiffness_out": lithosphere_arr,
+            "base_ocean_mask_out": base_ocean_mask_arr,
+        }
+    )
+
     events_ptr = _ffi.new("HotspotEventArray*")
     stats_ptr = _ffi.new("WorldAgeStats*")
 
@@ -258,25 +411,159 @@ def run_world_age_kernels(
 
     events_table = _events_to_arrow(events_ptr[0])
     stats = stats_ptr[0]
-    metadata = {
-        "convective_vigor": float(stats.convective_vigor),
-        "mean_crust_thickness": float(stats.mean_crust_thickness),
-        "std_crust_thickness": float(stats.std_crust_thickness),
-        "mean_isostatic_offset": float(stats.mean_isostatic_offset),
-        "hotspot_count": int(stats.hotspot_count),
-        "uplift_mean": float(stats.uplift_mean),
-        "subsidence_mean": float(stats.subsidence_mean),
-        "thermal_decay_factor": float(stats.thermal_decay_factor),
-        "water_fraction": float(stats.water_fraction),
-        "uplift_sigma_gt1": float(stats.uplift_sigma_gt1),
-        "uplift_sigma_gt2": float(stats.uplift_sigma_gt2),
-        "uplift_sigma_gt3": float(stats.uplift_sigma_gt3),
-        "subsidence_sigma_gt1": float(stats.subsidence_sigma_gt1),
-        "subsidence_sigma_gt2": float(stats.subsidence_sigma_gt2),
-        "subsidence_sigma_gt3": float(stats.subsidence_sigma_gt3),
-        "hotspot_density": float(stats.hotspot_density),
+    return events_table, _stats_metadata(stats)
+
+
+def run_cubed_sphere_world_age(
+    *,
+    seed: int,
+    world_age: float,
+    thermal_decay_half_life: float,
+    hotspot_scale: float,
+    isostasy_factor: float,
+    radiogenic_heat_scale: float,
+    areas: np.ndarray,
+    neighbors: np.ndarray,
+    plate_field: np.ndarray,
+    convergence_field: np.ndarray,
+    divergence_field: np.ndarray,
+    subduction_field: np.ndarray,
+    shear_field: np.ndarray,
+    hotspot_field: np.ndarray,
+    crust_thickness_out: np.ndarray,
+    isostatic_offset_out: np.ndarray,
+    uplift_out: np.ndarray,
+    subsidence_out: np.ndarray,
+    compression_out: np.ndarray,
+    extension_out: np.ndarray,
+    shear_out: np.ndarray,
+    margin_proximity_out: np.ndarray,
+    lithosphere_stiffness_out: np.ndarray,
+    proto_ocean_mask_out: np.ndarray,
+) -> Tuple[pa.Table, Dict[str, Any]]:
+    area_array = np.require(areas, dtype=np.float64, requirements=["C", "A"])
+    neighbor_array = np.require(neighbors, dtype=np.int32, requirements=["C", "A"])
+    if (
+        area_array.ndim != 3
+        or area_array.shape[0] != 6
+        or area_array.shape[1] != area_array.shape[2]
+    ):
+        raise ValueError("areas must have shape (6, n, n)")
+    face_shape = area_array.shape
+    face_resolution = face_shape[1]
+    if neighbor_array.shape != (*face_shape, 4):
+        raise ValueError(f"neighbors must have shape {(*face_shape, 4)}")
+
+    plate_array = _as_read_array(plate_field, name="plate_field")
+    if plate_array.ndim != 4 or plate_array.shape[:3] != face_shape or plate_array.shape[3] < 7:
+        raise ValueError(f"plate_field must have shape {(*face_shape, 7)} or more components")
+    scalar_inputs = {
+        "convergence_field": _as_read_array(convergence_field, name="convergence_field"),
+        "divergence_field": _as_read_array(divergence_field, name="divergence_field"),
+        "subduction_field": _as_read_array(subduction_field, name="subduction_field"),
+        "shear_field": _as_read_array(shear_field, name="shear_field"),
+        "hotspot_field": _as_read_array(hotspot_field, name="hotspot_field"),
     }
-    return events_table, metadata
+    scalar_outputs = {
+        "crust_thickness_out": _as_write_array(crust_thickness_out, name="crust_thickness_out"),
+        "isostatic_offset_out": _as_write_array(isostatic_offset_out, name="isostatic_offset_out"),
+        "uplift_out": _as_write_array(uplift_out, name="uplift_out"),
+        "subsidence_out": _as_write_array(subsidence_out, name="subsidence_out"),
+        "compression_out": _as_write_array(compression_out, name="compression_out"),
+        "extension_out": _as_write_array(extension_out, name="extension_out"),
+        "shear_out": _as_write_array(shear_out, name="shear_out"),
+        "margin_proximity_out": _as_write_array(margin_proximity_out, name="margin_proximity_out"),
+        "lithosphere_stiffness_out": _as_write_array(
+            lithosphere_stiffness_out, name="lithosphere_stiffness_out"
+        ),
+        "proto_ocean_mask_out": _as_write_array(proto_ocean_mask_out, name="proto_ocean_mask_out"),
+    }
+    for name, array in {**scalar_inputs, **scalar_outputs}.items():
+        if array.shape != face_shape:
+            raise ValueError(f"{name} must have shape {face_shape}")
+    buffers = {
+        "areas": area_array,
+        "neighbors": neighbor_array,
+        "plate_field": plate_array,
+        **scalar_inputs,
+        **scalar_outputs,
+    }
+    _require_disjoint(buffers)
+
+    events_ptr = _ffi.new("SphericalHotspotEventArray*")
+    stats_ptr = _ffi.new("WorldAgeStats*")
+    result = _lib.world_age_run_cubed_sphere(
+        int(np.prod(face_shape, dtype=np.int64)),
+        int(seed),
+        float(world_age),
+        float(thermal_decay_half_life),
+        float(hotspot_scale),
+        float(isostasy_factor),
+        float(radiogenic_heat_scale),
+        int(plate_array.shape[3]),
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", area_array)),
+        _ffi.cast("const int32_t*", _ffi.from_buffer("int32_t[]", neighbor_array)),
+        _ffi.cast("const float*", _ffi.from_buffer("float[]", plate_array, require_writable=False)),
+        _ffi.cast(
+            "const float*",
+            _ffi.from_buffer("float[]", scalar_inputs["convergence_field"], require_writable=False),
+        ),
+        _ffi.cast(
+            "const float*",
+            _ffi.from_buffer("float[]", scalar_inputs["divergence_field"], require_writable=False),
+        ),
+        _ffi.cast(
+            "const float*",
+            _ffi.from_buffer("float[]", scalar_inputs["subduction_field"], require_writable=False),
+        ),
+        _ffi.cast(
+            "const float*",
+            _ffi.from_buffer("float[]", scalar_inputs["shear_field"], require_writable=False),
+        ),
+        _ffi.cast(
+            "const float*",
+            _ffi.from_buffer("float[]", scalar_inputs["hotspot_field"], require_writable=False),
+        ),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["crust_thickness_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["isostatic_offset_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["uplift_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["subsidence_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["compression_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["extension_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["shear_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["margin_proximity_out"])),
+        _ffi.cast(
+            "float*",
+            _ffi.from_buffer("float[]", scalar_outputs["lithosphere_stiffness_out"]),
+        ),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_outputs["proto_ocean_mask_out"])),
+        events_ptr,
+        stats_ptr,
+    )
+    if result != 0:
+        raise RuntimeError(f"world_age_run_cubed_sphere failed with code {result}")
+    events = _spherical_events_to_arrow(events_ptr[0], face_resolution=face_resolution)
+    metadata = _stats_metadata(stats_ptr[0])
+    proto_ocean_area_fraction = metadata.pop("water_fraction")
+    metadata.update(
+        {
+            "event_coordinate_basis": "cubed_sphere_global_cell_id",
+            "event_semantics": "tectonic_thermal_anomaly_proxy_not_mantle_plume",
+            "plume_factor_semantics": "thermal_anomaly_intensity_compatibility_name",
+            "isostasy_weighting": "spherical_cell_area",
+            "ocean_mask_semantics": "oceanic_crust_candidate_not_final_water",
+            "coastal_exposure_semantics": "continental_margin_proximity",
+            "proto_ocean_area_fraction": proto_ocean_area_fraction,
+            "spatial_scale_basis": "approximate_angular_radians",
+        }
+    )
+    return events, metadata
 
 
-__all__ = ["HOTSPOT_EVENT_DTYPE", "run_world_age_kernels"]
+__all__ = [
+    "CUBED_SPHERE_WORLD_AGE_ABI_VERSION",
+    "HOTSPOT_EVENT_DTYPE",
+    "SPHERICAL_HOTSPOT_EVENT_DTYPE",
+    "run_cubed_sphere_world_age",
+    "run_world_age_kernels",
+]

--- a/src/map_maker/pipeline/native/world_age/src/lib.rs
+++ b/src/map_maker/pipeline/native/world_age/src/lib.rs
@@ -1,15 +1,26 @@
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
-use std::collections::VecDeque;
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, VecDeque};
 use std::f32;
 use std::mem;
 use std::slice;
 
 const DEFAULT_PLATE_COMPONENTS: usize = 6;
+const SPHERICAL_PLATE_COMPONENTS: usize = 7;
+const D4_NEIGHBORS: usize = 4;
+const SHEAR_SMOOTHING_ANGULAR_SCALE: f32 = 0.02;
+const MARGIN_EFOLD_ANGULAR_SCALE: f32 = 0.075;
+const MAX_DIFFUSION_PASSES: usize = 256;
 
 #[no_mangle]
 pub extern "C" fn world_age_native_abi_version() -> u32 {
     2
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_world_age_abi_version() -> u32 {
+    1
 }
 
 #[repr(C)]
@@ -23,6 +34,19 @@ pub struct HotspotEvent {
 #[repr(C)]
 pub struct HotspotEventArray {
     pub data: *mut HotspotEvent,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct SphericalHotspotEvent {
+    pub global_cell_id: i32,
+    pub strength: f32,
+    pub plume_factor: f32,
+}
+
+#[repr(C)]
+pub struct SphericalHotspotEventArray {
+    pub data: *mut SphericalHotspotEvent,
     pub len: usize,
 }
 
@@ -52,7 +76,7 @@ fn clamp_unit(value: f32) -> f32 {
 
 fn compute_decay_factor(world_age: f32, half_life: f32) -> f32 {
     let half_life = if half_life <= 0.0 { 1.0 } else { half_life };
-    (-world_age / half_life).exp()
+    (-f32::consts::LN_2 * world_age / half_life).exp()
 }
 
 fn sample_poisson(lambda: f64, rng: &mut ChaCha8Rng) -> usize {
@@ -90,7 +114,23 @@ unsafe fn slice_from_raw_mut<'a>(ptr: *mut f32, len: usize) -> &'a mut [f32] {
 /// have been released previously.
 pub unsafe extern "C" fn world_age_free_events(array: HotspotEventArray) {
     if !array.data.is_null() && array.len > 0 {
-        let _ = Vec::from_raw_parts(array.data, array.len, array.len);
+        let slice = std::ptr::slice_from_raw_parts_mut(array.data, array.len);
+        drop(Box::from_raw(slice));
+    }
+}
+
+#[no_mangle]
+/// Release spherical hotspot events allocated by
+/// [`world_age_run_cubed_sphere`].
+///
+/// # Safety
+///
+/// `array` must come from one successful spherical world-age call and must not
+/// have been released previously.
+pub unsafe extern "C" fn world_age_free_spherical_events(array: SphericalHotspotEventArray) {
+    if !array.data.is_null() && array.len > 0 {
+        let slice = std::ptr::slice_from_raw_parts_mut(array.data, array.len);
+        drop(Box::from_raw(slice));
     }
 }
 
@@ -515,10 +555,9 @@ pub unsafe extern "C" fn world_age_run(
         (*events_out).data = std::ptr::null_mut();
         (*events_out).len = 0;
         if event_len > 0 {
-            if let Some(mut owned) = events_opt.take() {
-                let ptr = owned.as_mut_ptr();
-                mem::forget(owned);
-                (*events_out).data = ptr;
+            if let Some(owned) = events_opt.take() {
+                let boxed = owned.into_boxed_slice();
+                (*events_out).data = Box::into_raw(boxed) as *mut HotspotEvent;
                 (*events_out).len = event_len;
             }
         }
@@ -555,4 +594,583 @@ pub unsafe extern "C" fn world_age_run(
     }
 
     0
+}
+
+fn valid_ffi_len<T>(len: usize) -> bool {
+    len.checked_mul(mem::size_of::<T>())
+        .is_some_and(|bytes| bytes <= isize::MAX as usize)
+}
+
+fn diffuse_d4(field: &mut [f32], neighbors: &[i32], areas: &[f64], angular_scale: f32) {
+    let target_variance = angular_scale * angular_scale;
+    let min_area = areas.iter().copied().fold(f64::INFINITY, f64::min) as f32;
+    let max_diffusion_time = target_variance / min_area.max(f32::MIN_POSITIVE);
+    let passes = ((max_diffusion_time / 0.5).ceil() as usize).clamp(1, MAX_DIFFUSION_PASSES);
+    let mut scratch = field.to_vec();
+    for _ in 0..passes {
+        scratch.copy_from_slice(field);
+        for (cell, value) in field.iter_mut().enumerate() {
+            let adjacent = &neighbors[cell * D4_NEIGHBORS..(cell + 1) * D4_NEIGHBORS];
+            let mean = adjacent
+                .iter()
+                .map(|neighbor| scratch[*neighbor as usize])
+                .sum::<f32>()
+                / D4_NEIGHBORS as f32;
+            let blend = (target_variance / areas[cell] as f32 / passes as f32).clamp(0.0, 0.5);
+            *value = scratch[cell] * (1.0 - blend) + mean * blend;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct DistanceEntry {
+    distance: f32,
+    cell: usize,
+}
+
+impl Eq for DistanceEntry {}
+
+impl Ord for DistanceEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .distance
+            .total_cmp(&self.distance)
+            .then_with(|| other.cell.cmp(&self.cell))
+    }
+}
+
+impl PartialOrd for DistanceEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn margin_distances(continental: &[bool], neighbors: &[i32], areas: &[f64]) -> Vec<f32> {
+    let mut distance = vec![f32::INFINITY; continental.len()];
+    let mut queue = BinaryHeap::new();
+    for cell in 0..continental.len() {
+        let adjacent = &neighbors[cell * D4_NEIGHBORS..(cell + 1) * D4_NEIGHBORS];
+        if adjacent
+            .iter()
+            .any(|neighbor| continental[*neighbor as usize] != continental[cell])
+        {
+            distance[cell] = 0.0;
+            queue.push(DistanceEntry {
+                distance: 0.0,
+                cell,
+            });
+        }
+    }
+    while let Some(entry) = queue.pop() {
+        if entry.distance > distance[entry.cell] {
+            continue;
+        }
+        let cell_scale = (areas[entry.cell] as f32).sqrt();
+        for &neighbor in &neighbors[entry.cell * D4_NEIGHBORS..(entry.cell + 1) * D4_NEIGHBORS] {
+            let adjacent = neighbor as usize;
+            let edge_scale = 0.5 * (cell_scale + (areas[adjacent] as f32).sqrt());
+            let candidate = entry.distance + edge_scale;
+            if candidate < distance[adjacent] {
+                distance[adjacent] = candidate;
+                queue.push(DistanceEntry {
+                    distance: candidate,
+                    cell: adjacent,
+                });
+            }
+        }
+    }
+    distance
+}
+
+fn weighted_sample_index(weights: &[f64], total_weight: f64, rng: &mut ChaCha8Rng) -> usize {
+    let target = rng.gen::<f64>() * total_weight;
+    let mut cumulative = 0.0f64;
+    for (index, weight) in weights.iter().enumerate() {
+        cumulative += *weight;
+        if cumulative >= target {
+            return index;
+        }
+    }
+    weights.len().saturating_sub(1)
+}
+
+#[no_mangle]
+/// Initialize age-conditioned crustal state on canonical cubed-sphere cells.
+///
+/// The proto-ocean output classifies oceanic crust and is not a final water or
+/// sea-level solution. Coastal exposure is continental-margin proximity.
+///
+/// # Safety
+///
+/// Inputs and outputs must be aligned, correctly sized, non-overlapping
+/// buffers. Areas contain one positive `f64` per cell; neighbors contain four
+/// valid global IDs per cell; the plate field has seven `f32` components per
+/// cell; scalar fields contain one `f32` per cell. Event and stats pointers may
+/// be null, though a null event pointer discards generated events.
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn world_age_run_cubed_sphere(
+    cell_count: i32,
+    seed: u64,
+    world_age: f32,
+    thermal_decay_half_life: f32,
+    hotspot_scale: f32,
+    isostasy_factor: f32,
+    radiogenic_heat_scale: f32,
+    plate_components: i32,
+    area_ptr: *const f64,
+    neighbors_ptr: *const i32,
+    plate_field_ptr: *const f32,
+    convergence_ptr: *const f32,
+    divergence_ptr: *const f32,
+    subduction_ptr: *const f32,
+    shear_ptr: *const f32,
+    hotspot_ptr: *const f32,
+    crust_out_ptr: *mut f32,
+    isostasy_out_ptr: *mut f32,
+    uplift_out_ptr: *mut f32,
+    subsidence_out_ptr: *mut f32,
+    compression_out_ptr: *mut f32,
+    extension_out_ptr: *mut f32,
+    shear_out_ptr: *mut f32,
+    margin_proximity_out_ptr: *mut f32,
+    lithosphere_stiffness_out_ptr: *mut f32,
+    proto_ocean_mask_ptr: *mut f32,
+    events_out: *mut SphericalHotspotEventArray,
+    stats_out: *mut WorldAgeStats,
+) -> i32 {
+    if cell_count <= 0
+        || plate_components < SPHERICAL_PLATE_COMPONENTS as i32
+        || !world_age.is_finite()
+        || world_age < 0.0
+        || !thermal_decay_half_life.is_finite()
+        || thermal_decay_half_life <= 0.0
+        || !hotspot_scale.is_finite()
+        || hotspot_scale < 0.0
+        || !isostasy_factor.is_finite()
+        || !radiogenic_heat_scale.is_finite()
+        || radiogenic_heat_scale <= 0.0
+        || area_ptr.is_null()
+        || neighbors_ptr.is_null()
+        || plate_field_ptr.is_null()
+        || convergence_ptr.is_null()
+        || divergence_ptr.is_null()
+        || subduction_ptr.is_null()
+        || shear_ptr.is_null()
+        || hotspot_ptr.is_null()
+        || crust_out_ptr.is_null()
+        || isostasy_out_ptr.is_null()
+        || uplift_out_ptr.is_null()
+        || subsidence_out_ptr.is_null()
+        || compression_out_ptr.is_null()
+        || extension_out_ptr.is_null()
+        || shear_out_ptr.is_null()
+        || margin_proximity_out_ptr.is_null()
+        || lithosphere_stiffness_out_ptr.is_null()
+        || proto_ocean_mask_ptr.is_null()
+    {
+        return 1;
+    }
+    let total = cell_count as usize;
+    let components = plate_components as usize;
+    let Some(plate_len) = total.checked_mul(components) else {
+        return 2;
+    };
+    let Some(neighbor_len) = total.checked_mul(D4_NEIGHBORS) else {
+        return 2;
+    };
+    if !valid_ffi_len::<f64>(total)
+        || !valid_ffi_len::<i32>(neighbor_len)
+        || !valid_ffi_len::<f32>(plate_len)
+        || !valid_ffi_len::<f32>(total)
+    {
+        return 2;
+    }
+
+    let areas = slice::from_raw_parts(area_ptr, total);
+    let neighbors = slice::from_raw_parts(neighbors_ptr, neighbor_len);
+    let plate_field = slice::from_raw_parts(plate_field_ptr, plate_len);
+    let convergence = slice::from_raw_parts(convergence_ptr, total);
+    let divergence = slice::from_raw_parts(divergence_ptr, total);
+    let subduction = slice::from_raw_parts(subduction_ptr, total);
+    let shear = slice::from_raw_parts(shear_ptr, total);
+    let hotspot = slice::from_raw_parts(hotspot_ptr, total);
+    let crust_out = slice::from_raw_parts_mut(crust_out_ptr, total);
+    let isostasy_out = slice::from_raw_parts_mut(isostasy_out_ptr, total);
+    let uplift_out = slice::from_raw_parts_mut(uplift_out_ptr, total);
+    let subsidence_out = slice::from_raw_parts_mut(subsidence_out_ptr, total);
+    let compression_out = slice::from_raw_parts_mut(compression_out_ptr, total);
+    let extension_out = slice::from_raw_parts_mut(extension_out_ptr, total);
+    let shear_out = slice::from_raw_parts_mut(shear_out_ptr, total);
+    let margin_out = slice::from_raw_parts_mut(margin_proximity_out_ptr, total);
+    let stiffness_out = slice::from_raw_parts_mut(lithosphere_stiffness_out_ptr, total);
+    let proto_ocean_out = slice::from_raw_parts_mut(proto_ocean_mask_ptr, total);
+
+    let mut total_area = 0.0f64;
+    for cell in 0..total {
+        let area = areas[cell];
+        let base = cell * components;
+        if !area.is_finite()
+            || area <= 0.0
+            || plate_field[base..base + SPHERICAL_PLATE_COMPONENTS]
+                .iter()
+                .any(|value| !value.is_finite())
+            || [
+                convergence[cell],
+                divergence[cell],
+                subduction[cell],
+                shear[cell],
+                hotspot[cell],
+            ]
+            .iter()
+            .any(|value| !value.is_finite())
+        {
+            return 3;
+        }
+        let mut unique = [
+            neighbors[cell * 4],
+            neighbors[cell * 4 + 1],
+            neighbors[cell * 4 + 2],
+            neighbors[cell * 4 + 3],
+        ];
+        unique.sort_unstable();
+        if unique.windows(2).any(|pair| pair[0] == pair[1])
+            || unique
+                .iter()
+                .any(|neighbor| *neighbor < 0 || *neighbor as usize >= total)
+        {
+            return 4;
+        }
+        total_area += area;
+    }
+    if !total_area.is_finite() || total_area <= 0.0 {
+        return 3;
+    }
+
+    let residual_heat = compute_decay_factor(world_age, thermal_decay_half_life);
+    let heat_scale = radiogenic_heat_scale.clamp(0.1, 4.0);
+    let convective_heat = ((0.28 + 0.72 * residual_heat) * heat_scale).clamp(0.05, 2.5);
+    let cooling = (1.0 - residual_heat).clamp(0.0, 1.0);
+    let mut continental = vec![false; total];
+    let mut buoyancy = vec![0.0f32; total];
+    let mut shear_smoothed = vec![0.0f32; total];
+    let mut thickness_sum = 0.0f64;
+    let mut thickness_sq_sum = 0.0f64;
+    let mut buoyancy_sum = 0.0f64;
+    let mut speed_sum = 0.0f64;
+    let mut ocean_area = 0.0f64;
+    let mantle_density = 3.30f32;
+
+    for cell in 0..total {
+        let base = cell * components;
+        continental[cell] = plate_field[base + 1] >= 0.5;
+        let base_thickness = plate_field[base + 2].max(0.1);
+        let density = plate_field[base + 3].clamp(2.4, 3.5);
+        let thickness_factor = if continental[cell] {
+            0.98 + 0.08 * convective_heat
+        } else {
+            0.84 + 0.22 * convective_heat
+        };
+        let thickness = (base_thickness * thickness_factor).max(0.5);
+        crust_out[cell] = thickness;
+        let root = thickness * (mantle_density - density).max(-0.2) / mantle_density;
+        buoyancy[cell] = root * isostasy_factor;
+        shear_smoothed[cell] = (shear[cell].abs() + 0.45 * subduction[cell].max(0.0))
+            * (0.65 + 0.35 * convective_heat);
+
+        let area = areas[cell];
+        thickness_sum += thickness as f64 * area;
+        thickness_sq_sum += thickness as f64 * thickness as f64 * area;
+        buoyancy_sum += buoyancy[cell] as f64 * area;
+        let vx = plate_field[base + 4] as f64;
+        let vy = plate_field[base + 5] as f64;
+        let vz = plate_field[base + 6] as f64;
+        speed_sum += (vx * vx + vy * vy + vz * vz).sqrt() * area;
+        if !continental[cell] {
+            proto_ocean_out[cell] = 1.0;
+            ocean_area += area;
+        } else {
+            proto_ocean_out[cell] = 0.0;
+        }
+    }
+
+    let mean_thickness = (thickness_sum / total_area) as f32;
+    let thickness_variance =
+        (thickness_sq_sum / total_area - mean_thickness as f64 * mean_thickness as f64).max(0.0);
+    let mean_buoyancy = (buoyancy_sum / total_area) as f32;
+    let mut uplift_sum = 0.0f64;
+    let mut subsidence_sum = 0.0f64;
+    let mut uplift_sq_sum = 0.0f64;
+    let mut subsidence_sq_sum = 0.0f64;
+
+    for cell in 0..total {
+        isostasy_out[cell] = buoyancy[cell] - mean_buoyancy;
+        let conv = convergence[cell].max(0.0);
+        let div = divergence[cell].max(0.0);
+        let subd = subduction[cell].clamp(0.0, 1.0);
+        let hot = hotspot[cell].clamp(0.0, 1.0);
+        compression_out[cell] = (0.55 * conv + 0.7 * subd).clamp(0.0, 1.0);
+        extension_out[cell] = (div * (0.8 + 0.35 * convective_heat) - 0.2 * conv).clamp(0.0, 1.0);
+        let stiffness_base = if continental[cell] { 0.58 } else { 0.36 };
+        stiffness_out[cell] = (stiffness_base
+            + 0.24 * cooling
+            + 0.12 * (crust_out[cell] / mean_thickness.max(0.1) - 1.0))
+            .clamp(0.0, 1.0);
+        let uplift = conv * (0.8 + 0.45 * convective_heat)
+            + subd * (0.45 + 0.2 * convective_heat)
+            + hot * 0.22 * convective_heat;
+        let oceanic_cooling = if continental[cell] {
+            0.0
+        } else {
+            0.08 * cooling
+        };
+        let subsidence = div * (0.7 + 0.25 * convective_heat) + oceanic_cooling + hot * 0.025;
+        uplift_out[cell] = uplift;
+        subsidence_out[cell] = subsidence;
+        let area = areas[cell];
+        uplift_sum += uplift as f64 * area;
+        subsidence_sum += subsidence as f64 * area;
+        uplift_sq_sum += uplift as f64 * uplift as f64 * area;
+        subsidence_sq_sum += subsidence as f64 * subsidence as f64 * area;
+    }
+
+    diffuse_d4(
+        &mut shear_smoothed,
+        neighbors,
+        areas,
+        SHEAR_SMOOTHING_ANGULAR_SCALE,
+    );
+    let max_shear = shear_smoothed
+        .iter()
+        .copied()
+        .fold(0.0f32, f32::max)
+        .max(1e-6);
+    for (output, value) in shear_out.iter_mut().zip(shear_smoothed.iter()) {
+        *output = (*value / max_shear).clamp(0.0, 1.0);
+    }
+
+    let distances = margin_distances(&continental, neighbors, areas);
+    for cell in 0..total {
+        margin_out[cell] = if distances[cell].is_finite() {
+            (-distances[cell] / MARGIN_EFOLD_ANGULAR_SCALE).exp()
+        } else {
+            0.0
+        };
+    }
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0xC1A0_1D2C_A5E2_5319);
+    let event_weights: Vec<f64> = hotspot
+        .iter()
+        .zip(areas.iter())
+        .map(|(value, area)| value.clamp(0.0, 1.0) as f64 * *area)
+        .collect();
+    let total_event_weight: f64 = event_weights.iter().sum();
+    let mean_hotspot = total_event_weight / total_area;
+    let expected_events =
+        hotspot_scale as f64 * (4.0 + 28.0 * convective_heat as f64) * (0.5 + 2.0 * mean_hotspot);
+    let event_count = if total_event_weight > 0.0 {
+        sample_poisson(expected_events, &mut rng)
+    } else {
+        0
+    };
+    let mut events = Vec::with_capacity(event_count);
+    for _ in 0..event_count {
+        let cell = weighted_sample_index(&event_weights, total_event_weight, &mut rng);
+        events.push(SphericalHotspotEvent {
+            global_cell_id: cell as i32,
+            strength: (hotspot[cell].clamp(0.0, 1.0) * (0.7 + 0.6 * convective_heat)).min(2.0),
+            plume_factor: clamp_unit(convective_heat + rng.gen::<f32>() * 0.2),
+        });
+    }
+
+    let uplift_mean = (uplift_sum / total_area) as f32;
+    let subsidence_mean = (subsidence_sum / total_area) as f32;
+    let uplift_std = (uplift_sq_sum / total_area - uplift_mean as f64 * uplift_mean as f64)
+        .max(0.0)
+        .sqrt() as f32;
+    let subsidence_std = (subsidence_sq_sum / total_area
+        - subsidence_mean as f64 * subsidence_mean as f64)
+        .max(0.0)
+        .sqrt() as f32;
+    let mut uplift_sigma_area = [0.0f64; 3];
+    let mut subsidence_sigma_area = [0.0f64; 3];
+    for cell in 0..total {
+        let uplift_z = (uplift_out[cell] - uplift_mean) / uplift_std.max(1e-6);
+        let subsidence_z = (subsidence_out[cell] - subsidence_mean) / subsidence_std.max(1e-6);
+        for (index, threshold) in [1.0f32, 2.0, 3.0].iter().enumerate() {
+            if uplift_z >= *threshold {
+                uplift_sigma_area[index] += areas[cell];
+            }
+            if subsidence_z >= *threshold {
+                subsidence_sigma_area[index] += areas[cell];
+            }
+        }
+    }
+
+    let event_len = events.len();
+    if !events_out.is_null() {
+        (*events_out).data = std::ptr::null_mut();
+        (*events_out).len = 0;
+        if event_len > 0 {
+            let boxed = events.into_boxed_slice();
+            (*events_out).data = Box::into_raw(boxed) as *mut SphericalHotspotEvent;
+            (*events_out).len = event_len;
+        }
+    }
+    if !stats_out.is_null() {
+        (*stats_out) = WorldAgeStats {
+            convective_vigor: (speed_sum / total_area) as f32 * convective_heat,
+            mean_crust_thickness: mean_thickness,
+            std_crust_thickness: thickness_variance.sqrt() as f32,
+            mean_isostatic_offset: (isostasy_out
+                .iter()
+                .zip(areas.iter())
+                .map(|(value, area)| *value as f64 * *area)
+                .sum::<f64>()
+                / total_area) as f32,
+            hotspot_count: event_len.min(i32::MAX as usize) as i32,
+            uplift_mean,
+            subsidence_mean,
+            thermal_decay_factor: residual_heat,
+            water_fraction: (ocean_area / total_area) as f32,
+            uplift_sigma_gt1: (uplift_sigma_area[0] / total_area) as f32,
+            uplift_sigma_gt2: (uplift_sigma_area[1] / total_area) as f32,
+            uplift_sigma_gt3: (uplift_sigma_area[2] / total_area) as f32,
+            subsidence_sigma_gt1: (subsidence_sigma_area[0] / total_area) as f32,
+            subsidence_sigma_gt2: (subsidence_sigma_area[1] / total_area) as f32,
+            subsidence_sigma_gt3: (subsidence_sigma_area[2] / total_area) as f32,
+            hotspot_density: event_len as f32 / total_area as f32,
+        };
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cyclic_d4_neighbors(cell_count: usize) -> Vec<i32> {
+        let mut neighbors = Vec::with_capacity(cell_count * D4_NEIGHBORS);
+        for cell in 0..cell_count {
+            for offset in 1..=D4_NEIGHBORS {
+                neighbors.push(((cell + offset) % cell_count) as i32);
+            }
+        }
+        neighbors
+    }
+
+    #[test]
+    fn margin_distances_cross_graph_boundaries() {
+        let continental = [true, true, true, false, false, false];
+        let neighbors = cyclic_d4_neighbors(continental.len());
+        let areas = [0.1f64; 6];
+        let distances = margin_distances(&continental, &neighbors, &areas);
+
+        assert_eq!(distances.len(), continental.len());
+        assert!(distances.iter().all(|distance| *distance == 0.0));
+    }
+
+    #[test]
+    fn spherical_kernel_closes_area_weighted_isostasy_and_owns_events() {
+        let cell_count = 6usize;
+        let areas = [0.7f64, 1.1, 1.4, 2.0, 2.3, 3.0];
+        let neighbors = cyclic_d4_neighbors(cell_count);
+        let mut plate_field = vec![0.0f32; cell_count * SPHERICAL_PLATE_COMPONENTS];
+        for cell in 0..cell_count {
+            let base = cell * SPHERICAL_PLATE_COMPONENTS;
+            let continental = cell < 3;
+            plate_field[base] = cell as f32;
+            plate_field[base + 1] = if continental { 1.0 } else { 0.0 };
+            plate_field[base + 2] = if continental { 35.0 } else { 7.0 };
+            plate_field[base + 3] = if continental { 2.75 } else { 3.0 };
+            plate_field[base + 4] = 0.02 * cell as f32;
+            plate_field[base + 5] = 0.01;
+            plate_field[base + 6] = -0.01;
+        }
+        let convergence = vec![0.2f32; cell_count];
+        let divergence = vec![0.1f32; cell_count];
+        let subduction = vec![0.15f32; cell_count];
+        let shear = vec![0.08f32; cell_count];
+        let hotspot = vec![1.0f32; cell_count];
+        let mut outputs = vec![vec![0.0f32; cell_count]; 10];
+        let mut events = SphericalHotspotEventArray {
+            data: std::ptr::null_mut(),
+            len: 0,
+        };
+        let mut stats = WorldAgeStats {
+            convective_vigor: 0.0,
+            mean_crust_thickness: 0.0,
+            std_crust_thickness: 0.0,
+            mean_isostatic_offset: 0.0,
+            hotspot_count: 0,
+            uplift_mean: 0.0,
+            subsidence_mean: 0.0,
+            thermal_decay_factor: 0.0,
+            water_fraction: 0.0,
+            uplift_sigma_gt1: 0.0,
+            uplift_sigma_gt2: 0.0,
+            uplift_sigma_gt3: 0.0,
+            subsidence_sigma_gt1: 0.0,
+            subsidence_sigma_gt2: 0.0,
+            subsidence_sigma_gt3: 0.0,
+            hotspot_density: 0.0,
+        };
+
+        let result = unsafe {
+            world_age_run_cubed_sphere(
+                cell_count as i32,
+                17,
+                4.1,
+                1.8,
+                20.0,
+                0.6,
+                1.0,
+                SPHERICAL_PLATE_COMPONENTS as i32,
+                areas.as_ptr(),
+                neighbors.as_ptr(),
+                plate_field.as_ptr(),
+                convergence.as_ptr(),
+                divergence.as_ptr(),
+                subduction.as_ptr(),
+                shear.as_ptr(),
+                hotspot.as_ptr(),
+                outputs[0].as_mut_ptr(),
+                outputs[1].as_mut_ptr(),
+                outputs[2].as_mut_ptr(),
+                outputs[3].as_mut_ptr(),
+                outputs[4].as_mut_ptr(),
+                outputs[5].as_mut_ptr(),
+                outputs[6].as_mut_ptr(),
+                outputs[7].as_mut_ptr(),
+                outputs[8].as_mut_ptr(),
+                outputs[9].as_mut_ptr(),
+                &mut events,
+                &mut stats,
+            )
+        };
+
+        assert_eq!(result, 0);
+        assert!(outputs.iter().flatten().all(|value| value.is_finite()));
+        let total_area: f64 = areas.iter().sum();
+        let weighted_offset = outputs[1]
+            .iter()
+            .zip(areas.iter())
+            .map(|(value, area)| *value as f64 * *area)
+            .sum::<f64>()
+            / total_area;
+        assert!(weighted_offset.abs() < 1e-6);
+        assert!(stats.mean_isostatic_offset.abs() < 1e-6);
+        assert_eq!(events.len, stats.hotspot_count as usize);
+        assert!(events.len > 0);
+        let generated = unsafe { slice::from_raw_parts(events.data, events.len) };
+        assert!(generated
+            .iter()
+            .all(|event| (0..cell_count as i32).contains(&event.global_cell_id)));
+        unsafe { world_age_free_spherical_events(events) };
+    }
+
+    #[test]
+    fn residual_heat_decreases_with_age() {
+        assert!((compute_decay_factor(1.8, 1.8) - 0.5).abs() < 1e-6);
+        assert!(compute_decay_factor(4.5, 1.8) < compute_decay_factor(1.0, 1.8));
+    }
 }

--- a/src/map_maker/pipeline/stages/erosion.py
+++ b/src/map_maker/pipeline/stages/erosion.py
@@ -9,6 +9,7 @@ import numpy as np
 import pyarrow as pa
 
 from .._erosion_native import run_erosion_kernels
+from ..cubed_sphere import CubedSphereGrid
 from ..registry import stage
 
 
@@ -134,6 +135,11 @@ def _log_erosion(context, metadata: Mapping[str, object]) -> None:
     version="v3",
 )
 def erosion_stage(context, deps, config_mapping):
+    if isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError(
+            "erosion has not migrated to cubed_sphere; use world_age as the current "
+            "canonical pipeline endpoint"
+        )
     config = ErosionConfig.from_mapping(config_mapping)
     height, width = context.topology.shape
 

--- a/src/map_maker/pipeline/stages/world_age.py
+++ b/src/map_maker/pipeline/stages/world_age.py
@@ -1,4 +1,4 @@
-"""Implementation scaffold for Stage 4 – World Age & Thermal Adjustments."""
+"""Age-conditioned crust-state initialization for rectangular and spherical worlds."""
 
 from __future__ import annotations
 
@@ -6,9 +6,12 @@ from dataclasses import dataclass
 from typing import Mapping
 
 import numpy as np
+from PIL import Image
 
-from .._world_age_native import run_world_age_kernels
+from .._world_age_native import run_cubed_sphere_world_age, run_world_age_kernels
+from ..cubed_sphere import CubedSphereGrid
 from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
 
 
 @dataclass(frozen=True)
@@ -55,26 +58,105 @@ def _artifact_view(result, name: str) -> np.ndarray:
 def _log_world_age(
     context, metadata: Mapping[str, object], *, seed: int, config: WorldAgeConfig
 ) -> None:
-    context.logger.log_event(
-        {
-            "type": "world_age_summary",
-            "stage": "world_age",
-            "seed": seed,
-            "world_age": config.world_age,
-            "thermal_decay_half_life": config.thermal_decay_half_life,
-            "radiogenic_heat_scale": config.radiogenic_heat_scale,
-            "convective_vigor": metadata.get("convective_vigor"),
-            "hotspot_count": metadata.get("hotspot_count"),
-            "uplift_mean": metadata.get("uplift_mean"),
-            "subsidence_mean": metadata.get("subsidence_mean"),
-            "water_fraction": metadata.get("water_fraction"),
-            "uplift_sigma_gt1": metadata.get("uplift_sigma_gt1"),
-            "uplift_sigma_gt2": metadata.get("uplift_sigma_gt2"),
-            "subsidence_sigma_gt1": metadata.get("subsidence_sigma_gt1"),
-            "subsidence_sigma_gt2": metadata.get("subsidence_sigma_gt2"),
-            "hotspot_density": metadata.get("hotspot_density"),
-        }
+    event = {
+        "type": "world_age_summary",
+        "stage": "world_age",
+        "seed": seed,
+        "world_age": config.world_age,
+        "thermal_decay_half_life": config.thermal_decay_half_life,
+        "radiogenic_heat_scale": config.radiogenic_heat_scale,
+        "convective_vigor": metadata.get("convective_vigor"),
+        "hotspot_count": metadata.get("hotspot_count"),
+        "uplift_mean": metadata.get("uplift_mean"),
+        "subsidence_mean": metadata.get("subsidence_mean"),
+        "uplift_sigma_gt1": metadata.get("uplift_sigma_gt1"),
+        "uplift_sigma_gt2": metadata.get("uplift_sigma_gt2"),
+        "subsidence_sigma_gt1": metadata.get("subsidence_sigma_gt1"),
+        "subsidence_sigma_gt2": metadata.get("subsidence_sigma_gt2"),
+        "hotspot_density": metadata.get("hotspot_density"),
+    }
+    if "proto_ocean_area_fraction" in metadata:
+        event["proto_ocean_area_fraction"] = metadata["proto_ocean_area_fraction"]
+    else:
+        event["water_fraction"] = metadata.get("water_fraction")
+    context.logger.log_event(event)
+
+
+def _result_array(result, name: str) -> np.ndarray | None:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        return None
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
+    resolution = faces.shape[1]
+    net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
+    placements = {3: (1, 0), 0: (1, 1), 2: (1, 2), 1: (1, 3), 4: (0, 1), 5: (2, 1)}
+    for face, (net_row, net_col) in placements.items():
+        row = net_row * resolution
+        col = net_col * resolution
+        net[row : row + resolution, col : col + resolution] = faces[face]
+    return net
+
+
+def _scaled(values: np.ndarray) -> np.ndarray:
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return np.zeros(values.shape, dtype=np.float32)
+    low, high = np.percentile(finite, (2.0, 98.0))
+    return np.clip((values - low) / max(float(high - low), 1e-9), 0.0, 1.0).astype(np.float32)
+
+
+def _world_age_visualizer(
+    result, request: VisualizationRequest
+) -> list[VisualizationResult] | None:
+    isostasy = _result_array(result, "IsostaticOffset")
+    uplift = _result_array(result, "UpliftRate")
+    subsidence = _result_array(result, "SubsidenceRate")
+    shear = _result_array(result, "ShearMagnitude")
+    proto_ocean = _result_array(result, "BaseOceanMask")
+    if (
+        isostasy is None
+        or uplift is None
+        or subsidence is None
+        or shear is None
+        or proto_ocean is None
+        or isostasy.ndim != 3
+        or isostasy.shape[0] != 6
+    ):
+        return None
+
+    results = []
+    scale = max(float(np.percentile(np.abs(isostasy), 98)), 1e-6)
+    signed = np.clip(isostasy / scale, -1.0, 1.0)
+    isostasy_rgb = np.empty((*isostasy.shape, 3), dtype=np.uint8)
+    isostasy_rgb[..., 0] = np.where(signed > 0, 110 + signed * 145, 40).astype(np.uint8)
+    isostasy_rgb[..., 1] = (95 + (1.0 - np.abs(signed)) * 95).astype(np.uint8)
+    isostasy_rgb[..., 2] = np.where(signed < 0, 120 - signed * 135, 45).astype(np.uint8)
+    isostasy_path = request.output_dir / "isostatic_potential.png"
+    Image.fromarray(_cube_net_rgb(isostasy_rgb), mode="RGB").save(isostasy_path)
+    results.append(
+        VisualizationResult(path=isostasy_path, artifact_name="IsostaticOffset", metadata={})
     )
+
+    rates = np.zeros((*uplift.shape, 3), dtype=np.uint8)
+    rates[..., 0] = (_scaled(uplift) * 255).astype(np.uint8)
+    rates[..., 1] = (_scaled(shear) * 190).astype(np.uint8)
+    rates[..., 2] = (_scaled(subsidence) * 255).astype(np.uint8)
+    rates_path = request.output_dir / "tectonic_rates.png"
+    Image.fromarray(_cube_net_rgb(rates), mode="RGB").save(rates_path)
+    results.append(VisualizationResult(path=rates_path, artifact_name="TectonicRates", metadata={}))
+
+    crust = np.zeros((*proto_ocean.shape, 3), dtype=np.uint8)
+    ocean = proto_ocean >= 0.5
+    crust[ocean] = np.array([38, 102, 153], dtype=np.uint8)
+    crust[~ocean] = np.array([177, 151, 99], dtype=np.uint8)
+    crust_path = request.output_dir / "proto_crust.png"
+    Image.fromarray(_cube_net_rgb(crust), mode="RGB").save(crust_path)
+    results.append(VisualizationResult(path=crust_path, artifact_name="BaseOceanMask", metadata={}))
+    return results
 
 
 @stage(
@@ -94,14 +176,13 @@ def _log_world_age(
         "HotspotEvents",
         "WorldAgeMetadata",
     ),
+    version="v2",
+    visualizer=_world_age_visualizer,
 )
 def world_age_stage(context, deps, config_mapping):
     config = WorldAgeConfig.from_mapping(config_mapping)
-    if len(context.topology.shape) != 2:
-        raise NotImplementedError(
-            "world_age has not yet migrated to cubed_sphere; run through tectonics only"
-        )
-    height, width = context.topology.shape
+    is_cubed_sphere = isinstance(context.topology, CubedSphereGrid)
+    shape = context.topology.face_shape if is_cubed_sphere else context.topology.shape
 
     tectonics_result = deps["tectonics"]
     plate_arr = _artifact_view(tectonics_result, "PlateField")
@@ -111,89 +192,70 @@ def world_age_stage(context, deps, config_mapping):
     shear_arr = _artifact_view(tectonics_result, "BoundaryShear")
     hotspot_arr = _artifact_view(tectonics_result, "HotspotMap")
 
-    crust_handle = context.arena.allocate_grid(
-        "world_age_crust_thickness", (height, width), dtype=np.float32
-    )
-    isostasy_handle = context.arena.allocate_grid(
-        "world_age_isostatic_offset", (height, width), dtype=np.float32
-    )
-    uplift_handle = context.arena.allocate_grid(
-        "world_age_uplift_rate", (height, width), dtype=np.float32
-    )
-    subsidence_handle = context.arena.allocate_grid(
-        "world_age_subsidence_rate", (height, width), dtype=np.float32
-    )
-    compression_handle = context.arena.allocate_grid(
-        "world_age_tectonic_compression", (height, width), dtype=np.float32
-    )
-    extension_handle = context.arena.allocate_grid(
-        "world_age_tectonic_extension", (height, width), dtype=np.float32
-    )
-    shear_handle = context.arena.allocate_grid(
-        "world_age_shear_magnitude", (height, width), dtype=np.float32
-    )
-    coastal_handle = context.arena.allocate_grid(
-        "world_age_coastal_exposure", (height, width), dtype=np.float32
-    )
-    lithosphere_handle = context.arena.allocate_grid(
-        "world_age_lithosphere_stiffness", (height, width), dtype=np.float32
-    )
-    ocean_mask_handle = context.arena.allocate_grid(
-        "world_age_base_ocean_mask", (height, width), dtype=np.float32
-    )
+    def allocate(name: str):
+        if is_cubed_sphere:
+            return context.arena.allocate_array(name, shape, dtype=np.float32)
+        return context.arena.allocate_grid(name, shape, dtype=np.float32)
 
-    crust_view = crust_handle.mutable_view()
-    isostasy_view = isostasy_handle.mutable_view()
-    uplift_view = uplift_handle.mutable_view()
-    subsidence_view = subsidence_handle.mutable_view()
-    compression_view = compression_handle.mutable_view()
-    extension_view = extension_handle.mutable_view()
-    shear_view = shear_handle.mutable_view()
-    coastal_view = coastal_handle.mutable_view()
-    lithosphere_view = lithosphere_handle.mutable_view()
-    ocean_mask_view = ocean_mask_handle.mutable_view()
+    handles = {
+        "CrustThickness": allocate("world_age_crust_thickness"),
+        "IsostaticOffset": allocate("world_age_isostatic_offset"),
+        "UpliftRate": allocate("world_age_uplift_rate"),
+        "SubsidenceRate": allocate("world_age_subsidence_rate"),
+        "TectonicCompression": allocate("world_age_tectonic_compression"),
+        "TectonicExtension": allocate("world_age_tectonic_extension"),
+        "ShearMagnitude": allocate("world_age_shear_magnitude"),
+        "CoastalExposure": allocate("world_age_coastal_exposure"),
+        "LithosphereStiffness": allocate("world_age_lithosphere_stiffness"),
+        "BaseOceanMask": allocate("world_age_base_ocean_mask"),
+    }
+    views = {name: handle.mutable_view() for name, handle in handles.items()}
 
     rng = context.rng("world_age")
     seed = int(rng.integers(0, 2**63 - 1))
 
     with context.timed("world_age_kernel"):
-        events_table, metadata = run_world_age_kernels(
-            height=height,
-            width=width,
-            seed=seed,
-            world_age=config.world_age,
-            thermal_decay_half_life=config.thermal_decay_half_life,
-            hotspot_scale=config.hotspot_scale,
-            isostasy_factor=config.isostasy_factor,
-            radiogenic_heat_scale=config.radiogenic_heat_scale,
-            plate_field=plate_arr,
-            convergence_field=convergence_arr,
-            divergence_field=divergence_arr,
-            subduction_field=subduction_arr,
-            shear_field=shear_arr,
-            hotspot_field=hotspot_arr,
-            crust_thickness_out=crust_view,
-            isostatic_offset_out=isostasy_view,
-            uplift_out=uplift_view,
-            subsidence_out=subsidence_view,
-            compression_out=compression_view,
-            extension_out=extension_view,
-            shear_out=shear_view,
-            coastal_exposure_out=coastal_view,
-            lithosphere_stiffness_out=lithosphere_view,
-            base_ocean_mask_out=ocean_mask_view,
-        )
+        common = {
+            "seed": seed,
+            "world_age": config.world_age,
+            "thermal_decay_half_life": config.thermal_decay_half_life,
+            "hotspot_scale": config.hotspot_scale,
+            "isostasy_factor": config.isostasy_factor,
+            "radiogenic_heat_scale": config.radiogenic_heat_scale,
+            "plate_field": plate_arr,
+            "convergence_field": convergence_arr,
+            "divergence_field": divergence_arr,
+            "subduction_field": subduction_arr,
+            "shear_field": shear_arr,
+            "hotspot_field": hotspot_arr,
+            "crust_thickness_out": views["CrustThickness"],
+            "isostatic_offset_out": views["IsostaticOffset"],
+            "uplift_out": views["UpliftRate"],
+            "subsidence_out": views["SubsidenceRate"],
+            "compression_out": views["TectonicCompression"],
+            "extension_out": views["TectonicExtension"],
+            "shear_out": views["ShearMagnitude"],
+            "lithosphere_stiffness_out": views["LithosphereStiffness"],
+        }
+        if is_cubed_sphere:
+            events_table, metadata = run_cubed_sphere_world_age(
+                **common,
+                areas=context.topology.cell_areas,
+                neighbors=context.topology.neighbor_indices,
+                margin_proximity_out=views["CoastalExposure"],
+                proto_ocean_mask_out=views["BaseOceanMask"],
+            )
+        else:
+            events_table, metadata = run_world_age_kernels(
+                **common,
+                height=shape[0],
+                width=shape[1],
+                coastal_exposure_out=views["CoastalExposure"],
+                base_ocean_mask_out=views["BaseOceanMask"],
+            )
 
-    crust_handle.seal()
-    isostasy_handle.seal()
-    uplift_handle.seal()
-    subsidence_handle.seal()
-    compression_handle.seal()
-    extension_handle.seal()
-    shear_handle.seal()
-    coastal_handle.seal()
-    lithosphere_handle.seal()
-    ocean_mask_handle.seal()
+    for handle in handles.values():
+        handle.seal()
 
     metadata = dict(metadata)
     metadata.update(
@@ -203,22 +265,16 @@ def world_age_stage(context, deps, config_mapping):
             "hotspot_scale": config.hotspot_scale,
             "isostasy_factor": config.isostasy_factor,
             "radiogenic_heat_scale": config.radiogenic_heat_scale,
+            "crust_state_model": (
+                "cubed_sphere_area_weighted_v1" if is_cubed_sphere else "provisional_rectangular_v1"
+            ),
         }
     )
 
     _log_world_age(context, metadata, seed=seed, config=config)
 
     return {
-        "CrustThickness": crust_handle,
-        "IsostaticOffset": isostasy_handle,
-        "UpliftRate": uplift_handle,
-        "SubsidenceRate": subsidence_handle,
-        "TectonicCompression": compression_handle,
-        "TectonicExtension": extension_handle,
-        "ShearMagnitude": shear_handle,
-        "CoastalExposure": coastal_handle,
-        "LithosphereStiffness": lithosphere_handle,
-        "BaseOceanMask": ocean_mask_handle,
+        **handles,
         "HotspotEvents": events_table,
         "WorldAgeMetadata": metadata,
     }

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -117,6 +117,15 @@ def _register_tectonics_stage() -> str:
     return stage_name
 
 
+def _register_world_age_stage() -> str:
+    stage_name = "world_age"
+    if stage_name in registry():
+        return stage_name
+    from .stages import world_age  # noqa: F401
+
+    return stage_name
+
+
 def run_topology_visualizer(
     topology: str = "sphere",
     *,
@@ -230,7 +239,9 @@ def run_tectonics_visualizer(
 
 def main(args: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Produce pipeline stage visualization PNGs.")
-    parser.add_argument("--stage", choices=["topology", "tectonics"], default="topology")
+    parser.add_argument(
+        "--stage", choices=["topology", "tectonics", "world_age"], default="topology"
+    )
     parser.add_argument("--config", type=Path, default=None)
     parser.add_argument(
         "--topology", default="sphere", choices=["sphere", "cylinder", "torus", "cubed_sphere"]
@@ -280,14 +291,18 @@ def main(args: Iterable[str] | None = None) -> int:
         ]
         if invalid_controls:
             parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
-        stage_name = "geometry" if parsed.stage == "topology" else _register_tectonics_stage()
+        if parsed.stage == "topology":
+            stage_name = "geometry"
+        elif parsed.stage == "tectonics":
+            stage_name = _register_tectonics_stage()
+        else:
+            stage_name = _register_world_age_stage()
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         visuals_dir = config.run_visual_dir() / stage_name
-        print(
-            f"{stage_name.title()} visuals written to {visuals_dir} (elapsed {elapsed_ms:.2f} ms)"
-        )
+        stage_label = stage_name.replace("_", " ").title()
+        print(f"{stage_label} visuals written to {visuals_dir} (elapsed {elapsed_ms:.2f} ms)")
         return 0
 
     invalid_controls = [
@@ -298,6 +313,8 @@ def main(args: Iterable[str] | None = None) -> int:
     if invalid_controls:
         parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
 
+    if parsed.stage == "world_age":
+        parser.error("--stage world_age requires --config")
     if parsed.stage == "topology":
         if parsed.topology == "cubed_sphere":
             from .cubed_sphere import run_cubed_sphere_diagnostic

--- a/tests/test_erosion.py
+++ b/tests/test_erosion.py
@@ -124,3 +124,21 @@ def test_erosion_determinism(tmp_path: Path):
     diag1 = res1.artifact_records["ErosionDiagnostics"].value
     diag2 = res2.artifact_records["ErosionDiagnostics"].value
     assert diag1.equals(diag2)
+
+
+def test_erosion_explicitly_rejects_unmigrated_cubed_sphere(tmp_path: Path):
+    config = PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 8}],
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "run_id": "erosion-cubed-rejection",
+            "stage_overrides": {
+                "tectonics": {"num_plates": 8, "lloyd_iterations": 2},
+            },
+        }
+    )
+    with pytest.raises(NotImplementedError, match="has not migrated to cubed_sphere"):
+        ExecutionEngine(config).run(["erosion"])

--- a/tests/test_world_age.py
+++ b/tests/test_world_age.py
@@ -8,6 +8,9 @@ import pyarrow as pa
 import pytest
 
 from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline._world_age_native import run_cubed_sphere_world_age
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.tools import main as pipeline_tools_main
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +46,80 @@ def _make_config(
     if overrides:
         base["stage_overrides"] = overrides
     return PipelineConfig.from_mapping(base)
+
+
+def _make_cubed_config(
+    tmp_path: Path,
+    run_id: str,
+    *,
+    rng_seed: int = 42,
+    world_age: float = 4.1,
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 32}],
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "run_id": run_id,
+            "rng_seed": rng_seed,
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 16,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 4,
+                },
+                "world_age": {
+                    "world_age": world_age,
+                    "thermal_decay_half_life": 1.8,
+                    "hotspot_scale": 0.9,
+                    "isostasy_factor": 0.6,
+                    "radiogenic_heat_scale": 1.0,
+                },
+            },
+        }
+    )
+
+
+def _cubed_ffi_arguments(face_resolution: int = 4) -> dict[str, object]:
+    grid = CubedSphereGrid.create(face_resolution)
+    shape = grid.face_shape
+    plate = np.zeros((*shape, 7), dtype=np.float32)
+    cell_ids = np.arange(grid.cell_count).reshape(shape)
+    continental = cell_ids % 3 == 0
+    plate[..., 0] = cell_ids
+    plate[..., 1] = continental
+    plate[..., 2] = np.where(continental, 35.0, 7.0)
+    plate[..., 3] = np.where(continental, 2.75, 3.0)
+    inputs = [np.full(shape, 0.1, dtype=np.float32) for _ in range(5)]
+    outputs = [np.empty(shape, dtype=np.float32) for _ in range(10)]
+    return {
+        "seed": 3,
+        "world_age": 4.1,
+        "thermal_decay_half_life": 1.8,
+        "hotspot_scale": 0.9,
+        "isostasy_factor": 0.6,
+        "radiogenic_heat_scale": 1.0,
+        "areas": grid.cell_areas,
+        "neighbors": grid.neighbor_indices,
+        "plate_field": plate,
+        "convergence_field": inputs[0],
+        "divergence_field": inputs[1],
+        "subduction_field": inputs[2],
+        "shear_field": inputs[3],
+        "hotspot_field": inputs[4],
+        "crust_thickness_out": outputs[0],
+        "isostatic_offset_out": outputs[1],
+        "uplift_out": outputs[2],
+        "subsidence_out": outputs[3],
+        "compression_out": outputs[4],
+        "extension_out": outputs[5],
+        "shear_out": outputs[6],
+        "margin_proximity_out": outputs[7],
+        "lithosphere_stiffness_out": outputs[8],
+        "proto_ocean_mask_out": outputs[9],
+    }
 
 
 def test_world_age_outputs_and_metadata(tmp_path: Path):
@@ -249,3 +326,177 @@ def test_world_age_age_dependence(tmp_path: Path):
     metadata_old = old_results["world_age"].artifact_records["WorldAgeMetadata"].value
     assert metadata_old["convective_vigor"] < metadata_young["convective_vigor"]
     assert metadata_old["hotspot_count"] >= metadata_young["hotspot_count"]
+
+
+def test_cubed_sphere_world_age_outputs_close_area_and_cross_faces(tmp_path: Path):
+    config = _make_cubed_config(tmp_path, "cubed-world-age")
+    engine = ExecutionEngine(config, generate_visuals=True)
+    results = engine.run(["world_age"])
+    grid = engine.context.topology
+    assert isinstance(grid, CubedSphereGrid)
+    world_age = results["world_age"]
+    tectonics = results["tectonics"]
+
+    arrays = {
+        name: np.asarray(world_age.artifact_records[name].value.array())
+        for name in (
+            "CrustThickness",
+            "IsostaticOffset",
+            "UpliftRate",
+            "SubsidenceRate",
+            "TectonicCompression",
+            "TectonicExtension",
+            "ShearMagnitude",
+            "CoastalExposure",
+            "LithosphereStiffness",
+            "BaseOceanMask",
+        )
+    }
+    for array in arrays.values():
+        assert array.shape == grid.face_shape
+        assert array.dtype == np.float32
+        assert np.all(np.isfinite(array))
+    assert abs(float(np.sum(arrays["IsostaticOffset"] * grid.cell_areas))) < 1e-5
+    assert np.all((arrays["LithosphereStiffness"] >= 0.0) & (arrays["LithosphereStiffness"] <= 1.0))
+    assert np.all((arrays["CoastalExposure"] >= 0.0) & (arrays["CoastalExposure"] <= 1.0))
+
+    plate = np.asarray(tectonics.artifact_records["PlateField"].value.array())
+    np.testing.assert_array_equal(arrays["BaseOceanMask"], plate[..., 1] < 0.5)
+    flat_ocean = arrays["BaseOceanMask"].reshape(-1) >= 0.5
+    neighbors = grid.neighbor_indices.reshape(-1, 4)
+    source = np.repeat(np.arange(grid.cell_count), 4)
+    target = neighbors.reshape(-1)
+    face_size = grid.face_resolution * grid.face_resolution
+    cross_margin = (
+        (source // face_size != target // face_size)
+        & (flat_ocean[source] != flat_ocean[target])
+        & (source < target)
+    )
+    assert np.any(cross_margin)
+    margin = arrays["CoastalExposure"].reshape(-1)
+    np.testing.assert_allclose(margin[source[cross_margin]], 1.0)
+    np.testing.assert_allclose(margin[target[cross_margin]], 1.0)
+
+    events = world_age.artifact_records["HotspotEvents"].value
+    assert isinstance(events, pa.Table)
+    assert events.column_names == [
+        "global_cell_id",
+        "face",
+        "row",
+        "col",
+        "strength",
+        "plume_factor",
+    ]
+    global_ids = events["global_cell_id"].to_numpy()
+    assert np.all((global_ids >= 0) & (global_ids < grid.cell_count))
+    for global_id, face, row, col in zip(
+        global_ids,
+        events["face"].to_numpy(),
+        events["row"].to_numpy(),
+        events["col"].to_numpy(),
+        strict=True,
+    ):
+        assert grid.decode_index(int(global_id)) == (int(face), int(row), int(col))
+
+    metadata = world_age.artifact_records["WorldAgeMetadata"].value
+    assert metadata["crust_state_model"] == "cubed_sphere_area_weighted_v1"
+    assert metadata["ocean_mask_semantics"] == "oceanic_crust_candidate_not_final_water"
+    assert "water_fraction" not in metadata
+    assert metadata["proto_ocean_area_fraction"] == pytest.approx(
+        float(np.sum(arrays["BaseOceanMask"] * grid.cell_areas) / np.sum(grid.cell_areas))
+    )
+    assert metadata["event_semantics"] == "tectonic_thermal_anomaly_proxy_not_mantle_plume"
+    assert metadata["spatial_scale_basis"] == "approximate_angular_radians"
+    assert abs(metadata["mean_isostatic_offset"]) < 1e-5
+    visuals = config.run_visual_dir() / "world_age"
+    assert (visuals / "isostatic_potential.png").is_file()
+    assert (visuals / "tectonic_rates.png").is_file()
+    assert (visuals / "proto_crust.png").is_file()
+
+
+def test_cubed_sphere_world_age_cools_with_age(tmp_path: Path):
+    young = ExecutionEngine(_make_cubed_config(tmp_path, "cubed-young", world_age=1.0)).run(
+        ["world_age"]
+    )
+    old = ExecutionEngine(_make_cubed_config(tmp_path, "cubed-old", world_age=4.5)).run(
+        ["world_age"]
+    )
+    young_meta = young["world_age"].artifact_records["WorldAgeMetadata"].value
+    old_meta = old["world_age"].artifact_records["WorldAgeMetadata"].value
+    assert old_meta["thermal_decay_factor"] < young_meta["thermal_decay_factor"]
+    assert old_meta["convective_vigor"] < young_meta["convective_vigor"]
+    assert old_meta["hotspot_count"] <= young_meta["hotspot_count"]
+
+    plate = np.asarray(young["tectonics"].artifact_records["PlateField"].value.array())
+    oceanic = plate[..., 1] < 0.5
+    young_crust = np.asarray(young["world_age"].artifact_records["CrustThickness"].value.array())
+    old_crust = np.asarray(old["world_age"].artifact_records["CrustThickness"].value.array())
+    assert float(np.mean(old_crust[oceanic])) < float(np.mean(young_crust[oceanic]))
+    young_stiffness = np.asarray(
+        young["world_age"].artifact_records["LithosphereStiffness"].value.array()
+    )
+    old_stiffness = np.asarray(
+        old["world_age"].artifact_records["LithosphereStiffness"].value.array()
+    )
+    assert float(np.mean(old_stiffness)) > float(np.mean(young_stiffness))
+
+
+def test_cubed_sphere_world_age_ffi_rejects_overlap_alignment_and_shape():
+    arguments = _cubed_ffi_arguments()
+    arguments["isostatic_offset_out"] = arguments["crust_thickness_out"]
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_cubed_sphere_world_age(**arguments)
+
+    arguments = _cubed_ffi_arguments()
+    shape = arguments["crust_thickness_out"].shape
+    raw = bytearray(int(np.prod(shape)) * np.dtype(np.float32).itemsize + 1)
+    arguments["crust_thickness_out"] = np.frombuffer(raw, dtype=np.float32, offset=1).reshape(shape)
+    with pytest.raises(ValueError, match="must be aligned"):
+        run_cubed_sphere_world_age(**arguments)
+
+    arguments = _cubed_ffi_arguments()
+    arguments["hotspot_field"] = np.empty((6, 4, 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="must have shape"):
+        run_cubed_sphere_world_age(**arguments)
+
+
+def test_cubed_sphere_hotspot_count_is_resolution_independent():
+    low_events, low_metadata = run_cubed_sphere_world_age(**_cubed_ffi_arguments(4))
+    high_events, high_metadata = run_cubed_sphere_world_age(**_cubed_ffi_arguments(8))
+
+    assert low_events.num_rows == high_events.num_rows
+    assert low_metadata["hotspot_count"] == high_metadata["hotspot_count"]
+
+
+def test_cubed_sphere_world_age_cli_requires_and_runs_config(tmp_path: Path):
+    with pytest.raises(SystemExit) as error:
+        pipeline_tools_main(["--stage", "world_age"])
+    assert error.value.code == 2
+
+    config_path = tmp_path / "world-age.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "topology: cubed_sphere",
+                "resolutions:",
+                "  - face_resolution: 8",
+                f"output_dir: {tmp_path / 'out'}",
+                f"cache_dir: {tmp_path / 'cache'}",
+                f"log_dir: {tmp_path / 'logs'}",
+                "run_id: world-age-cli",
+                "rng_seed: 19",
+                "stage_overrides:",
+                "  tectonics:",
+                "    num_plates: 8",
+                "    lloyd_iterations: 2",
+                "  world_age:",
+                "    world_age: 4.1",
+            ]
+        ),
+        encoding="utf8",
+    )
+    assert pipeline_tools_main(["--stage", "world_age", "--config", str(config_path)]) == 0
+    visual_dir = tmp_path / "out" / "world-age-cli" / "visuals" / "world_age"
+    assert (visual_dir / "isostatic_potential.png").is_file()
+    assert (visual_dir / "tectonic_rates.png").is_file()
+    assert (visual_dir / "proto_crust.png").is_file()


### PR DESCRIPTION
## What changed

- add a canonical Rust cubed-sphere world-age/crust-state kernel using exact spherical areas and global D4 neighbors
- persist age-conditioned crust, isostasy, tectonic-rate, stiffness, margin, proto-ocean, and thermal-anomaly event artifacts
- add safe CFFI contracts, stage visualization, CLI/config support, and explicit rejection at the unmigrated erosion boundary
- correct the world-age specification so it distinguishes crust state from geological history, oceanic crust from water, and tectonic thermal anomalies from modeled mantle plumes
- fix legacy event ownership while preserving the rectangular compatibility path

## Why

The canonical pipeline previously stopped after tectonics. This milestone provides a deterministic, seam-aware, area-weighted crust-state endpoint that can feed the future elevation and geological-history work without flattening cube faces or implying an already-solved ocean/coastline.

## Review follow-up

An independent review identified and this branch fixes half-life math, resolution-dependent spatial widths, overclaimed plume semantics, misleading water-fraction metadata, and stale README guidance.

## Validation

- `uv run pytest -q` (`75 passed`)
- `cargo test --workspace --locked` (`24 passed`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `uv run ruff check src tests`
- scoped Black and `cargo fmt --check`
- `uv run map-maker validate --config configs/validation.yaml` (`6 worlds passed`)
- canonical 128-per-face visual inspection
