### PR TITLE
Initialize canonical geological provinces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,10 @@ name = "erosion_native"
 version = "0.1.0"
 
 [[package]]
+name = "geology_native"
+version = "0.1.0"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "src/map_maker/pipeline/native/erosion",
+    "src/map_maker/pipeline/native/geology",
     "src/map_maker/pipeline/native/tectonics",
     "src/map_maker/pipeline/native/topology",
     "src/map_maker/pipeline/native/world_age",

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -18,16 +18,24 @@
 3. Outputs are persisted to a dataset directory (rasters, graphs, metadata) and a run log with timing/memory stats is written.
 4. A thin compatibility layer continues to expose the legacy generator for existing consumers.
 
-## Stage Ordering
-1. Geometry Topology
-2. Ocean Fraction / Sea-Level Initialization
-3. Tectonics (plates, velocities, boundaries)
-4. World Age & Thermal Adjustments
-5. Erosion & Sedimentation
-6. Current Elevation Map
-7. Atmospheric & Hydrology
-8. Soil Types & Biomes
-9. Societies, Settlements & Trade
+## Canonical Stage Ordering
+1. Geometry and cubed-sphere topology.
+2. Kinematic tectonic skeleton.
+3. Age-conditioned crust state.
+4. Connected geological provinces and boundary segments.
+5. Initial elevation and tectonic morphology.
+6. Climate pass 1.
+7. Hydrology pass 1.
+8. Erosion and sedimentation.
+9. Hydrology pass 2.
+10. Soils and biomes.
+11. Mineral and energy systems.
+12. Selected-region refinement and map export.
+
+The current canonical cubed-sphere implementation reaches stage 4. The older
+rectangular compatibility path runs directly from world age into provisional
+erosion and final rendering; it is reference behavior, not the canonical stage
+order.
 
 Legacy pipeline remains callable through `map_maker.legacy.*` but does not participate in this DAG.
 

--- a/docs/specs/02_topology.md
+++ b/docs/specs/02_topology.md
@@ -131,8 +131,8 @@ The cube net is a topology diagnostic, not an atlas projection.
 
 ## Migration Boundary
 
-The current tectonics, world-age, and erosion kernels still consume a
-provisional two-dimensional grid. They must not be switched to cubed sphere by
-flattening the six faces, because that would create false adjacency between face
-rows. Migration requires those kernels to consume global IDs and topology-owned
-neighbor tables or face-aware halo buffers.
+The canonical tectonics, world-age, and geology kernels consume global IDs,
+exact spherical areas, and topology-owned D4 neighbors. Erosion remains on the
+provisional two-dimensional grid and explicitly rejects cubed-sphere input. It
+must not be migrated by flattening the six faces, because that would create
+false adjacency between face rows.

--- a/docs/specs/05a_geological_provinces.md
+++ b/docs/specs/05a_geological_provinces.md
@@ -1,0 +1,136 @@
+# Stage 4B: Geological Province Initialization
+
+## Status and purpose
+
+This stage converts the canonical kinematic plate snapshot and age-conditioned
+crust state into persistent, connected geological process objects. It exists so
+initial elevation does not infer terrain directly from plate IDs or from a
+binary continental/oceanic mask.
+
+Hard downstream rule: province class is not an elevation lookup. Initial
+elevation must combine crustal buoyancy, boundary/event morphology, province
+state, roughness distributions, and later loading/erosion. A shield is not a
+plateau, and an orogen is not a fixed-width raised stripe.
+
+V1 is an initializer, not the event-driven geological history approved in
+Decision 009. Its outputs state current structural evidence and confidence.
+Later history sweeps may replace classifications while retaining the artifact
+and catalog contracts.
+
+The stage currently requires the cubed sphere. The rectangular erosion stack
+does not consume these artifacts.
+
+## Inputs
+
+- Exact spherical cell areas and global D4 neighbor IDs.
+- `PlateField`, subduction potential, and tectonic thermal-anomaly potential.
+- Isostatic potential, uplift, subsidence, compression, extension, shear,
+  continental-margin proximity, lithosphere stiffness, and proto-oceanic crust.
+- Planet age from `WorldAgeMetadata`.
+
+## Province model
+
+Every cell receives one evidence class:
+
+- Shield.
+- Stable platform.
+- Sedimentary basin.
+- Orogen.
+- Continental rift.
+- Continental arc.
+- Shelf or passive margin.
+- Abyssal basin.
+- Oceanic ridge.
+- Intra-oceanic arc.
+- Volcanic province (reserved; not emitted by this initializer).
+
+Class evidence is ordered so active tectonic settings take precedence over
+stable interiors. Sedimentary basins require tectonically quiet accommodation;
+low-amplitude boundary subsidence is not promoted to a basin. The volcanic
+province code is reserved because the current noisy thermal-anomaly proxy cannot
+support a coherent province object or establish a modeled mantle plume.
+
+After evidence classification, components below a class-specific physical
+spherical-area threshold merge into the longest adjacent same-crust class.
+This suppresses resolution-scale threshold fragments without deleting resolved
+linear rifts, ridges, shelves, arcs, or orogens. An undersized component with no
+same-crust neighbor is an isolated crust domain, such as a coarse island; it is
+preserved under Decision 011 and its confidence is capped at `0.5` rather than
+being merged across the land/ocean boundary.
+
+Global D4 connected-component labeling assigns stable dense province IDs. A
+province catalog records class, cell count, exact spherical area, parent plate
+when unambiguous, area-weighted crust age, rock strength, sediment
+accommodation, and confidence. Provinces may cross plates; plates and geological
+provinces are deliberately different object systems.
+
+## Boundary segments
+
+Every undirected D4 edge whose endpoints belong to different plates receives a
+deterministic unordered plate pair and one current kinematic regime:
+
+- Inactive boundary.
+- Continental collision.
+- Subduction margin.
+- Intra-oceanic subduction.
+- Continental rift.
+- Spreading ridge.
+- Transform.
+
+Each physical edge is classified once from endpoint-averaged evidence, then
+written identically to both reciprocal directed edge slots. Confidence-weighted
+along-boundary smoothing and a minimum angular segment length suppress
+one-edge regime flips. Edges with the same plate pair and regime are labeled
+into globally connected segments using face-crossing D4 boundary adjacency.
+The segment catalog stores the plate pair, regime, edge count, approximate
+angular length, mean process evidence, and confidence. The current area-derived
+length is diagnostic, not a survey-grade boundary polyline.
+
+## Dense outputs
+
+- `GeologicalProvinceID` (`int32`).
+- `GeologicalProvinceClass` (`uint8`).
+- `CrustAgeGa` (`float32`).
+- `RockStrength` (`float32`, `[0, 1]`).
+- `SedimentAccommodation` (`float32`, `[0, 1]`).
+- `ProvinceConfidence` (`float32`, `[0, 1]`).
+- `BoundarySegmentID` (`int32`, shape `(6, n, n, 4)`, `-1` on nonboundary
+  directed D4 edge slots).
+- `BoundaryRegime` (`uint8`, shape `(6, n, n, 4)`, zero on nonboundary slots).
+- `BoundaryConfidence` (`float32`, shape `(6, n, n, 4)`, zero on nonboundary
+  slots).
+
+## Catalog and metadata outputs
+
+- `GeologicalProvinceCatalog` (Arrow).
+- `BoundarySegmentCatalog` (Arrow).
+- `GeologyMetadata` (JSON), including explicit
+  `initialization_not_simulated_deep_time` history semantics.
+
+## Hard acceptance
+
+- Every raster province ID maps to exactly one catalog row and one globally D4
+  connected component.
+- Every nonnegative boundary edge slot has an identical reciprocal slot. Every
+  segment ID maps to one catalog row and one globally connected boundary
+  component with a stable unordered plate pair and regime.
+- Province cell counts equal the planet cell count and province areas sum to
+  `4*pi` within floating-point tolerance.
+- Oceanic crust age remains at or below 250 Ma in this Earth-like initializer;
+  continental mean crust age exceeds oceanic mean crust age.
+- IDs and catalogs are deterministic for identical dependency artifacts.
+- Classes, strengths, accommodation, and confidence remain in declared ranges.
+- Truth renders expose province class, boundary regime, and crust age on a cube
+  net without flattening or face-local wrap assumptions.
+
+## Known limitations
+
+- No terrane ledger, stratigraphic packages, basin fill history, sutures,
+  inherited structures, or explicit event chronology exists yet.
+- Crust age is an evidence-conditioned prior, not an integrated age-of-formation
+  solution. Oceanic age does not yet derive from tracked ridge production and
+  subduction consumption.
+- The D4 edge graph preserves every raster-resolved incident plate pair at
+  triple junctions, but exact subcell vector geometry remains deferred.
+- Process thresholds are provisional and require deterministic Earth-analog
+  scenarios before calibration.

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,8 @@ The native build is explicit. Importing `map_maker` never invokes Cargo or a
 C++ compiler. To load native libraries built elsewhere, set
 `MAP_MAKER_NATIVE_LIB_DIR` to their containing directory.
 
-Every native library currently exposes ABI version `2`. `map-maker doctor` verifies that
-ABI and reports the binary SHA-256 fingerprint. Simulation-library fingerprints
+Every native library currently exposes ABI version `2`. `map-maker doctor`
+verifies that ABI and reports the binary SHA-256 fingerprint. Simulation-library fingerprints
 are included in stage cache keys and run manifests, so replacing a native binary
 cannot silently reuse outputs from different code.
 
@@ -69,10 +69,12 @@ uv run map-maker generate --width 1024 --height 512 --seed 8675309
 
 Rerunning the same configuration reuses the stage cache. The current executable
 stack includes tectonics, crust/world-age fields, erosion/sedimentation, dataset
-persistence, diagnostics, and final cartography. Cubed-sphere topology,
-geological event history, routed hydrology, climate, soils, biomes, and regional
-refinement remain implementation milestones; the current output is a functional
-prototype rather than an atlas-grade world.
+persistence, diagnostics, and final cartography. The canonical cubed-sphere path
+now reaches connected geological province and boundary-segment initialization.
+Explicit geological event history, spherical elevation/erosion, routed
+hydrology, climate, soils, biomes, and regional refinement remain implementation
+milestones; the current output is a functional prototype rather than an
+atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -93,9 +95,10 @@ uv run map-maker topology --face-resolution 96 --output-dir out/topology
 ```
 
 This writes a globally continuous XYZ-colored cube net and a geometry report.
-The canonical tectonic snapshot and age-conditioned crust state now run directly
-on cubed-sphere neighbor IDs. Erosion remains on the provisional two-dimensional
-path and explicitly rejects six-face fields.
+The canonical tectonic snapshot, age-conditioned crust state, and connected
+geological provinces now run directly on cubed-sphere neighbor IDs. Erosion
+remains on the provisional two-dimensional path and explicitly rejects six-face
+fields.
 
 Run the previous procedural generator for comparison:
 
@@ -113,6 +116,9 @@ uv run map-maker-pipeline --stage tectonics --config configs/cubed_sphere_tecton
 
 # Canonical age-conditioned crust state
 uv run map-maker-pipeline --stage world_age --config configs/cubed_sphere_crust_state.yaml
+
+# Canonical connected geological provinces and boundary segments
+uv run map-maker-pipeline --stage geology --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -7,11 +7,12 @@ import hashlib
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
 SIMULATION_NATIVE_LIBRARIES = (
     "erosion_native",
+    "geology_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",
@@ -120,9 +121,12 @@ def native_library_info(name: str) -> dict[str, Any]:
     return _native_library_info_cached(name, str(path), stat.st_size, stat.st_mtime_ns)
 
 
-def simulation_native_fingerprints() -> dict[str, dict[str, Any]]:
+def simulation_native_fingerprints(
+    names: Iterable[str] | None = None,
+) -> dict[str, dict[str, Any]]:
     fingerprints: dict[str, dict[str, Any]] = {}
-    for name in sorted(SIMULATION_NATIVE_LIBRARIES):
+    selected = SIMULATION_NATIVE_LIBRARIES if names is None else tuple(names)
+    for name in sorted(selected):
         info = native_library_info(name)
         fingerprints[name] = {
             "abi_version": info["abi_version"],

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -10,6 +10,7 @@ from ._native import library_filename, workspace_root
 
 NATIVE_LIBRARIES = (
     "erosion_native",
+    "geology_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/pipeline/_geology_native.py
+++ b/src/map_maker/pipeline/_geology_native.py
@@ -1,0 +1,420 @@
+"""Rust-backed bindings for geological province initialization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+from cffi import FFI
+
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+CUBED_SPHERE_GEOLOGY_ABI_VERSION = 1
+
+PROVINCE_CLASSES = {
+    1: "shield",
+    2: "stable_platform",
+    3: "sedimentary_basin",
+    4: "orogen",
+    5: "continental_rift",
+    6: "continental_arc",
+    7: "shelf_or_passive_margin",
+    8: "abyssal_basin",
+    9: "oceanic_ridge",
+    10: "intra_oceanic_arc",
+    11: "volcanic_province",
+}
+
+BOUNDARY_REGIMES = {
+    1: "inactive_boundary",
+    2: "continental_collision",
+    3: "subduction_margin",
+    4: "intra_oceanic_subduction",
+    5: "continental_rift",
+    6: "spreading_ridge",
+    7: "transform",
+}
+
+PROVINCE_RECORD_DTYPE = np.dtype(
+    [
+        ("province_id", "<i4"),
+        ("class_code", "<i4"),
+        ("parent_plate_id", "<i4"),
+        ("cell_count", "<i4"),
+        ("area_steradians", "<f8"),
+        ("mean_crust_age_ga", "<f4"),
+        ("mean_rock_strength", "<f4"),
+        ("mean_accommodation", "<f4"),
+        ("mean_confidence", "<f4"),
+    ],
+    align=True,
+)
+
+BOUNDARY_RECORD_DTYPE = np.dtype(
+    [
+        ("segment_id", "<i4"),
+        ("regime_code", "<i4"),
+        ("plate_a", "<i4"),
+        ("plate_b", "<i4"),
+        ("edge_count", "<i4"),
+        ("angular_length", "<f8"),
+        ("mean_compression", "<f4"),
+        ("mean_extension", "<f4"),
+        ("mean_shear", "<f4"),
+        ("mean_subduction", "<f4"),
+        ("mean_confidence", "<f4"),
+    ],
+    align=True,
+)
+
+_CDEF = """
+typedef struct {
+    int32_t province_id;
+    int32_t class_code;
+    int32_t parent_plate_id;
+    int32_t cell_count;
+    double area_steradians;
+    float mean_crust_age_ga;
+    float mean_rock_strength;
+    float mean_accommodation;
+    float mean_confidence;
+} ProvinceRecord;
+typedef struct { ProvinceRecord* data; size_t len; } ProvinceRecordArray;
+
+typedef struct {
+    int32_t segment_id;
+    int32_t regime_code;
+    int32_t plate_a;
+    int32_t plate_b;
+    int32_t edge_count;
+    double angular_length;
+    float mean_compression;
+    float mean_extension;
+    float mean_shear;
+    float mean_subduction;
+    float mean_confidence;
+} BoundarySegmentRecord;
+typedef struct { BoundarySegmentRecord* data; size_t len; } BoundarySegmentRecordArray;
+
+typedef struct {
+    int32_t province_count;
+    int32_t boundary_segment_count;
+    int32_t active_boundary_segment_count;
+    int32_t mixed_plate_province_count;
+    double continental_area;
+    double oceanic_area;
+    float mean_crust_age_ga;
+    float mean_confidence;
+} GeologyStats;
+
+uint32_t cubed_sphere_geology_abi_version(void);
+int32_t geology_run_cubed_sphere(
+    int32_t cell_count,
+    float world_age_ga,
+    int32_t plate_components,
+    const double* area,
+    const int32_t* neighbors,
+    const float* plate_field,
+    const float* subduction,
+    const float* isostasy,
+    const float* uplift,
+    const float* subsidence,
+    const float* compression,
+    const float* extension,
+    const float* shear,
+    const float* margin,
+    const float* stiffness,
+    const float* proto_ocean,
+    int32_t* province_id_out,
+    uint8_t* province_class_out,
+    float* crust_age_out,
+    float* rock_strength_out,
+    float* accommodation_out,
+    float* province_confidence_out,
+    int32_t* boundary_segment_id_out,
+    uint8_t* boundary_regime_out,
+    float* boundary_confidence_out,
+    ProvinceRecordArray* provinces_out,
+    BoundarySegmentRecordArray* segments_out,
+    GeologyStats* stats_out
+);
+void geology_free_provinces(ProvinceRecordArray array);
+void geology_free_boundary_segments(BoundarySegmentRecordArray array);
+"""
+
+
+def _read_float32(array: np.ndarray, *, name: str) -> np.ndarray:
+    value = np.array(array, copy=False)
+    if value.dtype != np.float32:
+        raise ValueError(f"{name} must be float32, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    return value
+
+
+def _write_array(array: np.ndarray, *, name: str, dtype: np.dtype) -> np.ndarray:
+    value = np.array(array, copy=False)
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must be {dtype}, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    if not value.flags.writeable:
+        raise ValueError(f"{name} must be writable")
+    return value
+
+
+def _require_disjoint(buffers: dict[str, np.ndarray]) -> None:
+    entries = list(buffers.items())
+    for index, (first_name, first) in enumerate(entries):
+        for second_name, second in entries[index + 1 :]:
+            if np.shares_memory(first, second):
+                raise ValueError(f"{first_name} and {second_name} buffers must not overlap")
+
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+native_library_info("geology_native")
+_lib = _ffi.dlopen(str(native_library_path("geology_native")))
+try:
+    _cubed_sphere_abi = int(_lib.cubed_sphere_geology_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "geology_native lacks the cubed-sphere API; rebuild native libraries"
+    ) from exc
+if _cubed_sphere_abi != CUBED_SPHERE_GEOLOGY_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "geology_native cubed-sphere ABI "
+        f"{_cubed_sphere_abi} does not match expected {CUBED_SPHERE_GEOLOGY_ABI_VERSION}"
+    )
+
+
+def _copy_records(record_array: Any, *, dtype: np.dtype, free) -> np.ndarray:
+    length = int(record_array.len)
+    if length <= 0 or int(_ffi.cast("uintptr_t", record_array.data)) == 0:
+        free(record_array)
+        return np.empty(0, dtype=dtype)
+    try:
+        buffer = _ffi.buffer(record_array.data, length * dtype.itemsize)
+        return np.frombuffer(buffer, dtype=dtype, count=length).copy()
+    finally:
+        free(record_array)
+
+
+def _province_table(records: np.ndarray) -> pa.Table:
+    class_codes = records["class_code"]
+    return pa.table(
+        {
+            "province_id": pa.array(records["province_id"], type=pa.int32()),
+            "class_code": pa.array(class_codes, type=pa.int32()),
+            "class_name": pa.array(
+                [PROVINCE_CLASSES.get(int(code), "unknown") for code in class_codes],
+                type=pa.string(),
+            ),
+            "parent_plate_id": pa.array(records["parent_plate_id"], type=pa.int32()),
+            "cell_count": pa.array(records["cell_count"], type=pa.int32()),
+            "area_steradians": pa.array(records["area_steradians"], type=pa.float64()),
+            "mean_crust_age_ga": pa.array(records["mean_crust_age_ga"], type=pa.float32()),
+            "mean_rock_strength": pa.array(records["mean_rock_strength"], type=pa.float32()),
+            "mean_accommodation": pa.array(records["mean_accommodation"], type=pa.float32()),
+            "mean_confidence": pa.array(records["mean_confidence"], type=pa.float32()),
+        }
+    )
+
+
+def _boundary_table(records: np.ndarray) -> pa.Table:
+    regime_codes = records["regime_code"]
+    return pa.table(
+        {
+            "segment_id": pa.array(records["segment_id"], type=pa.int32()),
+            "regime_code": pa.array(regime_codes, type=pa.int32()),
+            "regime_name": pa.array(
+                [BOUNDARY_REGIMES.get(int(code), "unknown") for code in regime_codes],
+                type=pa.string(),
+            ),
+            "plate_a": pa.array(records["plate_a"], type=pa.int32()),
+            "plate_b": pa.array(records["plate_b"], type=pa.int32()),
+            "edge_count": pa.array(records["edge_count"], type=pa.int32()),
+            "angular_length": pa.array(records["angular_length"], type=pa.float64()),
+            "mean_compression": pa.array(records["mean_compression"], type=pa.float32()),
+            "mean_extension": pa.array(records["mean_extension"], type=pa.float32()),
+            "mean_shear": pa.array(records["mean_shear"], type=pa.float32()),
+            "mean_subduction": pa.array(records["mean_subduction"], type=pa.float32()),
+            "mean_confidence": pa.array(records["mean_confidence"], type=pa.float32()),
+        }
+    )
+
+
+def run_cubed_sphere_geology(
+    *,
+    world_age_ga: float,
+    areas: np.ndarray,
+    neighbors: np.ndarray,
+    plate_field: np.ndarray,
+    subduction: np.ndarray,
+    isostasy: np.ndarray,
+    uplift: np.ndarray,
+    subsidence: np.ndarray,
+    compression: np.ndarray,
+    extension: np.ndarray,
+    shear: np.ndarray,
+    margin: np.ndarray,
+    stiffness: np.ndarray,
+    proto_ocean: np.ndarray,
+    province_id_out: np.ndarray,
+    province_class_out: np.ndarray,
+    crust_age_out: np.ndarray,
+    rock_strength_out: np.ndarray,
+    accommodation_out: np.ndarray,
+    province_confidence_out: np.ndarray,
+    boundary_segment_id_out: np.ndarray,
+    boundary_regime_out: np.ndarray,
+    boundary_confidence_out: np.ndarray,
+) -> tuple[pa.Table, pa.Table, dict[str, Any]]:
+    area_array = np.require(areas, dtype=np.float64, requirements=["C", "A"])
+    neighbor_array = np.require(neighbors, dtype=np.int32, requirements=["C", "A"])
+    if (
+        area_array.ndim != 3
+        or area_array.shape[0] != 6
+        or area_array.shape[1] != area_array.shape[2]
+    ):
+        raise ValueError("areas must have shape (6, n, n)")
+    shape = area_array.shape
+    if neighbor_array.shape != (*shape, 4):
+        raise ValueError(f"neighbors must have shape {(*shape, 4)}")
+    plate_array = _read_float32(plate_field, name="plate_field")
+    if plate_array.ndim != 4 or plate_array.shape[:3] != shape or plate_array.shape[3] < 7:
+        raise ValueError(f"plate_field must have shape {(*shape, 7)} or more components")
+
+    inputs = {
+        name: _read_float32(array, name=name)
+        for name, array in {
+            "subduction": subduction,
+            "isostasy": isostasy,
+            "uplift": uplift,
+            "subsidence": subsidence,
+            "compression": compression,
+            "extension": extension,
+            "shear": shear,
+            "margin": margin,
+            "stiffness": stiffness,
+            "proto_ocean": proto_ocean,
+        }.items()
+    }
+    outputs = {
+        "province_id_out": _write_array(
+            province_id_out, name="province_id_out", dtype=np.dtype(np.int32)
+        ),
+        "province_class_out": _write_array(
+            province_class_out, name="province_class_out", dtype=np.dtype(np.uint8)
+        ),
+        "crust_age_out": _write_array(
+            crust_age_out, name="crust_age_out", dtype=np.dtype(np.float32)
+        ),
+        "rock_strength_out": _write_array(
+            rock_strength_out, name="rock_strength_out", dtype=np.dtype(np.float32)
+        ),
+        "accommodation_out": _write_array(
+            accommodation_out, name="accommodation_out", dtype=np.dtype(np.float32)
+        ),
+        "province_confidence_out": _write_array(
+            province_confidence_out,
+            name="province_confidence_out",
+            dtype=np.dtype(np.float32),
+        ),
+        "boundary_segment_id_out": _write_array(
+            boundary_segment_id_out,
+            name="boundary_segment_id_out",
+            dtype=np.dtype(np.int32),
+        ),
+        "boundary_regime_out": _write_array(
+            boundary_regime_out, name="boundary_regime_out", dtype=np.dtype(np.uint8)
+        ),
+        "boundary_confidence_out": _write_array(
+            boundary_confidence_out,
+            name="boundary_confidence_out",
+            dtype=np.dtype(np.float32),
+        ),
+    }
+    for name, array in inputs.items():
+        if array.shape != shape:
+            raise ValueError(f"{name} must have shape {shape}")
+    edge_shape = (*shape, 4)
+    for name, array in outputs.items():
+        expected_shape = edge_shape if name.startswith("boundary_") else shape
+        if array.shape != expected_shape:
+            raise ValueError(f"{name} must have shape {expected_shape}")
+    _require_disjoint(
+        {
+            "areas": area_array,
+            "neighbors": neighbor_array,
+            "plate_field": plate_array,
+            **inputs,
+            **outputs,
+        }
+    )
+
+    provinces_ptr = _ffi.new("ProvinceRecordArray*")
+    segments_ptr = _ffi.new("BoundarySegmentRecordArray*")
+    stats_ptr = _ffi.new("GeologyStats*")
+    result = _lib.geology_run_cubed_sphere(
+        int(np.prod(shape, dtype=np.int64)),
+        float(world_age_ga),
+        int(plate_array.shape[3]),
+        _ffi.cast("const double*", _ffi.from_buffer("double[]", area_array)),
+        _ffi.cast("const int32_t*", _ffi.from_buffer("int32_t[]", neighbor_array)),
+        _ffi.cast("const float*", _ffi.from_buffer("float[]", plate_array, require_writable=False)),
+        *[
+            _ffi.cast("const float*", _ffi.from_buffer("float[]", array, require_writable=False))
+            for array in inputs.values()
+        ],
+        _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", outputs["province_id_out"])),
+        _ffi.cast("uint8_t*", _ffi.from_buffer("uint8_t[]", outputs["province_class_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", outputs["crust_age_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", outputs["rock_strength_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", outputs["accommodation_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", outputs["province_confidence_out"])),
+        _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", outputs["boundary_segment_id_out"])),
+        _ffi.cast("uint8_t*", _ffi.from_buffer("uint8_t[]", outputs["boundary_regime_out"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", outputs["boundary_confidence_out"])),
+        provinces_ptr,
+        segments_ptr,
+        stats_ptr,
+    )
+    if result != 0:
+        raise RuntimeError(f"geology_run_cubed_sphere failed with code {result}")
+
+    province_records = _copy_records(
+        provinces_ptr[0], dtype=PROVINCE_RECORD_DTYPE, free=_lib.geology_free_provinces
+    )
+    segment_records = _copy_records(
+        segments_ptr[0], dtype=BOUNDARY_RECORD_DTYPE, free=_lib.geology_free_boundary_segments
+    )
+    stats = stats_ptr[0]
+    metadata = {
+        "province_count": int(stats.province_count),
+        "boundary_segment_count": int(stats.boundary_segment_count),
+        "active_boundary_segment_count": int(stats.active_boundary_segment_count),
+        "mixed_plate_province_count": int(stats.mixed_plate_province_count),
+        "continental_area_steradians": float(stats.continental_area),
+        "oceanic_area_steradians": float(stats.oceanic_area),
+        "mean_crust_age_ga": float(stats.mean_crust_age_ga),
+        "mean_confidence": float(stats.mean_confidence),
+        "province_model": "current_process_evidence_v1",
+        "history_semantics": "initialization_not_simulated_deep_time",
+        "boundary_length_semantics": "edge_center_spacing_from_area_approximation",
+        "boundary_storage": "reciprocal_directed_d4_edge_slots",
+    }
+    return _province_table(province_records), _boundary_table(segment_records), metadata
+
+
+__all__ = [
+    "BOUNDARY_REGIMES",
+    "CUBED_SPHERE_GEOLOGY_ABI_VERSION",
+    "PROVINCE_CLASSES",
+    "run_cubed_sphere_geology",
+]

--- a/src/map_maker/pipeline/execution.py
+++ b/src/map_maker/pipeline/execution.py
@@ -171,7 +171,7 @@ class ExecutionEngine:
             "stage": descriptor.name,
             "version": descriptor.version,
             "rng_seed": self._context.config.rng_seed,
-            "native_libraries": simulation_native_fingerprints(),
+            "native_libraries": simulation_native_fingerprints(descriptor.native_libraries),
             "config": _serialize_for_hash(stage_config),
             "topology": {
                 "type": self._context.config.topology,

--- a/src/map_maker/pipeline/native/geology/Cargo.toml
+++ b/src/map_maker/pipeline/native/geology/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "geology_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "geology_native"
+crate-type = ["cdylib"]

--- a/src/map_maker/pipeline/native/geology/src/lib.rs
+++ b/src/map_maker/pipeline/native/geology/src/lib.rs
@@ -1,0 +1,993 @@
+use std::collections::VecDeque;
+use std::mem;
+use std::slice;
+
+const PLATE_COMPONENTS: usize = 7;
+const D4_NEIGHBORS: usize = 4;
+
+const PROVINCE_SHIELD: u8 = 1;
+const PROVINCE_PLATFORM: u8 = 2;
+const PROVINCE_SEDIMENTARY_BASIN: u8 = 3;
+const PROVINCE_OROGEN: u8 = 4;
+const PROVINCE_CONTINENTAL_RIFT: u8 = 5;
+const PROVINCE_CONTINENTAL_ARC: u8 = 6;
+const PROVINCE_SHELF: u8 = 7;
+const PROVINCE_ABYSSAL_BASIN: u8 = 8;
+const PROVINCE_OCEANIC_RIDGE: u8 = 9;
+const PROVINCE_INTRA_OCEANIC_ARC: u8 = 10;
+const PROVINCE_VOLCANIC: u8 = 11;
+
+const REGIME_INACTIVE: u8 = 1;
+const REGIME_CONTINENTAL_COLLISION: u8 = 2;
+const REGIME_SUBDUCTION_MARGIN: u8 = 3;
+const REGIME_INTRA_OCEANIC_SUBDUCTION: u8 = 4;
+const REGIME_CONTINENTAL_RIFT: u8 = 5;
+const REGIME_SPREADING_RIDGE: u8 = 6;
+const REGIME_TRANSFORM: u8 = 7;
+
+#[no_mangle]
+pub extern "C" fn geology_native_abi_version() -> u32 {
+    2
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_geology_abi_version() -> u32 {
+    1
+}
+
+#[repr(C)]
+pub struct ProvinceRecord {
+    pub province_id: i32,
+    pub class_code: i32,
+    pub parent_plate_id: i32,
+    pub cell_count: i32,
+    pub area_steradians: f64,
+    pub mean_crust_age_ga: f32,
+    pub mean_rock_strength: f32,
+    pub mean_accommodation: f32,
+    pub mean_confidence: f32,
+}
+
+#[repr(C)]
+pub struct ProvinceRecordArray {
+    pub data: *mut ProvinceRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct BoundarySegmentRecord {
+    pub segment_id: i32,
+    pub regime_code: i32,
+    pub plate_a: i32,
+    pub plate_b: i32,
+    pub edge_count: i32,
+    pub angular_length: f64,
+    pub mean_compression: f32,
+    pub mean_extension: f32,
+    pub mean_shear: f32,
+    pub mean_subduction: f32,
+    pub mean_confidence: f32,
+}
+
+struct BoundaryEdge {
+    source: usize,
+    target: usize,
+    source_slot: usize,
+    target_slot: usize,
+    plate_a: i32,
+    plate_b: i32,
+    regime: u8,
+    confidence: f32,
+    compression: f32,
+    extension: f32,
+    shear: f32,
+    subduction: f32,
+}
+
+fn adjacent_boundary_edges(
+    edge_index: usize,
+    edges: &[BoundaryEdge],
+    edge_by_slot: &[i32],
+    neighbors: &[i32],
+) -> Vec<usize> {
+    let edge = &edges[edge_index];
+    let mut adjacent_edges = Vec::new();
+    for cell in [edge.source, edge.target] {
+        let mut nearby_cells = [0usize; 5];
+        nearby_cells[0] = cell;
+        for (offset, neighbor) in neighbors[cell * 4..cell * 4 + 4].iter().enumerate() {
+            nearby_cells[offset + 1] = *neighbor as usize;
+        }
+        for nearby in nearby_cells {
+            for adjacent_index in &edge_by_slot[nearby * 4..nearby * 4 + 4] {
+                if *adjacent_index < 0 {
+                    continue;
+                }
+                let adjacent_index = *adjacent_index as usize;
+                if adjacent_index != edge_index && !adjacent_edges.contains(&adjacent_index) {
+                    adjacent_edges.push(adjacent_index);
+                }
+            }
+        }
+    }
+    adjacent_edges
+}
+
+fn smooth_boundary_regimes(edges: &mut [BoundaryEdge], edge_by_slot: &[i32], neighbors: &[i32]) {
+    for _ in 0..4 {
+        let mut updates = Vec::with_capacity(edges.len());
+        for (edge_index, edge) in edges.iter().enumerate() {
+            let mut scores = [0.0f32; 8];
+            scores[edge.regime as usize] = edge.confidence * 1.25;
+            for adjacent_index in
+                adjacent_boundary_edges(edge_index, edges, edge_by_slot, neighbors)
+            {
+                let adjacent = &edges[adjacent_index];
+                if adjacent.plate_a == edge.plate_a && adjacent.plate_b == edge.plate_b {
+                    scores[adjacent.regime as usize] += adjacent.confidence;
+                }
+            }
+            let mut selected = edge.regime;
+            let mut selected_score = scores[selected as usize];
+            for (regime, score) in scores.iter().enumerate().skip(1) {
+                if *score > selected_score {
+                    selected = regime as u8;
+                    selected_score = *score;
+                }
+            }
+            updates.push((selected, selected_score / 6.0));
+        }
+        for (edge, (regime, neighborhood_confidence)) in edges.iter_mut().zip(updates) {
+            if edge.regime != regime {
+                edge.regime = regime;
+                edge.confidence = edge
+                    .confidence
+                    .min(neighborhood_confidence.clamp(0.5, 0.75));
+            }
+        }
+    }
+}
+
+fn merge_short_boundary_segments(
+    edges: &mut [BoundaryEdge],
+    edge_by_slot: &[i32],
+    neighbors: &[i32],
+    areas: &[f64],
+) {
+    const MIN_SEGMENT_ANGULAR_LENGTH: f64 = 0.035;
+    let mut queue = VecDeque::new();
+    for _ in 0..4 {
+        let mut component_id = vec![-1i32; edges.len()];
+        let mut components: Vec<Vec<usize>> = Vec::new();
+        let mut lengths = Vec::new();
+        for start in 0..edges.len() {
+            if component_id[start] >= 0 {
+                continue;
+            }
+            let id = components.len() as i32;
+            let regime = edges[start].regime;
+            let plate_a = edges[start].plate_a;
+            let plate_b = edges[start].plate_b;
+            let mut members = Vec::new();
+            let mut length = 0.0f64;
+            component_id[start] = id;
+            queue.push_back(start);
+            while let Some(edge_index) = queue.pop_front() {
+                let edge = &edges[edge_index];
+                members.push(edge_index);
+                length += 0.5 * (areas[edge.source].sqrt() + areas[edge.target].sqrt());
+                for adjacent_index in
+                    adjacent_boundary_edges(edge_index, edges, edge_by_slot, neighbors)
+                {
+                    let adjacent = &edges[adjacent_index];
+                    if component_id[adjacent_index] < 0
+                        && adjacent.regime == regime
+                        && adjacent.plate_a == plate_a
+                        && adjacent.plate_b == plate_b
+                    {
+                        component_id[adjacent_index] = id;
+                        queue.push_back(adjacent_index);
+                    }
+                }
+            }
+            components.push(members);
+            lengths.push(length);
+        }
+
+        let mut updates = Vec::new();
+        for (index, members) in components.iter().enumerate() {
+            if lengths[index] >= MIN_SEGMENT_ANGULAR_LENGTH {
+                continue;
+            }
+            let plate_a = edges[members[0]].plate_a;
+            let plate_b = edges[members[0]].plate_b;
+            let mut contacts = vec![0usize; components.len()];
+            for &edge_index in members {
+                for adjacent_index in
+                    adjacent_boundary_edges(edge_index, edges, edge_by_slot, neighbors)
+                {
+                    let adjacent_component = component_id[adjacent_index] as usize;
+                    let adjacent = &edges[adjacent_index];
+                    if adjacent_component != index
+                        && adjacent.plate_a == plate_a
+                        && adjacent.plate_b == plate_b
+                        && lengths[adjacent_component] > lengths[index]
+                    {
+                        contacts[adjacent_component] += 1;
+                    }
+                }
+            }
+            let target = contacts
+                .iter()
+                .enumerate()
+                .max_by_key(|(component, count)| (**count, lengths[*component].to_bits()))
+                .filter(|(_, count)| **count > 0)
+                .map(|(component, _)| component);
+            if let Some(target_component) = target {
+                let target_regime = edges[components[target_component][0]].regime;
+                updates.push((members.clone(), target_regime));
+            }
+        }
+        if updates.is_empty() {
+            break;
+        }
+        for (members, target_regime) in updates {
+            for edge_index in members {
+                edges[edge_index].regime = target_regime;
+                edges[edge_index].confidence = edges[edge_index].confidence.min(0.55);
+            }
+        }
+    }
+}
+
+#[repr(C)]
+pub struct BoundarySegmentRecordArray {
+    pub data: *mut BoundarySegmentRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct GeologyStats {
+    pub province_count: i32,
+    pub boundary_segment_count: i32,
+    pub active_boundary_segment_count: i32,
+    pub mixed_plate_province_count: i32,
+    pub continental_area: f64,
+    pub oceanic_area: f64,
+    pub mean_crust_age_ga: f32,
+    pub mean_confidence: f32,
+}
+
+#[no_mangle]
+/// Release province records allocated by [`geology_run_cubed_sphere`].
+///
+/// # Safety
+///
+/// `array` must be returned by one successful kernel call and released once.
+pub unsafe extern "C" fn geology_free_provinces(array: ProvinceRecordArray) {
+    if !array.data.is_null() && array.len > 0 {
+        let records = std::ptr::slice_from_raw_parts_mut(array.data, array.len);
+        drop(Box::from_raw(records));
+    }
+}
+
+#[no_mangle]
+/// Release boundary records allocated by [`geology_run_cubed_sphere`].
+///
+/// # Safety
+///
+/// `array` must be returned by one successful kernel call and released once.
+pub unsafe extern "C" fn geology_free_boundary_segments(array: BoundarySegmentRecordArray) {
+    if !array.data.is_null() && array.len > 0 {
+        let records = std::ptr::slice_from_raw_parts_mut(array.data, array.len);
+        drop(Box::from_raw(records));
+    }
+}
+
+fn valid_ffi_len<T>(len: usize) -> bool {
+    len.checked_mul(mem::size_of::<T>())
+        .is_some_and(|bytes| bytes <= isize::MAX as usize)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn province_class(
+    oceanic: bool,
+    compression: f32,
+    extension: f32,
+    subduction: f32,
+    uplift: f32,
+    subsidence: f32,
+    isostasy: f32,
+    margin: f32,
+    stiffness: f32,
+    basin_isostasy_threshold: f32,
+) -> (u8, f32) {
+    let activity = compression.max(extension).max(subduction);
+    if oceanic {
+        if extension > 0.22 && extension >= compression.max(subduction) {
+            return (PROVINCE_OCEANIC_RIDGE, (0.58 + 0.35 * extension).min(0.98));
+        }
+        if subduction > 0.22 && compression > 0.12 {
+            return (
+                PROVINCE_INTRA_OCEANIC_ARC,
+                (0.56 + 0.24 * subduction + 0.12 * compression).min(0.98),
+            );
+        }
+        return (PROVINCE_ABYSSAL_BASIN, (0.62 + 0.2 * stiffness).min(0.9));
+    }
+
+    if subduction > 0.24 && compression > 0.14 {
+        return (
+            PROVINCE_CONTINENTAL_ARC,
+            (0.56 + 0.22 * subduction + 0.12 * compression).min(0.98),
+        );
+    }
+    if compression > 0.26 && uplift > 0.16 {
+        return (
+            PROVINCE_OROGEN,
+            (0.56 + 0.24 * compression + 0.12 * uplift).min(0.98),
+        );
+    }
+    if extension > 0.22 && extension > compression {
+        return (
+            PROVINCE_CONTINENTAL_RIFT,
+            (0.56 + 0.34 * extension).min(0.98),
+        );
+    }
+    if margin > 0.58 && activity < 0.28 {
+        return (
+            PROVINCE_SHELF,
+            (0.55 + 0.32 * margin - 0.15 * activity).clamp(0.5, 0.92),
+        );
+    }
+    if activity < 0.18 && isostasy < basin_isostasy_threshold && subsidence >= uplift * 0.3 {
+        let signal = (basin_isostasy_threshold - isostasy).max(subsidence - uplift * 0.3);
+        return (
+            PROVINCE_SEDIMENTARY_BASIN,
+            (0.56 + 0.35 * signal).clamp(0.52, 0.92),
+        );
+    }
+    if stiffness > 0.915 {
+        return (PROVINCE_SHIELD, (0.58 + 0.38 * stiffness).min(0.97));
+    }
+    (PROVINCE_PLATFORM, (0.55 + 0.3 * stiffness).clamp(0.5, 0.9))
+}
+
+fn boundary_regime(
+    continental_a: bool,
+    continental_b: bool,
+    compression: f32,
+    extension: f32,
+    shear: f32,
+    subduction: f32,
+) -> (u8, f32) {
+    let compressive = compression.max(subduction * 0.9);
+    if extension > 0.1 && extension >= compressive.max(shear) {
+        let regime = if continental_a && continental_b {
+            REGIME_CONTINENTAL_RIFT
+        } else {
+            REGIME_SPREADING_RIDGE
+        };
+        return (regime, (0.52 + 0.4 * extension).min(0.98));
+    }
+    if compressive > 0.1 && compressive >= shear {
+        let regime = match (continental_a, continental_b) {
+            (true, true) => REGIME_CONTINENTAL_COLLISION,
+            (false, false) => REGIME_INTRA_OCEANIC_SUBDUCTION,
+            _ => REGIME_SUBDUCTION_MARGIN,
+        };
+        return (
+            regime,
+            (0.52 + 0.25 * compressive + 0.18 * subduction).min(0.98),
+        );
+    }
+    if shear > 0.08 {
+        return (REGIME_TRANSFORM, (0.52 + 0.42 * shear).min(0.96));
+    }
+    (REGIME_INACTIVE, 0.5)
+}
+
+fn plate_id(plate_field: &[f32], cell: usize, components: usize) -> i32 {
+    plate_field[cell * components].round() as i32
+}
+
+fn is_continental(plate_field: &[f32], cell: usize, components: usize) -> bool {
+    plate_field[cell * components + 1] >= 0.5
+}
+
+fn minimum_province_area(class_code: u8, total_area: f64) -> f64 {
+    match class_code {
+        PROVINCE_SHIELD | PROVINCE_PLATFORM | PROVINCE_SEDIMENTARY_BASIN | PROVINCE_VOLCANIC => {
+            total_area / 8192.0
+        }
+        _ => total_area / 16384.0,
+    }
+}
+
+fn merge_small_provinces(
+    classes: &mut [u8],
+    confidence: &mut [f32],
+    oceanic: &[bool],
+    neighbors: &[i32],
+    areas: &[f64],
+    total_area: f64,
+) {
+    let mut queue = VecDeque::new();
+    for _ in 0..12 {
+        let mut component_id = vec![-1i32; classes.len()];
+        let mut components: Vec<Vec<usize>> = Vec::new();
+        let mut component_areas = Vec::new();
+        for start in 0..classes.len() {
+            if component_id[start] >= 0 {
+                continue;
+            }
+            let id = components.len() as i32;
+            let class_code = classes[start];
+            let mut cells = Vec::new();
+            let mut area = 0.0f64;
+            component_id[start] = id;
+            queue.push_back(start);
+            while let Some(cell) = queue.pop_front() {
+                cells.push(cell);
+                area += areas[cell];
+                for &neighbor in &neighbors[cell * 4..cell * 4 + 4] {
+                    let adjacent = neighbor as usize;
+                    if component_id[adjacent] < 0 && classes[adjacent] == class_code {
+                        component_id[adjacent] = id;
+                        queue.push_back(adjacent);
+                    }
+                }
+            }
+            components.push(cells);
+            component_areas.push(area);
+        }
+
+        let mut updates = Vec::new();
+        for (index, cells) in components.iter().enumerate() {
+            let source_class = classes[cells[0]];
+            if component_areas[index] >= minimum_province_area(source_class, total_area) {
+                continue;
+            }
+            let source_oceanic = oceanic[cells[0]];
+            let mut shared_edge_length = [0.0f64; 12];
+            for &cell in cells {
+                for &neighbor in &neighbors[cell * 4..cell * 4 + 4] {
+                    let adjacent = neighbor as usize;
+                    let target_class = classes[adjacent];
+                    let target_component = component_id[adjacent] as usize;
+                    let target_is_larger = component_areas[target_component]
+                        > component_areas[index]
+                        || (component_areas[target_component] == component_areas[index]
+                            && target_component < index);
+                    if target_class != source_class
+                        && oceanic[adjacent] == source_oceanic
+                        && target_is_larger
+                        && (target_class as usize) < shared_edge_length.len()
+                    {
+                        shared_edge_length[target_class as usize] +=
+                            0.5 * (areas[cell].sqrt() + areas[adjacent].sqrt());
+                    }
+                }
+            }
+            let target = shared_edge_length
+                .iter()
+                .enumerate()
+                .skip(1)
+                .max_by(|left, right| left.1.total_cmp(right.1).then_with(|| right.0.cmp(&left.0)))
+                .filter(|(_, weight)| **weight > 0.0)
+                .map(|(class_code, _)| class_code as u8);
+            if let Some(target_class) = target {
+                updates.push((cells.clone(), target_class));
+            }
+        }
+        if updates.is_empty() {
+            for (index, cells) in components.iter().enumerate() {
+                let class_code = classes[cells[0]];
+                if component_areas[index] < minimum_province_area(class_code, total_area) {
+                    for &cell in cells {
+                        confidence[cell] = confidence[cell].min(0.5);
+                    }
+                }
+            }
+            break;
+        }
+        for (cells, target_class) in updates {
+            for cell in cells {
+                classes[cell] = target_class;
+                confidence[cell] = confidence[cell].min(0.55);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+/// Initialize connected geological process provinces and plate-boundary segments.
+///
+/// This classifies current structural evidence. It does not claim a simulated
+/// stratigraphic or terrane history.
+///
+/// # Safety
+///
+/// Every input and output must be aligned, correctly sized, and non-overlapping.
+/// Neighbor IDs must reference four unique valid global cells. Catalog and
+/// stats pointers may be null; null catalog pointers discard generated records.
+pub unsafe extern "C" fn geology_run_cubed_sphere(
+    cell_count: i32,
+    world_age_ga: f32,
+    plate_components: i32,
+    area_ptr: *const f64,
+    neighbors_ptr: *const i32,
+    plate_field_ptr: *const f32,
+    subduction_ptr: *const f32,
+    isostasy_ptr: *const f32,
+    uplift_ptr: *const f32,
+    subsidence_ptr: *const f32,
+    compression_ptr: *const f32,
+    extension_ptr: *const f32,
+    shear_ptr: *const f32,
+    margin_ptr: *const f32,
+    stiffness_ptr: *const f32,
+    proto_ocean_ptr: *const f32,
+    province_id_out_ptr: *mut i32,
+    province_class_out_ptr: *mut u8,
+    crust_age_out_ptr: *mut f32,
+    rock_strength_out_ptr: *mut f32,
+    accommodation_out_ptr: *mut f32,
+    province_confidence_out_ptr: *mut f32,
+    boundary_segment_id_out_ptr: *mut i32,
+    boundary_regime_out_ptr: *mut u8,
+    boundary_confidence_out_ptr: *mut f32,
+    provinces_out: *mut ProvinceRecordArray,
+    segments_out: *mut BoundarySegmentRecordArray,
+    stats_out: *mut GeologyStats,
+) -> i32 {
+    if cell_count <= 0
+        || !world_age_ga.is_finite()
+        || world_age_ga <= 0.0
+        || plate_components < PLATE_COMPONENTS as i32
+        || area_ptr.is_null()
+        || neighbors_ptr.is_null()
+        || plate_field_ptr.is_null()
+        || subduction_ptr.is_null()
+        || isostasy_ptr.is_null()
+        || uplift_ptr.is_null()
+        || subsidence_ptr.is_null()
+        || compression_ptr.is_null()
+        || extension_ptr.is_null()
+        || shear_ptr.is_null()
+        || margin_ptr.is_null()
+        || stiffness_ptr.is_null()
+        || proto_ocean_ptr.is_null()
+        || province_id_out_ptr.is_null()
+        || province_class_out_ptr.is_null()
+        || crust_age_out_ptr.is_null()
+        || rock_strength_out_ptr.is_null()
+        || accommodation_out_ptr.is_null()
+        || province_confidence_out_ptr.is_null()
+        || boundary_segment_id_out_ptr.is_null()
+        || boundary_regime_out_ptr.is_null()
+        || boundary_confidence_out_ptr.is_null()
+    {
+        return 1;
+    }
+    let total = cell_count as usize;
+    let components = plate_components as usize;
+    let Some(plate_len) = total.checked_mul(components) else {
+        return 2;
+    };
+    let Some(neighbor_len) = total.checked_mul(D4_NEIGHBORS) else {
+        return 2;
+    };
+    if !valid_ffi_len::<f64>(total)
+        || !valid_ffi_len::<i32>(neighbor_len)
+        || !valid_ffi_len::<f32>(plate_len)
+        || !valid_ffi_len::<f32>(total)
+        || !valid_ffi_len::<i32>(total)
+        || !valid_ffi_len::<u8>(total)
+        || !valid_ffi_len::<f32>(neighbor_len)
+    {
+        return 2;
+    }
+
+    let areas = slice::from_raw_parts(area_ptr, total);
+    let neighbors = slice::from_raw_parts(neighbors_ptr, neighbor_len);
+    let plate_field = slice::from_raw_parts(plate_field_ptr, plate_len);
+    let subduction = slice::from_raw_parts(subduction_ptr, total);
+    let isostasy = slice::from_raw_parts(isostasy_ptr, total);
+    let uplift = slice::from_raw_parts(uplift_ptr, total);
+    let subsidence = slice::from_raw_parts(subsidence_ptr, total);
+    let compression = slice::from_raw_parts(compression_ptr, total);
+    let extension = slice::from_raw_parts(extension_ptr, total);
+    let shear = slice::from_raw_parts(shear_ptr, total);
+    let margin = slice::from_raw_parts(margin_ptr, total);
+    let stiffness = slice::from_raw_parts(stiffness_ptr, total);
+    let proto_ocean = slice::from_raw_parts(proto_ocean_ptr, total);
+    let province_ids = slice::from_raw_parts_mut(province_id_out_ptr, total);
+    let province_classes = slice::from_raw_parts_mut(province_class_out_ptr, total);
+    let crust_age = slice::from_raw_parts_mut(crust_age_out_ptr, total);
+    let rock_strength = slice::from_raw_parts_mut(rock_strength_out_ptr, total);
+    let accommodation = slice::from_raw_parts_mut(accommodation_out_ptr, total);
+    let province_confidence = slice::from_raw_parts_mut(province_confidence_out_ptr, total);
+    let segment_ids = slice::from_raw_parts_mut(boundary_segment_id_out_ptr, neighbor_len);
+    let regimes = slice::from_raw_parts_mut(boundary_regime_out_ptr, neighbor_len);
+    let boundary_confidence = slice::from_raw_parts_mut(boundary_confidence_out_ptr, neighbor_len);
+
+    let scalar_inputs = [
+        subduction,
+        isostasy,
+        uplift,
+        subsidence,
+        compression,
+        extension,
+        shear,
+        margin,
+        stiffness,
+        proto_ocean,
+    ];
+    let mut total_area = 0.0f64;
+    for cell in 0..total {
+        if !areas[cell].is_finite()
+            || areas[cell] <= 0.0
+            || plate_field[cell * components..cell * components + PLATE_COMPONENTS]
+                .iter()
+                .any(|value| !value.is_finite())
+            || scalar_inputs.iter().any(|values| !values[cell].is_finite())
+        {
+            return 3;
+        }
+        let mut unique = [
+            neighbors[cell * 4],
+            neighbors[cell * 4 + 1],
+            neighbors[cell * 4 + 2],
+            neighbors[cell * 4 + 3],
+        ];
+        unique.sort_unstable();
+        if unique.windows(2).any(|pair| pair[0] == pair[1])
+            || unique
+                .iter()
+                .any(|neighbor| *neighbor < 0 || *neighbor as usize >= total)
+        {
+            return 4;
+        }
+        total_area += areas[cell];
+    }
+
+    let mut continental_area = 0.0f64;
+    let mut continental_isostasy_sum = 0.0f64;
+    let mut continental_isostasy_sq_sum = 0.0f64;
+    for cell in 0..total {
+        if proto_ocean[cell] < 0.5 {
+            let area = areas[cell];
+            continental_area += area;
+            continental_isostasy_sum += isostasy[cell] as f64 * area;
+            continental_isostasy_sq_sum += isostasy[cell] as f64 * isostasy[cell] as f64 * area;
+        }
+    }
+    let basin_isostasy_threshold = if continental_area > 0.0 {
+        let continental_isostasy_mean = continental_isostasy_sum / continental_area;
+        let continental_isostasy_std = (continental_isostasy_sq_sum / continental_area
+            - continental_isostasy_mean * continental_isostasy_mean)
+            .max(0.0)
+            .sqrt();
+        (continental_isostasy_mean - 0.45 * continental_isostasy_std) as f32
+    } else {
+        f32::NEG_INFINITY
+    };
+
+    let oceanic: Vec<bool> = proto_ocean.iter().map(|value| *value >= 0.5).collect();
+    for cell in 0..total {
+        let (class_code, confidence) = province_class(
+            oceanic[cell],
+            compression[cell].clamp(0.0, 1.0),
+            extension[cell].clamp(0.0, 1.0),
+            subduction[cell].clamp(0.0, 1.0),
+            uplift[cell].max(0.0),
+            subsidence[cell].max(0.0),
+            isostasy[cell],
+            margin[cell].clamp(0.0, 1.0),
+            stiffness[cell].clamp(0.0, 1.0),
+            basin_isostasy_threshold,
+        );
+        province_classes[cell] = class_code;
+        province_confidence[cell] = confidence;
+        rock_strength[cell] = (0.28 + 0.58 * stiffness[cell].clamp(0.0, 1.0)
+            - 0.18 * extension[cell].clamp(0.0, 1.0)
+            - 0.1 * subduction[cell].clamp(0.0, 1.0))
+        .clamp(0.0, 1.0);
+        accommodation[cell] = (0.48 * subsidence[cell].max(0.0)
+            + 0.28 * extension[cell].clamp(0.0, 1.0)
+            + 0.18 * (1.0 - stiffness[cell].clamp(0.0, 1.0))
+            + 0.12 * (-isostasy[cell]).max(0.0))
+        .clamp(0.0, 1.0);
+    }
+
+    merge_small_provinces(
+        province_classes,
+        province_confidence,
+        &oceanic,
+        neighbors,
+        areas,
+        total_area,
+    );
+
+    let mut age_area_sum = 0.0f64;
+    let mut confidence_area_sum = 0.0f64;
+    for cell in 0..total {
+        let class_code = province_classes[cell];
+        crust_age[cell] = if oceanic[cell] {
+            let oceanic_max_age = world_age_ga.min(0.25);
+            (oceanic_max_age
+                * (0.12 + 0.72 * stiffness[cell].clamp(0.0, 1.0)
+                    - 0.5 * extension[cell].clamp(0.0, 1.0)))
+            .clamp(0.005, oceanic_max_age)
+        } else {
+            let age_fraction = match class_code {
+                PROVINCE_SHIELD => 0.78 + 0.2 * stiffness[cell],
+                PROVINCE_PLATFORM => 0.38 + 0.34 * stiffness[cell],
+                PROVINCE_SEDIMENTARY_BASIN => 0.3 + 0.3 * stiffness[cell],
+                PROVINCE_OROGEN | PROVINCE_CONTINENTAL_ARC => 0.42 + 0.32 * stiffness[cell],
+                PROVINCE_CONTINENTAL_RIFT => 0.3 + 0.3 * stiffness[cell],
+                PROVINCE_SHELF => 0.36 + 0.3 * stiffness[cell],
+                PROVINCE_VOLCANIC => 0.12 + 0.24 * stiffness[cell],
+                _ => 0.35 + 0.3 * stiffness[cell],
+            };
+            (world_age_ga
+                * (age_fraction
+                    - 0.14 * extension[cell].clamp(0.0, 1.0)
+                    - 0.08 * subduction[cell].clamp(0.0, 1.0)))
+            .clamp(0.05, world_age_ga)
+        };
+        let area = areas[cell];
+        age_area_sum += crust_age[cell] as f64 * area;
+        confidence_area_sum += province_confidence[cell] as f64 * area;
+    }
+
+    province_ids.fill(-1);
+    let mut province_records = Vec::new();
+    let mut queue = VecDeque::new();
+    for start in 0..total {
+        if province_ids[start] >= 0 {
+            continue;
+        }
+        let province_id = province_records.len() as i32;
+        let class_code = province_classes[start];
+        let initial_plate = plate_id(plate_field, start, components);
+        let mut parent_plate = initial_plate;
+        let mut cells = 0i32;
+        let mut area_sum = 0.0f64;
+        let mut age_sum = 0.0f64;
+        let mut strength_sum = 0.0f64;
+        let mut accommodation_sum = 0.0f64;
+        let mut confidence_sum = 0.0f64;
+        province_ids[start] = province_id;
+        queue.push_back(start);
+        while let Some(cell) = queue.pop_front() {
+            cells += 1;
+            let area = areas[cell];
+            area_sum += area;
+            age_sum += crust_age[cell] as f64 * area;
+            strength_sum += rock_strength[cell] as f64 * area;
+            accommodation_sum += accommodation[cell] as f64 * area;
+            confidence_sum += province_confidence[cell] as f64 * area;
+            if plate_id(plate_field, cell, components) != initial_plate {
+                parent_plate = -1;
+            }
+            for &neighbor in &neighbors[cell * 4..cell * 4 + 4] {
+                let adjacent = neighbor as usize;
+                if province_ids[adjacent] < 0 && province_classes[adjacent] == class_code {
+                    province_ids[adjacent] = province_id;
+                    queue.push_back(adjacent);
+                }
+            }
+        }
+        province_records.push(ProvinceRecord {
+            province_id,
+            class_code: class_code as i32,
+            parent_plate_id: parent_plate,
+            cell_count: cells,
+            area_steradians: area_sum,
+            mean_crust_age_ga: (age_sum / area_sum) as f32,
+            mean_rock_strength: (strength_sum / area_sum) as f32,
+            mean_accommodation: (accommodation_sum / area_sum) as f32,
+            mean_confidence: (confidence_sum / area_sum) as f32,
+        });
+    }
+
+    segment_ids.fill(-1);
+    regimes.fill(0);
+    boundary_confidence.fill(0.0);
+    let mut edge_by_slot = vec![-1i32; neighbor_len];
+    let mut edges = Vec::new();
+    for source in 0..total {
+        let source_plate = plate_id(plate_field, source, components);
+        for source_slot in 0..D4_NEIGHBORS {
+            let target = neighbors[source * 4 + source_slot] as usize;
+            if source >= target {
+                continue;
+            }
+            let target_plate = plate_id(plate_field, target, components);
+            if source_plate == target_plate {
+                continue;
+            }
+            let Some(target_slot) = neighbors[target * 4..target * 4 + 4]
+                .iter()
+                .position(|neighbor| *neighbor as usize == source)
+            else {
+                return 4;
+            };
+            let mean_compression = 0.5 * (compression[source] + compression[target]);
+            let mean_extension = 0.5 * (extension[source] + extension[target]);
+            let mean_shear = 0.5 * (shear[source] + shear[target]);
+            let mean_subduction = 0.5 * (subduction[source] + subduction[target]);
+            let (regime, confidence) = boundary_regime(
+                is_continental(plate_field, source, components),
+                is_continental(plate_field, target, components),
+                mean_compression.clamp(0.0, 1.0),
+                mean_extension.clamp(0.0, 1.0),
+                mean_shear.clamp(0.0, 1.0),
+                mean_subduction.clamp(0.0, 1.0),
+            );
+            let edge_index = edges.len() as i32;
+            edge_by_slot[source * 4 + source_slot] = edge_index;
+            edge_by_slot[target * 4 + target_slot] = edge_index;
+            edges.push(BoundaryEdge {
+                source,
+                target,
+                source_slot,
+                target_slot,
+                plate_a: source_plate.min(target_plate),
+                plate_b: source_plate.max(target_plate),
+                regime,
+                confidence,
+                compression: mean_compression,
+                extension: mean_extension,
+                shear: mean_shear,
+                subduction: mean_subduction,
+            });
+        }
+    }
+    smooth_boundary_regimes(&mut edges, &edge_by_slot, neighbors);
+    merge_short_boundary_segments(&mut edges, &edge_by_slot, neighbors, areas);
+
+    let mut segment_records = Vec::new();
+    let mut edge_segments = vec![-1i32; edges.len()];
+    for start in 0..edges.len() {
+        if edge_segments[start] >= 0 {
+            continue;
+        }
+        let segment_id = segment_records.len() as i32;
+        let regime = edges[start].regime;
+        let plate_a = edges[start].plate_a;
+        let plate_b = edges[start].plate_b;
+        let mut edge_count = 0i32;
+        let mut angular_length = 0.0f64;
+        let mut compression_sum = 0.0f64;
+        let mut extension_sum = 0.0f64;
+        let mut shear_sum = 0.0f64;
+        let mut subduction_sum = 0.0f64;
+        let mut confidence_sum = 0.0f64;
+        edge_segments[start] = segment_id;
+        queue.push_back(start);
+        while let Some(edge_index) = queue.pop_front() {
+            let edge = &edges[edge_index];
+            edge_count += 1;
+            angular_length += 0.5 * (areas[edge.source].sqrt() + areas[edge.target].sqrt());
+            compression_sum += edge.compression as f64;
+            extension_sum += edge.extension as f64;
+            shear_sum += edge.shear as f64;
+            subduction_sum += edge.subduction as f64;
+            confidence_sum += edge.confidence as f64;
+            for adjacent_index in
+                adjacent_boundary_edges(edge_index, &edges, &edge_by_slot, neighbors)
+            {
+                let adjacent = &edges[adjacent_index];
+                if edge_segments[adjacent_index] < 0
+                    && adjacent.regime == regime
+                    && adjacent.plate_a == plate_a
+                    && adjacent.plate_b == plate_b
+                {
+                    edge_segments[adjacent_index] = segment_id;
+                    queue.push_back(adjacent_index);
+                }
+            }
+        }
+        let count = edge_count as f64;
+        segment_records.push(BoundarySegmentRecord {
+            segment_id,
+            regime_code: regime as i32,
+            plate_a,
+            plate_b,
+            edge_count,
+            angular_length,
+            mean_compression: (compression_sum / count) as f32,
+            mean_extension: (extension_sum / count) as f32,
+            mean_shear: (shear_sum / count) as f32,
+            mean_subduction: (subduction_sum / count) as f32,
+            mean_confidence: (confidence_sum / count) as f32,
+        });
+    }
+
+    for (edge_index, edge) in edges.iter().enumerate() {
+        let segment_id = edge_segments[edge_index];
+        let source_slot = edge.source * 4 + edge.source_slot;
+        let target_slot = edge.target * 4 + edge.target_slot;
+        for slot in [source_slot, target_slot] {
+            segment_ids[slot] = segment_id;
+            regimes[slot] = edge.regime;
+            boundary_confidence[slot] = edge.confidence;
+        }
+    }
+
+    let mixed_plate_provinces = province_records
+        .iter()
+        .filter(|record| record.parent_plate_id < 0)
+        .count();
+    let active_segments = segment_records
+        .iter()
+        .filter(|record| record.regime_code != REGIME_INACTIVE as i32)
+        .count();
+    let province_count = province_records.len();
+    let segment_count = segment_records.len();
+
+    if !provinces_out.is_null() {
+        (*provinces_out).data = std::ptr::null_mut();
+        (*provinces_out).len = 0;
+        if province_count > 0 {
+            let records = province_records.into_boxed_slice();
+            (*provinces_out).data = Box::into_raw(records) as *mut ProvinceRecord;
+            (*provinces_out).len = province_count;
+        }
+    }
+    if !segments_out.is_null() {
+        (*segments_out).data = std::ptr::null_mut();
+        (*segments_out).len = 0;
+        if segment_count > 0 {
+            let records = segment_records.into_boxed_slice();
+            (*segments_out).data = Box::into_raw(records) as *mut BoundarySegmentRecord;
+            (*segments_out).len = segment_count;
+        }
+    }
+    if !stats_out.is_null() {
+        (*stats_out) = GeologyStats {
+            province_count: province_count.min(i32::MAX as usize) as i32,
+            boundary_segment_count: segment_count.min(i32::MAX as usize) as i32,
+            active_boundary_segment_count: active_segments.min(i32::MAX as usize) as i32,
+            mixed_plate_province_count: mixed_plate_provinces.min(i32::MAX as usize) as i32,
+            continental_area,
+            oceanic_area: total_area - continental_area,
+            mean_crust_age_ga: (age_area_sum / total_area) as f32,
+            mean_confidence: (confidence_area_sum / total_area) as f32,
+        };
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_major_structural_regimes() {
+        assert_eq!(
+            province_class(false, 0.7, 0.0, 0.5, 0.6, 0.0, 0.2, 0.0, 0.7, 0.0).0,
+            PROVINCE_CONTINENTAL_ARC
+        );
+        assert_eq!(
+            province_class(false, 0.0, 0.8, 0.0, 0.0, 0.1, 0.0, 0.0, 0.4, 0.0).0,
+            PROVINCE_CONTINENTAL_RIFT
+        );
+        assert_eq!(
+            province_class(true, 0.0, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4, 0.0).0,
+            PROVINCE_OCEANIC_RIDGE
+        );
+    }
+
+    #[test]
+    fn distinguishes_collision_subduction_rift_and_transform() {
+        assert_eq!(boundary_regime(true, true, 0.8, 0.0, 0.1, 0.2).0, 2);
+        assert_eq!(boundary_regime(true, false, 0.6, 0.0, 0.1, 0.7).0, 3);
+        assert_eq!(boundary_regime(true, true, 0.0, 0.7, 0.1, 0.0).0, 5);
+        assert_eq!(boundary_regime(false, false, 0.0, 0.0, 0.7, 0.0).0, 7);
+    }
+}

--- a/src/map_maker/pipeline/registry.py
+++ b/src/map_maker/pipeline/registry.py
@@ -27,6 +27,7 @@ class StageDescriptor:
     outputs: tuple[str, ...]
     callable: StageCallable
     version: str = "v1"
+    native_libraries: tuple[str, ...] = ()
     visualizer: Optional[StageVisualizer] = None
     description: Optional[str] = None
 
@@ -67,6 +68,7 @@ def stage(
     outputs: Iterable[str] | None = None,
     *,
     version: str = "v1",
+    native_libraries: Iterable[str] | None = None,
     visualizer: StageVisualizer | None = None,
     description: str | None = None,
 ) -> Callable[[StageCallable], StageCallable]:
@@ -79,6 +81,7 @@ def stage(
             outputs=tuple(outputs or ()),
             callable=func,
             version=version,
+            native_libraries=tuple(native_libraries or ()),
             visualizer=visualizer or getattr(func, "visualizer", None),
             description=description or getattr(func, "__doc__", None),
         )

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -5,6 +5,7 @@ import importlib
 from . import geometry  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
+from . import geology  # noqa: F401
 from . import erosion  # noqa: F401
 
 
@@ -17,6 +18,7 @@ def ensure_builtin_stages() -> None:
         "geometry": geometry,
         "tectonics": tectonics,
         "world_age": world_age,
+        "geology": geology,
         "erosion": erosion,
     }
     for stage_name, module in modules.items():

--- a/src/map_maker/pipeline/stages/erosion.py
+++ b/src/map_maker/pipeline/stages/erosion.py
@@ -133,6 +133,7 @@ def _log_erosion(context, metadata: Mapping[str, object]) -> None:
         "ErosionMetadata",
     ),
     version="v3",
+    native_libraries=("erosion_native",),
 )
 def erosion_stage(context, deps, config_mapping):
     if isinstance(context.topology, CubedSphereGrid):

--- a/src/map_maker/pipeline/stages/geology.py
+++ b/src/map_maker/pipeline/stages/geology.py
@@ -1,0 +1,218 @@
+"""Connected geological process provinces on the canonical cubed sphere."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import numpy as np
+from PIL import Image
+
+from .._geology_native import BOUNDARY_REGIMES, PROVINCE_CLASSES, run_cubed_sphere_geology
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+
+def _artifact_array(result, name: str) -> np.ndarray:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        raise KeyError(f"Missing dependency artifact '{name}'")
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
+    resolution = faces.shape[1]
+    net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
+    placements = {3: (1, 0), 0: (1, 1), 2: (1, 2), 1: (1, 3), 4: (0, 1), 5: (2, 1)}
+    for face, (net_row, net_col) in placements.items():
+        row = net_row * resolution
+        col = net_col * resolution
+        net[row : row + resolution, col : col + resolution] = faces[face]
+    return net
+
+
+def _result_array(result, name: str) -> np.ndarray | None:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        return None
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _geology_visualizer(result, request: VisualizationRequest) -> list[VisualizationResult] | None:
+    classes = _result_array(result, "GeologicalProvinceClass")
+    regimes = _result_array(result, "BoundaryRegime")
+    crust_age = _result_array(result, "CrustAgeGa")
+    if classes is None or regimes is None or crust_age is None or classes.shape[0] != 6:
+        return None
+
+    province_palette = np.array(
+        [
+            [0, 0, 0],
+            [164, 139, 91],
+            [187, 174, 126],
+            [116, 150, 104],
+            [143, 74, 62],
+            [176, 86, 96],
+            [207, 124, 55],
+            [211, 190, 136],
+            [42, 88, 132],
+            [47, 143, 155],
+            [116, 74, 145],
+            [194, 66, 48],
+        ],
+        dtype=np.uint8,
+    )
+    province_rgb = province_palette[np.clip(classes.astype(np.intp), 0, len(province_palette) - 1)]
+    province_path = request.output_dir / "geological_provinces.png"
+    Image.fromarray(_cube_net_rgb(province_rgb), mode="RGB").save(province_path)
+
+    regime_palette = np.array(
+        [
+            [0, 0, 0],
+            [90, 90, 90],
+            [238, 64, 53],
+            [237, 139, 45],
+            [172, 80, 167],
+            [214, 77, 139],
+            [39, 176, 191],
+            [241, 209, 70],
+        ],
+        dtype=np.uint8,
+    )
+    boundary_confidence = _result_array(result, "BoundaryConfidence")
+    if boundary_confidence is None:
+        return None
+    strongest_edge = np.argmax(boundary_confidence, axis=-1)[..., None]
+    cell_regimes = np.take_along_axis(regimes, strongest_edge, axis=-1)[..., 0]
+    regime_rgb = regime_palette[np.clip(cell_regimes.astype(np.intp), 0, len(regime_palette) - 1)]
+    regime_path = request.output_dir / "boundary_regimes.png"
+    Image.fromarray(_cube_net_rgb(regime_rgb), mode="RGB").save(regime_path)
+
+    age_scale = max(float(np.percentile(crust_age, 99)), 1e-6)
+    normalized = np.clip(crust_age / age_scale, 0.0, 1.0)
+    age_rgb = np.empty((*crust_age.shape, 3), dtype=np.uint8)
+    age_rgb[..., 0] = (55 + normalized * 180).astype(np.uint8)
+    age_rgb[..., 1] = (125 + normalized * 90).astype(np.uint8)
+    age_rgb[..., 2] = (170 - normalized * 120).astype(np.uint8)
+    age_path = request.output_dir / "crust_age.png"
+    Image.fromarray(_cube_net_rgb(age_rgb), mode="RGB").save(age_path)
+
+    return [
+        VisualizationResult(province_path, "GeologicalProvinceClass", {}),
+        VisualizationResult(regime_path, "BoundaryRegime", {}),
+        VisualizationResult(age_path, "CrustAgeGa", {}),
+    ]
+
+
+@stage(
+    "geology",
+    inputs=("tectonics", "world_age"),
+    outputs=(
+        "GeologicalProvinceID",
+        "GeologicalProvinceClass",
+        "CrustAgeGa",
+        "RockStrength",
+        "SedimentAccommodation",
+        "ProvinceConfidence",
+        "BoundarySegmentID",
+        "BoundaryRegime",
+        "BoundaryConfidence",
+        "GeologicalProvinceCatalog",
+        "BoundarySegmentCatalog",
+        "GeologyMetadata",
+    ),
+    version="v1",
+    native_libraries=("geology_native",),
+    visualizer=_geology_visualizer,
+)
+def geology_stage(context, deps, config_mapping: Mapping[str, object]):
+    if config_mapping:
+        unknown = ", ".join(sorted(config_mapping))
+        raise ValueError(f"geology v1 has no configurable controls; received: {unknown}")
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("canonical geology requires topology: cubed_sphere")
+
+    shape = context.topology.face_shape
+    edge_shape = (*shape, 4)
+    tectonics = deps["tectonics"]
+    world_age = deps["world_age"]
+    world_metadata = world_age.artifact_records["WorldAgeMetadata"].value
+    world_age_ga = float(world_metadata["world_age"])
+
+    handles = {
+        "GeologicalProvinceID": context.arena.allocate_array(
+            "geology_province_id", shape, dtype=np.int32
+        ),
+        "GeologicalProvinceClass": context.arena.allocate_array(
+            "geology_province_class", shape, dtype=np.uint8
+        ),
+        "CrustAgeGa": context.arena.allocate_array("geology_crust_age", shape, dtype=np.float32),
+        "RockStrength": context.arena.allocate_array(
+            "geology_rock_strength", shape, dtype=np.float32
+        ),
+        "SedimentAccommodation": context.arena.allocate_array(
+            "geology_sediment_accommodation", shape, dtype=np.float32
+        ),
+        "ProvinceConfidence": context.arena.allocate_array(
+            "geology_province_confidence", shape, dtype=np.float32
+        ),
+        "BoundarySegmentID": context.arena.allocate_array(
+            "geology_boundary_segment_id", edge_shape, dtype=np.int32
+        ),
+        "BoundaryRegime": context.arena.allocate_array(
+            "geology_boundary_regime", edge_shape, dtype=np.uint8
+        ),
+        "BoundaryConfidence": context.arena.allocate_array(
+            "geology_boundary_confidence", edge_shape, dtype=np.float32
+        ),
+    }
+    views = {name: handle.mutable_view() for name, handle in handles.items()}
+    with context.timed("geology_kernel"):
+        province_catalog, boundary_catalog, metadata = run_cubed_sphere_geology(
+            world_age_ga=world_age_ga,
+            areas=context.topology.cell_areas,
+            neighbors=context.topology.neighbor_indices,
+            plate_field=_artifact_array(tectonics, "PlateField"),
+            subduction=_artifact_array(tectonics, "BoundarySubduction"),
+            isostasy=_artifact_array(world_age, "IsostaticOffset"),
+            uplift=_artifact_array(world_age, "UpliftRate"),
+            subsidence=_artifact_array(world_age, "SubsidenceRate"),
+            compression=_artifact_array(world_age, "TectonicCompression"),
+            extension=_artifact_array(world_age, "TectonicExtension"),
+            shear=_artifact_array(world_age, "ShearMagnitude"),
+            margin=_artifact_array(world_age, "CoastalExposure"),
+            stiffness=_artifact_array(world_age, "LithosphereStiffness"),
+            proto_ocean=_artifact_array(world_age, "BaseOceanMask"),
+            province_id_out=views["GeologicalProvinceID"],
+            province_class_out=views["GeologicalProvinceClass"],
+            crust_age_out=views["CrustAgeGa"],
+            rock_strength_out=views["RockStrength"],
+            accommodation_out=views["SedimentAccommodation"],
+            province_confidence_out=views["ProvinceConfidence"],
+            boundary_segment_id_out=views["BoundarySegmentID"],
+            boundary_regime_out=views["BoundaryRegime"],
+            boundary_confidence_out=views["BoundaryConfidence"],
+        )
+    for handle in handles.values():
+        handle.seal()
+
+    metadata.update(
+        {
+            "world_age_ga": world_age_ga,
+            "province_classes": {str(code): name for code, name in PROVINCE_CLASSES.items()},
+            "boundary_regimes": {str(code): name for code, name in BOUNDARY_REGIMES.items()},
+            "topology": "cubed_sphere",
+        }
+    )
+    context.logger.log_event({"type": "geology_summary", "stage": "geology", **metadata})
+    return {
+        **handles,
+        "GeologicalProvinceCatalog": province_catalog,
+        "BoundarySegmentCatalog": boundary_catalog,
+        "GeologyMetadata": metadata,
+    }
+
+
+__all__ = ["geology_stage"]

--- a/src/map_maker/pipeline/stages/geometry.py
+++ b/src/map_maker/pipeline/stages/geometry.py
@@ -63,6 +63,7 @@ def _geometry_visualizer(
         "TopologyMetadata",
     ),
     version="v1",
+    native_libraries=("topology_native",),
     visualizer=_geometry_visualizer,
 )
 def geometry_stage(context, deps, config):

--- a/src/map_maker/pipeline/stages/tectonics.py
+++ b/src/map_maker/pipeline/stages/tectonics.py
@@ -193,6 +193,7 @@ def _tectonics_visualizer(
         "TectonicsMetadata",
     ),
     version="v5",
+    native_libraries=("tectonics_native",),
     visualizer=_tectonics_visualizer,
 )
 def tectonics_stage(context, deps, config_mapping):

--- a/src/map_maker/pipeline/stages/world_age.py
+++ b/src/map_maker/pipeline/stages/world_age.py
@@ -177,6 +177,7 @@ def _world_age_visualizer(
         "WorldAgeMetadata",
     ),
     version="v2",
+    native_libraries=("world_age_native",),
     visualizer=_world_age_visualizer,
 )
 def world_age_stage(context, deps, config_mapping):

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -95,7 +95,10 @@ def _register_topology_stage() -> str:
         return stage_name
 
     @stage(
-        stage_name, outputs=("xyz_coords", "longitude", "latitude"), visualizer=_topology_visualizer
+        stage_name,
+        outputs=("xyz_coords", "longitude", "latitude"),
+        native_libraries=("topology_native",),
+        visualizer=_topology_visualizer,
     )
     def topology_stage(context, deps, config):
         topo = context.topology
@@ -122,6 +125,15 @@ def _register_world_age_stage() -> str:
     if stage_name in registry():
         return stage_name
     from .stages import world_age  # noqa: F401
+
+    return stage_name
+
+
+def _register_geology_stage() -> str:
+    stage_name = "geology"
+    if stage_name in registry():
+        return stage_name
+    from .stages import geology  # noqa: F401
 
     return stage_name
 
@@ -240,7 +252,7 @@ def run_tectonics_visualizer(
 def main(args: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Produce pipeline stage visualization PNGs.")
     parser.add_argument(
-        "--stage", choices=["topology", "tectonics", "world_age"], default="topology"
+        "--stage", choices=["topology", "tectonics", "world_age", "geology"], default="topology"
     )
     parser.add_argument("--config", type=Path, default=None)
     parser.add_argument(
@@ -295,8 +307,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = "geometry"
         elif parsed.stage == "tectonics":
             stage_name = _register_tectonics_stage()
-        else:
+        elif parsed.stage == "world_age":
             stage_name = _register_world_age_stage()
+        else:
+            stage_name = _register_geology_stage()
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -313,8 +327,8 @@ def main(args: Iterable[str] | None = None) -> int:
     if invalid_controls:
         parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
 
-    if parsed.stage == "world_age":
-        parser.error("--stage world_age requires --config")
+    if parsed.stage in {"world_age", "geology"}:
+        parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":
         if parsed.topology == "cubed_sphere":
             from .cubed_sphere import run_cubed_sphere_diagnostic

--- a/tests/test_geology.py
+++ b/tests/test_geology.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import importlib
+import math
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline._geology_native import (
+    BOUNDARY_REGIMES,
+    PROVINCE_CLASSES,
+    run_cubed_sphere_geology,
+)
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.tools import main as pipeline_tools_main
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    reg = registry()
+    reg.clear()
+    for module_name in ("geometry", "tectonics", "world_age", "geology"):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+    reg.clear()
+
+
+def _config(
+    tmp_path: Path, run_id: str, *, seed: int = 42, face_resolution: int = 32
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": face_resolution}],
+            "rng_seed": seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 16,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 4,
+                },
+                "world_age": {"world_age": 4.1},
+            },
+        }
+    )
+
+
+def _array(result, name: str) -> np.ndarray:
+    return np.asarray(result.artifact_records[name].value.array())
+
+
+def _assert_labels_connected(labels: np.ndarray, neighbors: np.ndarray, valid: np.ndarray) -> None:
+    flat_labels = labels.reshape(-1)
+    flat_valid = valid.reshape(-1)
+    flat_neighbors = neighbors.reshape(-1, 4)
+    for label in np.unique(flat_labels[flat_valid]):
+        members = np.flatnonzero(flat_valid & (flat_labels == label))
+        seen = {int(members[0])}
+        stack = [int(members[0])]
+        while stack:
+            cell = stack.pop()
+            for adjacent in flat_neighbors[cell]:
+                neighbor = int(adjacent)
+                if flat_valid[neighbor] and flat_labels[neighbor] == label and neighbor not in seen:
+                    seen.add(neighbor)
+                    stack.append(neighbor)
+        assert len(seen) == len(members), f"label {label} is disconnected"
+
+
+def _assert_edge_segments_connected(segment_ids: np.ndarray, neighbors: np.ndarray) -> None:
+    flat_segments = segment_ids.reshape(-1, 4)
+    flat_neighbors = neighbors.reshape(-1, 4)
+    edges: list[tuple[int, int, int]] = []
+    incident: dict[int, list[int]] = {}
+    for source in range(flat_segments.shape[0]):
+        for slot, target_value in enumerate(flat_neighbors[source]):
+            target = int(target_value)
+            segment_id = int(flat_segments[source, slot])
+            if segment_id < 0 or source >= target:
+                continue
+            edge_index = len(edges)
+            edges.append((source, target, segment_id))
+            incident.setdefault(source, []).append(edge_index)
+            incident.setdefault(target, []).append(edge_index)
+    edge_segments = np.array([edge[2] for edge in edges], dtype=np.int32)
+    for segment_id in np.unique(edge_segments):
+        members = np.flatnonzero(edge_segments == segment_id)
+        seen = {int(members[0])}
+        stack = [int(members[0])]
+        while stack:
+            edge_index = stack.pop()
+            source, target, _ = edges[edge_index]
+            for cell in (source, target):
+                nearby_cells = [cell, *(int(value) for value in flat_neighbors[cell])]
+                for nearby in nearby_cells:
+                    for adjacent in incident.get(nearby, []):
+                        if edge_segments[adjacent] == segment_id and adjacent not in seen:
+                            seen.add(adjacent)
+                            stack.append(adjacent)
+        assert len(seen) == len(members), f"edge segment {segment_id} is disconnected"
+
+
+def test_geology_outputs_catalogs_and_global_connectivity(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "geology-basic"), generate_visuals=True)
+    results = engine.run(["geology"])
+    geology = results["geology"]
+    grid = engine.context.topology
+    assert isinstance(grid, CubedSphereGrid)
+
+    expected_dtypes = {
+        "GeologicalProvinceID": np.int32,
+        "GeologicalProvinceClass": np.uint8,
+        "CrustAgeGa": np.float32,
+        "RockStrength": np.float32,
+        "SedimentAccommodation": np.float32,
+        "ProvinceConfidence": np.float32,
+        "BoundarySegmentID": np.int32,
+        "BoundaryRegime": np.uint8,
+        "BoundaryConfidence": np.float32,
+    }
+    arrays = {name: _array(geology, name) for name in expected_dtypes}
+    for name, array in arrays.items():
+        expected_shape = (*grid.face_shape, 4) if name.startswith("Boundary") else grid.face_shape
+        assert array.shape == expected_shape
+        assert array.dtype == expected_dtypes[name]
+        assert np.all(np.isfinite(array))
+
+    province_ids = arrays["GeologicalProvinceID"]
+    province_classes = arrays["GeologicalProvinceClass"]
+    assert set(np.unique(province_classes)).issubset(PROVINCE_CLASSES)
+    _assert_labels_connected(
+        province_ids, grid.neighbor_indices, np.ones(grid.face_shape, dtype=bool)
+    )
+
+    province_catalog = geology.artifact_records["GeologicalProvinceCatalog"].value
+    assert isinstance(province_catalog, pa.Table)
+    np.testing.assert_array_equal(
+        np.sort(province_catalog["province_id"].to_numpy()), np.arange(province_catalog.num_rows)
+    )
+    assert int(np.sum(province_catalog["cell_count"].to_numpy())) == grid.cell_count
+    assert float(np.sum(province_catalog["area_steradians"].to_numpy())) == pytest.approx(
+        4.0 * math.pi, abs=1e-8
+    )
+    assert set(province_catalog["class_name"].to_pylist()).issubset(PROVINCE_CLASSES.values())
+    assert np.any(province_catalog["parent_plate_id"].to_numpy() < 0)
+
+    faces = np.indices(grid.face_shape)[0].reshape(-1)
+    flat_provinces = province_ids.reshape(-1)
+    assert any(
+        np.unique(faces[flat_provinces == province_id]).size > 1
+        for province_id in np.unique(flat_provinces)
+    )
+
+    plate = _array(results["tectonics"], "PlateField")
+    flat_plate_ids = plate[..., 0].astype(np.int32).reshape(-1)
+    flat_neighbors = grid.neighbor_indices.reshape(-1, 4)
+    expected_boundary = flat_plate_ids[:, None] != flat_plate_ids[flat_neighbors]
+    segment_ids = arrays["BoundarySegmentID"]
+    regimes = arrays["BoundaryRegime"]
+    boundary = segment_ids >= 0
+    np.testing.assert_array_equal(boundary.reshape(-1, 4), expected_boundary)
+    assert np.all(regimes[~boundary] == 0)
+    assert set(np.unique(regimes[boundary])).issubset(BOUNDARY_REGIMES)
+    _assert_edge_segments_connected(segment_ids, grid.neighbor_indices)
+    flat_segment_ids = segment_ids.reshape(-1, 4)
+    flat_regimes = regimes.reshape(-1, 4)
+    flat_confidence = arrays["BoundaryConfidence"].reshape(-1, 4)
+    for source in range(grid.cell_count):
+        for slot, target_value in enumerate(flat_neighbors[source]):
+            target = int(target_value)
+            reverse_slot = int(np.flatnonzero(flat_neighbors[target] == source)[0])
+            assert flat_segment_ids[source, slot] == flat_segment_ids[target, reverse_slot]
+            assert flat_regimes[source, slot] == flat_regimes[target, reverse_slot]
+            assert flat_confidence[source, slot] == flat_confidence[target, reverse_slot]
+
+    segment_catalog = geology.artifact_records["BoundarySegmentCatalog"].value
+    assert isinstance(segment_catalog, pa.Table)
+    np.testing.assert_array_equal(
+        np.sort(segment_catalog["segment_id"].to_numpy()), np.arange(segment_catalog.num_rows)
+    )
+    assert int(np.sum(segment_catalog["edge_count"].to_numpy())) * 2 == int(
+        np.count_nonzero(boundary)
+    )
+    assert np.all(segment_catalog["plate_a"].to_numpy() < segment_catalog["plate_b"].to_numpy())
+    assert set(segment_catalog["regime_name"].to_pylist()).issubset(BOUNDARY_REGIMES.values())
+
+    oceanic = plate[..., 1] < 0.5
+    crust_age = arrays["CrustAgeGa"]
+    assert float(np.max(crust_age[oceanic])) <= 0.25 + 1e-6
+    assert float(np.mean(crust_age[~oceanic])) > float(np.mean(crust_age[oceanic]))
+    for name in ("RockStrength", "SedimentAccommodation", "ProvinceConfidence"):
+        assert np.all((arrays[name] >= 0.0) & (arrays[name] <= 1.0))
+
+    metadata = geology.artifact_records["GeologyMetadata"].value
+    assert metadata["history_semantics"] == "initialization_not_simulated_deep_time"
+    assert metadata["province_count"] == province_catalog.num_rows
+    assert metadata["boundary_segment_count"] == segment_catalog.num_rows
+    visual_dir = engine.context.config.run_visual_dir() / "geology"
+    assert (visual_dir / "geological_provinces.png").is_file()
+    assert (visual_dir / "boundary_regimes.png").is_file()
+    assert (visual_dir / "crust_age.png").is_file()
+
+
+def test_geology_is_deterministic(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "geology-first")).run(["geology"])["geology"]
+    second = ExecutionEngine(_config(tmp_path, "geology-second")).run(["geology"])["geology"]
+    for name in (
+        "GeologicalProvinceID",
+        "GeologicalProvinceClass",
+        "CrustAgeGa",
+        "RockStrength",
+        "SedimentAccommodation",
+        "ProvinceConfidence",
+        "BoundarySegmentID",
+        "BoundaryRegime",
+        "BoundaryConfidence",
+    ):
+        np.testing.assert_array_equal(_array(first, name), _array(second, name))
+    assert first.artifact_records["GeologicalProvinceCatalog"].value.equals(
+        second.artifact_records["GeologicalProvinceCatalog"].value
+    )
+    assert first.artifact_records["BoundarySegmentCatalog"].value.equals(
+        second.artifact_records["BoundarySegmentCatalog"].value
+    )
+
+
+def test_geology_merges_sub_resolution_fragments_and_defers_volcanic_class(tmp_path: Path):
+    geology = ExecutionEngine(
+        _config(tmp_path, "geology-fragments", seed=11, face_resolution=64)
+    ).run(["geology"])["geology"]
+    catalog = geology.artifact_records["GeologicalProvinceCatalog"].value
+    stable = np.isin(catalog["class_code"].to_numpy(), [1, 2, 3, 11])
+    minimum_area = np.where(stable, 4.0 * math.pi / 8192.0, 4.0 * math.pi / 16384.0)
+    undersized = np.flatnonzero(catalog["area_steradians"].to_numpy() < minimum_area)
+    province_ids = _array(geology, "GeologicalProvinceID").reshape(-1)
+    confidence = _array(geology, "ProvinceConfidence").reshape(-1)
+    dataset_root = Path(geology.artifact_records["GeologicalProvinceID"].dataset_path).parents[1]
+    crust = np.load(dataset_root / "world_age" / "BaseOceanMask.npy").reshape(-1) >= 0.5
+    neighbors = np.load(dataset_root / "geometry" / "NeighborsD4.npy").reshape(-1, 4)
+    for row in undersized:
+        province_id = int(catalog["province_id"][int(row)].as_py())
+        cells = np.flatnonzero(province_ids == province_id)
+        outside_neighbors = neighbors[cells].reshape(-1)
+        same_crust_outside = (crust[outside_neighbors] == crust[cells[0]]) & (
+            province_ids[outside_neighbors] != province_id
+        )
+        assert not np.any(same_crust_outside)
+        assert np.all(confidence[cells] <= 0.5)
+    assert "volcanic_province" not in catalog["class_name"].to_pylist()
+
+
+def _ffi_arguments(face_resolution: int = 4) -> dict[str, object]:
+    grid = CubedSphereGrid.create(face_resolution)
+    shape = grid.face_shape
+    plate = np.zeros((*shape, 7), dtype=np.float32)
+    plate[..., 0] = np.indices(shape)[0]
+    plate[..., 1] = np.indices(shape)[0] < 3
+    plate[..., 2] = np.where(plate[..., 1] > 0.5, 35.0, 7.0)
+    plate[..., 3] = np.where(plate[..., 1] > 0.5, 2.75, 3.0)
+    scalar_inputs = [np.full(shape, 0.1, dtype=np.float32) for _ in range(10)]
+    scalar_inputs[-1][...] = plate[..., 1] < 0.5
+    return {
+        "world_age_ga": 4.1,
+        "areas": grid.cell_areas,
+        "neighbors": grid.neighbor_indices,
+        "plate_field": plate,
+        **dict(
+            zip(
+                (
+                    "subduction",
+                    "isostasy",
+                    "uplift",
+                    "subsidence",
+                    "compression",
+                    "extension",
+                    "shear",
+                    "margin",
+                    "stiffness",
+                    "proto_ocean",
+                ),
+                scalar_inputs,
+                strict=True,
+            )
+        ),
+        "province_id_out": np.empty(shape, dtype=np.int32),
+        "province_class_out": np.empty(shape, dtype=np.uint8),
+        "crust_age_out": np.empty(shape, dtype=np.float32),
+        "rock_strength_out": np.empty(shape, dtype=np.float32),
+        "accommodation_out": np.empty(shape, dtype=np.float32),
+        "province_confidence_out": np.empty(shape, dtype=np.float32),
+        "boundary_segment_id_out": np.empty((*shape, 4), dtype=np.int32),
+        "boundary_regime_out": np.empty((*shape, 4), dtype=np.uint8),
+        "boundary_confidence_out": np.empty((*shape, 4), dtype=np.float32),
+    }
+
+
+def test_geology_ffi_rejects_overlap_alignment_and_shape():
+    arguments = _ffi_arguments()
+    arguments["rock_strength_out"] = arguments["crust_age_out"]
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_cubed_sphere_geology(**arguments)
+
+    arguments = _ffi_arguments()
+    shape = arguments["crust_age_out"].shape
+    raw = bytearray(int(np.prod(shape)) * np.dtype(np.float32).itemsize + 1)
+    arguments["crust_age_out"] = np.frombuffer(raw, dtype=np.float32, offset=1).reshape(shape)
+    with pytest.raises(ValueError, match="must be aligned"):
+        run_cubed_sphere_geology(**arguments)
+
+    arguments = _ffi_arguments()
+    arguments["margin"] = np.empty((6, 4, 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="must have shape"):
+        run_cubed_sphere_geology(**arguments)
+
+
+def test_geology_requires_cubed_sphere_and_cli_config(tmp_path: Path):
+    rectangular = PipelineConfig.from_mapping(
+        {
+            "topology": "sphere",
+            "resolutions": [{"height": 16, "width": 32}],
+            "run_id": "rectangular-geology",
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+        }
+    )
+    with pytest.raises(NotImplementedError, match="requires topology: cubed_sphere"):
+        ExecutionEngine(rectangular).run(["geology"])
+    with pytest.raises(SystemExit) as error:
+        pipeline_tools_main(["--stage", "geology"])
+    assert error.value.code == 2

--- a/tests/test_pipeline_framework.py
+++ b/tests/test_pipeline_framework.py
@@ -156,7 +156,7 @@ def test_native_fingerprint_change_invalidates_stage_cache(tmp_path: Path, monke
 
     calls = 0
 
-    @stage("native_sensitive")
+    @stage("native_sensitive", native_libraries=("kernel",))
     def native_sensitive(context, deps, config):
         nonlocal calls
         calls += 1
@@ -165,19 +165,47 @@ def test_native_fingerprint_change_invalidates_stage_cache(tmp_path: Path, monke
     monkeypatch.setattr(
         execution,
         "simulation_native_fingerprints",
-        lambda: {"kernel": {"abi_version": 1, "sha256": "a" * 64}},
+        lambda names: {"kernel": {"abi_version": 1, "sha256": "a" * 64}},
     )
     first = ExecutionEngine(_make_config(tmp_path, "fingerprint-a")).run(["native_sensitive"])
     monkeypatch.setattr(
         execution,
         "simulation_native_fingerprints",
-        lambda: {"kernel": {"abi_version": 1, "sha256": "b" * 64}},
+        lambda names: {"kernel": {"abi_version": 1, "sha256": "b" * 64}},
     )
     second = ExecutionEngine(_make_config(tmp_path, "fingerprint-b")).run(["native_sensitive"])
 
     assert calls == 2
     assert first["native_sensitive"].cache_key != second["native_sensitive"].cache_key
     assert not second["native_sensitive"].stats.cache_hit
+
+
+def test_unrelated_native_fingerprint_does_not_invalidate_stage_cache(tmp_path: Path, monkeypatch):
+    import map_maker.pipeline.execution as execution
+
+    calls = 0
+    fingerprints = {
+        "used": {"abi_version": 1, "sha256": "a" * 64},
+        "unrelated": {"abi_version": 1, "sha256": "b" * 64},
+    }
+
+    @stage("scoped_native", native_libraries=("used",))
+    def scoped_native(context, deps, config):
+        nonlocal calls
+        calls += 1
+        return {"value": calls}
+
+    monkeypatch.setattr(
+        execution,
+        "simulation_native_fingerprints",
+        lambda names: {name: fingerprints[name] for name in names},
+    )
+    ExecutionEngine(_make_config(tmp_path, "scoped-a")).run(["scoped_native"])
+    fingerprints["unrelated"] = {"abi_version": 1, "sha256": "c" * 64}
+    second = ExecutionEngine(_make_config(tmp_path, "scoped-b")).run(["scoped_native"])
+
+    assert calls == 1
+    assert second["scoped_native"].stats.cache_hit
 
 
 def test_corrupt_cache_artifact_is_recomputed(tmp_path: Path):

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -52,6 +52,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
     assert manifest["statistics"]["land_fraction"] > 0.0
     assert set(manifest["native_libraries"]) == {
         "erosion_native",
+        "geology_native",
         "tectonics_native",
         "topology_native",
         "world_age_native",


### PR DESCRIPTION
## What changed

- add a `geology_native` Rust crate and safe CFFI binding for connected geological process provinces
- persist province IDs/classes, crust-age priors, rock strength, sediment accommodation, confidence, reciprocal D4 boundary-edge state, and Arrow catalogs
- classify each physical cross-plate edge once, smooth regimes along plate-pair boundaries, and produce coherent connected segment IDs across cube faces
- merge sub-resolution province fragments by spherical area while preserving isolated crust domains such as coarse islands with reduced confidence
- add the `geology` DAG/CLI stage and truth renders for province class, boundary regime, and crust age
- scope stage cache fingerprints to native libraries actually executed by each stage
- update the canonical pipeline/specification and keep spherical erosion explicitly deferred

## Why

Canonical elevation cannot safely derive terrain directly from plate IDs or a continental/oceanic mask without recreating blob continents, plate-wide plateaus, and fixed-width boundary mountains. This milestone creates persistent geological state and provenance for the future elevation/orogeny stage without claiming a completed deep-time simulation.

## Independent review follow-up

The independent review identified four issues, all resolved before publication:

- boundary regimes now live on canonical reciprocal D4 edges rather than disagreeing endpoint cells
- physical-area fragment merging and the seed-11 isolated-island exception are covered by regression tests and a 100-seed reviewer sweep
- the noisy hotspot field no longer emits volcanic provinces; that taxonomy code is reserved
- geology binary changes no longer invalidate unrelated stage caches

## Validation

- `uv run pytest -q` (`81 passed`)
- `cargo test --workspace --locked` (`26 passed`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `uv run ruff check src tests`
- scoped Black and `cargo fmt --check`
- `uv run map-maker validate --config configs/validation.yaml` (`6 worlds passed`)
- canonical 128-per-face catalog audit: 74 connected provinces, 107 connected boundary segments, no mergeable undersized provinces, no one-edge segments
- cube-net truth-render inspection
