### PR TITLE
Add causal cubed-sphere elevation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "elevation_native"
+version = "0.1.0"
+
+[[package]]
 name = "erosion_native"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "src/map_maker/pipeline/native/elevation",
     "src/map_maker/pipeline/native/erosion",
     "src/map_maker/pipeline/native/geology",
     "src/map_maker/pipeline/native/tectonics",
@@ -17,6 +18,9 @@ rust-version = "1.80"
 rand = "0.8.6"
 rand_chacha = "0.3.1"
 rayon = "1.12.0"
+
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
 
 [profile.release]
 lto = "thin"

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -21,3 +21,9 @@ stage_overrides:
     hotspot_scale: 0.9
     isostasy_factor: 0.6
     radiogenic_heat_scale: 1.0
+  elevation:
+    collision_height_m: 5200.0
+    arc_height_m: 2800.0
+    ridge_height_m: 1800.0
+    trench_depth_m: 3600.0
+    rift_depth_m: 950.0

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1013,3 +1013,35 @@ Reuse the current Python stage registry, execution, caching, artifact, and
 visualization concepts while incrementally replacing the current tectonic and
 elevation kernels. Do not rewrite the full pipeline solely to make the project
 Rust-only.
+
+## Decision 021: Causal Pre-Erosion Elevation Components
+
+Status: approved, provisional
+
+Decision:
+Canonical elevation is generated before surface-process erosion as separate,
+inspectable crustal, orogenic, and basin components on the cubed sphere. The
+stage produces an initial bedrock surface and unresolved relief priors; it does
+not finalize sea level or claim eroded landform realism.
+
+Causality rule:
+Broad elevation derives from crust thickness, density, age, buoyancy, and
+subsidence. Localized tectonic relief derives from boundary regime, rate,
+polarity, strength, and angular distance from connected boundary segments.
+Geological province classes may condition those calculations but may not map
+directly to fixed elevations.
+
+Morphology rule:
+Collision belts, volcanic arcs, trenches, ridges, rifts, and transforms use
+distinct cross-strike profiles. Profiles cross cube-face seams through the
+canonical neighbor graph. Long structures receive coherent along-strike
+variation so they do not become uniform walls.
+
+Ownership rule:
+Rust owns graph propagation and component synthesis. Python owns configuration,
+persistence, diagnostics, and cartographic previews.
+
+Failure rule:
+Continental-sized flat plateaus, uniform boundary walls, cube-face seams,
+arbitrary class-to-height painting, and loss of inherited islands are hard
+failures.

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -32,7 +32,9 @@
 11. Mineral and energy systems.
 12. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches stage 4. The older
+The current canonical cubed-sphere implementation reaches stage 5 with a
+causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
+relief-prior artifacts. The older
 rectangular compatibility path runs directly from world age into provisional
 erosion and final rendering; it is reference behavior, not the canonical stage
 order.

--- a/docs/specs/07_elevation.md
+++ b/docs/specs/07_elevation.md
@@ -1,39 +1,113 @@
-# Stage 6 – Elevation Consolidation
+# Canonical Elevation And Orogenic Morphology
+
+## Status
+
+V1 implementation target. This stage creates pre-erosion bedrock elevation on
+the canonical cubed sphere. It does not finalize sea level, coastlines,
+drainage, sediment, or eroded landforms.
 
 ## Purpose
-- Convert erosion outputs into finalized multi-resolution elevation products and derived terrain metrics.
+
+Convert crustal state and geological process evidence into a continuous,
+seam-free initial topographic surface. The result must express broad crustal
+buoyancy, ocean-basin depth, sedimentary accommodation, and localized tectonic
+relief without turning geological labels into fixed elevation classes.
 
 ## Inputs
-- `ElevationRaw`, `SedimentDepth`, `BaseOceanMask`, `Topology`.
-- Config: `smoothing_kernel`, `shelf_depth`, `min_island_size`, `tile_size`, `enable_gpu`.
 
-## Steps (Rust SIMD w/ optional GPU kernels)
-1. **Finalize Sea Level**
-   - Adjust baseline via area-weighted binary search to ensure target ocean fraction (respecting sediment adjustments).
-   - Remove tiny islands below `min_island_size` using connected-component analysis on bit-packed masks.
-2. **Sediment & Bedrock Merge**
-   - Combine raw elevation with sediment depth; clamp bathymetry to non-negative values in place, using fused operations for cache efficiency.
-3. **Derived Metrics**
-   - Compute slope/aspect via gradient kernels (Sobel/Prewitt) implemented in Rust SIMD; GPU path uses Metal compute shader when enabled.
-   - Curvature and relief computed through windowed convolution with sliding tiles to keep cache hot.
-   - Hypsometric statistics derived via parallel histogram over elevation.
-4. **Multi-resolution Outputs**
-   - Downsample using area-weighted averaging (summed-area tables) to produce pyramid levels without re-reading from Python.
-   - Generate hillshade textures (vectorized lighting) and store as uint8 buffers.
-5. **Outputs**
-   - `Elevation` (arena-backed native grid + pyramid handles), `Slope`, `Aspect`, `Relief`, `Hillshade`.
+- Cubed-sphere geometry, cell areas, and reciprocal D4 neighbors.
+- Plate crust type, thickness, density, and motion.
+- Crust thickness, isostatic offset, uplift, subsidence, compression,
+  extension, shear, stiffness, and proto-ocean mask.
+- Crust age, rock strength, sediment accommodation, province confidence,
+  boundary regime, boundary confidence, and boundary segment identity.
+- A deterministic stage seed and versioned morphology parameters.
 
-## Performance
-- Rust SIMD + Rayon path target <1 s for 8 k grid; GPU hillshade optional for faster previews.
-- All computations tile-based to avoid thrashing caches; Python never touches raw buffers.
+## Scientific Model
 
-## Logging
-- Elevation min/max, quartiles.
-- Percentage land vs sea after cleanup.
-- Slope distribution summary, relief histogram, tile throughput (cells/sec).
+Elevation is the sum of independently inspectable causal components:
 
-## Testing
-- Sea-level adjustment achieves configured fraction.
-- Derived metrics match analytic results on test surfaces (plane, cone).
-- Multi-resolution downsampling conserves mean elevation.
-- CPU/GPU paths match within tolerance when both enabled.
+1. **Crustal buoyancy** supplies broad continental freeboard and age-dependent
+   ocean-basin depth from crust thickness, density, and isostatic state.
+2. **Basin subsidence** lowers extensional, sediment-accommodating, and old
+   oceanic crust without forcing all cells in a named basin to one height.
+3. **Orogenic morphology** localizes relief around active process corridors.
+   Collision, subduction, spreading, rifting, and transform regimes use
+   different cross-strike profiles.
+4. **Correlated structural variation** modulates relief coherently along and
+   across belts. It may not introduce cube-face seams or independent per-cell
+   noise.
+
+Geological province classes are evidence and modifiers. They may adjust
+strength, accommodation, confidence, and plausible morphology, but they are
+not elevation bins.
+
+## Boundary Morphology
+
+- Continental collision creates broad, high, asymmetric belts whose amplitude
+  follows compression and whose width responds to lithosphere strength.
+- Continental subduction creates a narrow oceanward trench and an inland
+  volcanic/magmatic arc. The oceanic and continental sides are identified from
+  crust state rather than arbitrary edge ordering.
+- Intra-oceanic subduction creates a trench plus a displaced island-arc ridge.
+- Spreading ridges create broad positive oceanic relief centered on the
+  boundary and age/depth gradients away from it.
+- Continental rifts create an axial depression with lower shoulders and
+  elevated roughness, not a mountain wall.
+- Transform boundaries create narrow, low-amplitude structural relief and may
+  orient later drainage, but do not receive collision-scale uplift.
+
+Boundary influence is propagated by angular distance over the canonical
+neighbor graph. Profiles therefore cross cube-face seams continuously and use
+physical angular widths rather than face-local pixel widths.
+
+## Outputs
+
+- `BedrockElevationM`: signed pre-erosion bedrock elevation relative to the
+  provisional zero datum.
+- `CrustalElevationM`: broad buoyancy and ocean-basin component.
+- `OrogenicElevationM`: collision, arc, ridge, rift-shoulder, and transform
+  contribution.
+- `BasinDepressionM`: positive magnitude subtracted for trenches, rifts, and
+  sediment-accommodating basins.
+- `TerrainReliefM`: unresolved local-relief prior for later refinement and
+  erosion; it is not added wholesale to cell elevation.
+- `ElevationConfidence`: confidence inherited from geological evidence and
+  proximity to constrained structures.
+- `ElevationMetadata`: parameters, component statistics, and model semantics.
+
+## Required Invariants
+
+- Every numeric output is finite and deterministic for identical inputs,
+  seed, software version, and configuration.
+- Reciprocal graph topology produces no cube-face discontinuity.
+- Proto-continental and proto-oceanic area classifications remain distinguishable
+  before final sea-level selection; isolated islands are not deleted here.
+- Collision uplift is statistically concentrated near collision corridors.
+- Subduction trenches occur on oceanic sides and arcs are displaced away from
+  the boundary rather than painted on top of the trench.
+- Stable continental interiors retain substantial elevation variation and may
+  contain basins; continental-sized flat plateaus are a hard visual failure.
+- Orogenic amplitude varies along long boundary segments; uniform walls are a
+  hard visual failure.
+- A geology class alone is insufficient to determine elevation.
+
+## Deferred Work
+
+- Geological-time integration of evolving elevation and sediment load.
+- Flexural/isostatic response to erosion, deposition, ice, and water loading.
+- Drainage-aware erosion, basin filling and overflow, sediment routing, and
+  coastal reworking.
+- Final sea-level solution, shoreline topology, and atlas cartography.
+- Conditional higher-resolution terrain realization and restriction checks.
+
+## Validation
+
+- Analytic synthetic cases for collision, subduction polarity, spreading,
+  rifting, and inactive boundaries.
+- Multi-seed global distributions for continental freeboard, ocean depth,
+  maximum relief, hypsometry, and boundary localization.
+- Seam checks over every cross-face neighbor edge.
+- Correlation checks between causal component fields and their source evidence.
+- Fixed truth-render gallery reviewed for plateaus, polygonal walls, concentric
+  halos, streaks, seam artifacts, and lost islands.

--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,9 @@ uv run map-maker generate --width 1024 --height 512 --seed 8675309
 Rerunning the same configuration reuses the stage cache. The current executable
 stack includes tectonics, crust/world-age fields, erosion/sedimentation, dataset
 persistence, diagnostics, and final cartography. The canonical cubed-sphere path
-now reaches connected geological province and boundary-segment initialization.
-Explicit geological event history, spherical elevation/erosion, routed
+now reaches connected geological provinces, boundary segments, and causal
+pre-erosion elevation/orogenic morphology. Explicit geological event history,
+spherical erosion, routed
 hydrology, climate, soils, biomes, and regional refinement remain implementation
 milestones; the current output is a functional prototype rather than an
 atlas-grade world.
@@ -95,10 +96,10 @@ uv run map-maker topology --face-resolution 96 --output-dir out/topology
 ```
 
 This writes a globally continuous XYZ-colored cube net and a geometry report.
-The canonical tectonic snapshot, age-conditioned crust state, and connected
-geological provinces now run directly on cubed-sphere neighbor IDs. Erosion
-remains on the provisional two-dimensional path and explicitly rejects six-face
-fields.
+The canonical tectonic snapshot, age-conditioned crust state, connected
+geological provinces, and initial elevation now run directly on cubed-sphere
+neighbor IDs. Erosion remains on the provisional two-dimensional path and
+explicitly rejects six-face fields.
 
 Run the previous procedural generator for comparison:
 
@@ -119,6 +120,9 @@ uv run map-maker-pipeline --stage world_age --config configs/cubed_sphere_crust_
 
 # Canonical connected geological provinces and boundary segments
 uv run map-maker-pipeline --stage geology --config configs/cubed_sphere_crust_state.yaml
+
+# Canonical pre-erosion bedrock elevation and orogenic morphology
+uv run map-maker-pipeline --stage elevation --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
 SIMULATION_NATIVE_LIBRARIES = (
+    "elevation_native",
     "erosion_native",
     "geology_native",
     "tectonics_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from ._native import library_filename, workspace_root
 
 NATIVE_LIBRARIES = (
+    "elevation_native",
     "erosion_native",
     "geology_native",
     "tectonics_native",

--- a/src/map_maker/pipeline/_elevation_native.py
+++ b/src/map_maker/pipeline/_elevation_native.py
@@ -1,0 +1,295 @@
+"""Rust-backed bindings for canonical cubed-sphere elevation synthesis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from cffi import FFI
+
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+CUBED_SPHERE_ELEVATION_ABI_VERSION = 1
+
+_CDEF = """
+typedef struct {
+    float elevation_min_m;
+    float elevation_mean_m;
+    float elevation_max_m;
+    float continental_mean_m;
+    float oceanic_mean_m;
+    float maximum_orogenic_m;
+    float maximum_basin_m;
+    double high_mountain_area_fraction;
+    double deep_ocean_area_fraction;
+    double active_relief_area_fraction;
+} ElevationStats;
+
+uint32_t cubed_sphere_elevation_abi_version(void);
+int32_t elevation_run_cubed_sphere(
+    int32_t cell_count,
+    uint64_t seed,
+    float collision_height_m,
+    float arc_height_m,
+    float ridge_height_m,
+    float trench_depth_m,
+    float rift_depth_m,
+    int32_t plate_components,
+    const double* area,
+    const int32_t* neighbors,
+    const float* plate_field,
+    const float* crust_thickness,
+    const float* isostasy,
+    const float* uplift,
+    const float* subsidence,
+    const float* compression,
+    const float* extension,
+    const float* shear,
+    const float* stiffness,
+    const float* proto_ocean,
+    const float* hotspot,
+    const float* crust_age,
+    const float* rock_strength,
+    const float* accommodation,
+    const float* province_confidence,
+    const uint8_t* boundary_regime,
+    const float* boundary_confidence,
+    float* crustal_out,
+    float* orogenic_out,
+    float* basin_out,
+    float* bedrock_out,
+    float* relief_out,
+    float* confidence_out,
+    ElevationStats* stats_out
+);
+"""
+
+
+def _read_array(array: np.ndarray, *, name: str, dtype: np.dtype) -> np.ndarray:
+    value = np.array(array, copy=False)
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must be {dtype}, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    return value
+
+
+def _write_array(array: np.ndarray, *, name: str) -> np.ndarray:
+    value = _read_array(array, name=name, dtype=np.dtype(np.float32))
+    if not value.flags.writeable:
+        raise ValueError(f"{name} must be writable")
+    return value
+
+
+def _require_disjoint(inputs: dict[str, np.ndarray], outputs: dict[str, np.ndarray]) -> None:
+    output_items = list(outputs.items())
+    for index, (first_name, first) in enumerate(output_items):
+        for second_name, second in output_items[index + 1 :]:
+            if np.shares_memory(first, second):
+                raise ValueError(f"{first_name} and {second_name} buffers must not overlap")
+        for input_name, input_array in inputs.items():
+            if np.shares_memory(first, input_array):
+                raise ValueError(f"{first_name} and {input_name} buffers must not overlap")
+
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+native_library_info("elevation_native")
+_lib = _ffi.dlopen(str(native_library_path("elevation_native")))
+try:
+    _cubed_sphere_abi = int(_lib.cubed_sphere_elevation_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "elevation_native lacks the cubed-sphere API; rebuild native libraries"
+    ) from exc
+if _cubed_sphere_abi != CUBED_SPHERE_ELEVATION_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "elevation_native cubed-sphere ABI "
+        f"{_cubed_sphere_abi} does not match expected {CUBED_SPHERE_ELEVATION_ABI_VERSION}"
+    )
+
+
+def run_cubed_sphere_elevation(
+    *,
+    seed: int,
+    collision_height_m: float,
+    arc_height_m: float,
+    ridge_height_m: float,
+    trench_depth_m: float,
+    rift_depth_m: float,
+    areas: np.ndarray,
+    neighbors: np.ndarray,
+    plate_field: np.ndarray,
+    crust_thickness: np.ndarray,
+    isostasy: np.ndarray,
+    uplift: np.ndarray,
+    subsidence: np.ndarray,
+    compression: np.ndarray,
+    extension: np.ndarray,
+    shear: np.ndarray,
+    stiffness: np.ndarray,
+    proto_ocean: np.ndarray,
+    hotspot: np.ndarray,
+    crust_age: np.ndarray,
+    rock_strength: np.ndarray,
+    accommodation: np.ndarray,
+    province_confidence: np.ndarray,
+    boundary_regime: np.ndarray,
+    boundary_confidence: np.ndarray,
+    crustal_out: np.ndarray,
+    orogenic_out: np.ndarray,
+    basin_out: np.ndarray,
+    bedrock_out: np.ndarray,
+    relief_out: np.ndarray,
+    confidence_out: np.ndarray,
+) -> dict[str, Any]:
+    area_array = np.require(areas, dtype=np.float64, requirements=["C", "A"])
+    neighbor_array = np.require(neighbors, dtype=np.int32, requirements=["C", "A"])
+    if (
+        area_array.ndim != 3
+        or area_array.shape[0] != 6
+        or area_array.shape[1] != area_array.shape[2]
+    ):
+        raise ValueError("areas must have shape (6, n, n)")
+    shape = area_array.shape
+    edge_shape = (*shape, 4)
+    if neighbor_array.shape != edge_shape:
+        raise ValueError(f"neighbors must have shape {edge_shape}")
+
+    plate_array = _read_array(plate_field, name="plate_field", dtype=np.dtype(np.float32))
+    if plate_array.ndim != 4 or plate_array.shape[:3] != shape or plate_array.shape[3] < 4:
+        raise ValueError(f"plate_field must have shape {(*shape, 4)} or more components")
+
+    scalar_inputs = {
+        name: _read_array(array, name=name, dtype=np.dtype(np.float32))
+        for name, array in {
+            "crust_thickness": crust_thickness,
+            "isostasy": isostasy,
+            "uplift": uplift,
+            "subsidence": subsidence,
+            "compression": compression,
+            "extension": extension,
+            "shear": shear,
+            "stiffness": stiffness,
+            "proto_ocean": proto_ocean,
+            "hotspot": hotspot,
+            "crust_age": crust_age,
+            "rock_strength": rock_strength,
+            "accommodation": accommodation,
+            "province_confidence": province_confidence,
+        }.items()
+    }
+    for name, array in scalar_inputs.items():
+        if array.shape != shape:
+            raise ValueError(f"{name} must have shape {shape}")
+    regime_array = _read_array(boundary_regime, name="boundary_regime", dtype=np.dtype(np.uint8))
+    boundary_confidence_array = _read_array(
+        boundary_confidence, name="boundary_confidence", dtype=np.dtype(np.float32)
+    )
+    if regime_array.shape != edge_shape:
+        raise ValueError(f"boundary_regime must have shape {edge_shape}")
+    if boundary_confidence_array.shape != edge_shape:
+        raise ValueError(f"boundary_confidence must have shape {edge_shape}")
+
+    output_arrays = {
+        name: _write_array(array, name=name)
+        for name, array in {
+            "crustal_out": crustal_out,
+            "orogenic_out": orogenic_out,
+            "basin_out": basin_out,
+            "bedrock_out": bedrock_out,
+            "relief_out": relief_out,
+            "confidence_out": confidence_out,
+        }.items()
+    }
+    for name, array in output_arrays.items():
+        if array.shape != shape:
+            raise ValueError(f"{name} must have shape {shape}")
+
+    all_inputs = {
+        "areas": area_array,
+        "neighbors": neighbor_array,
+        "plate_field": plate_array,
+        "boundary_regime": regime_array,
+        "boundary_confidence": boundary_confidence_array,
+        **scalar_inputs,
+    }
+    _require_disjoint(all_inputs, output_arrays)
+
+    stats = _ffi.new("ElevationStats*")
+    status = int(
+        _lib.elevation_run_cubed_sphere(
+            int(np.prod(shape, dtype=np.int64)),
+            int(seed) & ((1 << 64) - 1),
+            float(collision_height_m),
+            float(arc_height_m),
+            float(ridge_height_m),
+            float(trench_depth_m),
+            float(rift_depth_m),
+            int(plate_array.shape[-1]),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", area_array)),
+            _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", neighbor_array)),
+            _ffi.cast("float*", _ffi.from_buffer("float[]", plate_array)),
+            *(
+                _ffi.cast("float*", _ffi.from_buffer("float[]", scalar_inputs[name]))
+                for name in (
+                    "crust_thickness",
+                    "isostasy",
+                    "uplift",
+                    "subsidence",
+                    "compression",
+                    "extension",
+                    "shear",
+                    "stiffness",
+                    "proto_ocean",
+                    "hotspot",
+                    "crust_age",
+                    "rock_strength",
+                    "accommodation",
+                    "province_confidence",
+                )
+            ),
+            _ffi.cast("uint8_t*", _ffi.from_buffer("uint8_t[]", regime_array)),
+            _ffi.cast("float*", _ffi.from_buffer("float[]", boundary_confidence_array)),
+            *(
+                _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays[name]))
+                for name in (
+                    "crustal_out",
+                    "orogenic_out",
+                    "basin_out",
+                    "bedrock_out",
+                    "relief_out",
+                    "confidence_out",
+                )
+            ),
+            stats,
+        )
+    )
+    if status != 0:
+        messages = {
+            1: "invalid dimensions or null buffers",
+            2: "invalid morphology parameters",
+            3: "non-finite numeric inputs",
+            4: "invalid cubed-sphere topology",
+        }
+        raise ValueError(
+            f"cubed-sphere elevation kernel failed: {messages.get(status, f'status {status}')}"
+        )
+
+    return {
+        "elevation_min_m": float(stats.elevation_min_m),
+        "elevation_mean_m": float(stats.elevation_mean_m),
+        "elevation_max_m": float(stats.elevation_max_m),
+        "continental_mean_m": float(stats.continental_mean_m),
+        "oceanic_mean_m": float(stats.oceanic_mean_m),
+        "maximum_orogenic_m": float(stats.maximum_orogenic_m),
+        "maximum_basin_m": float(stats.maximum_basin_m),
+        "high_mountain_area_fraction": float(stats.high_mountain_area_fraction),
+        "deep_ocean_area_fraction": float(stats.deep_ocean_area_fraction),
+        "active_relief_area_fraction": float(stats.active_relief_area_fraction),
+    }
+
+
+__all__ = ["CUBED_SPHERE_ELEVATION_ABI_VERSION", "run_cubed_sphere_elevation"]

--- a/src/map_maker/pipeline/native/elevation/Cargo.toml
+++ b/src/map_maker/pipeline/native/elevation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "elevation_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/elevation/src/lib.rs
+++ b/src/map_maker/pipeline/native/elevation/src/lib.rs
@@ -1,0 +1,779 @@
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::slice;
+
+const D4_NEIGHBORS: usize = 4;
+const EARTH_RADIUS_KM: f32 = 6371.0;
+
+const REGIME_CONTINENTAL_COLLISION: u8 = 2;
+const REGIME_SUBDUCTION_MARGIN: u8 = 3;
+const REGIME_INTRA_OCEANIC_SUBDUCTION: u8 = 4;
+const REGIME_CONTINENTAL_RIFT: u8 = 5;
+const REGIME_SPREADING_RIDGE: u8 = 6;
+const REGIME_TRANSFORM: u8 = 7;
+
+#[repr(C)]
+pub struct ElevationStats {
+    pub elevation_min_m: f32,
+    pub elevation_mean_m: f32,
+    pub elevation_max_m: f32,
+    pub continental_mean_m: f32,
+    pub oceanic_mean_m: f32,
+    pub maximum_orogenic_m: f32,
+    pub maximum_basin_m: f32,
+    pub high_mountain_area_fraction: f64,
+    pub deep_ocean_area_fraction: f64,
+    pub active_relief_area_fraction: f64,
+}
+
+#[derive(Clone, Copy)]
+struct QueueEntry {
+    distance: f64,
+    cell: usize,
+}
+
+impl PartialEq for QueueEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.cell == other.cell && self.distance.to_bits() == other.distance.to_bits()
+    }
+}
+
+impl Eq for QueueEntry {}
+
+impl PartialOrd for QueueEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for QueueEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .distance
+            .total_cmp(&self.distance)
+            .then_with(|| other.cell.cmp(&self.cell))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn elevation_native_abi_version() -> u32 {
+    2
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_elevation_abi_version() -> u32 {
+    1
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}
+
+fn random_signed(seed: u64, cell: usize) -> f32 {
+    let bits = splitmix64(seed ^ (cell as u64).wrapping_mul(0xD6E8_FEB8_6659_FD93));
+    let unit = (bits >> 40) as f32 / ((1u32 << 24) - 1) as f32;
+    unit * 2.0 - 1.0
+}
+
+fn smooth_graph(values: &mut [f32], neighbors: &[i32], passes: usize) {
+    let mut next = vec![0.0f32; values.len()];
+    for _ in 0..passes {
+        for cell in 0..values.len() {
+            let adjacent_sum: f32 = neighbors[cell * D4_NEIGHBORS..(cell + 1) * D4_NEIGHBORS]
+                .iter()
+                .map(|neighbor| values[*neighbor as usize])
+                .sum();
+            next[cell] = values[cell] * 0.5 + adjacent_sum * 0.125;
+        }
+        values.copy_from_slice(&next);
+    }
+}
+
+fn normalized_noise(seed: u64, areas: &[f64], neighbors: &[i32]) -> Vec<f32> {
+    let mut broad: Vec<f32> = (0..areas.len())
+        .map(|cell| random_signed(seed ^ 0xA076_1D64_78BD_642F, cell))
+        .collect();
+    let mut medium: Vec<f32> = (0..areas.len())
+        .map(|cell| random_signed(seed ^ 0xE703_7ED1_A0B4_28DB, cell))
+        .collect();
+    smooth_graph(&mut broad, neighbors, 36);
+    smooth_graph(&mut medium, neighbors, 9);
+    let mut result: Vec<f32> = broad
+        .iter()
+        .zip(medium.iter())
+        .map(|(low, mid)| 0.72 * low + 0.28 * mid)
+        .collect();
+    let area_total: f64 = areas.iter().sum();
+    let mean = result
+        .iter()
+        .zip(areas.iter())
+        .map(|(value, area)| *value as f64 * *area)
+        .sum::<f64>()
+        / area_total;
+    let variance = result
+        .iter()
+        .zip(areas.iter())
+        .map(|(value, area)| {
+            let centered = *value as f64 - mean;
+            centered * centered * *area
+        })
+        .sum::<f64>()
+        / area_total;
+    let scale = variance.sqrt().max(1e-8) as f32;
+    for value in &mut result {
+        *value = (((*value - mean as f32) / scale) * 0.72).tanh();
+    }
+    result
+}
+
+fn nearest_source(
+    source_strength: &[f32],
+    plate_ids: &[i32],
+    neighbors: &[i32],
+    areas: &[f64],
+) -> (Vec<f32>, Vec<f32>) {
+    let mut distances = vec![f64::INFINITY; source_strength.len()];
+    let mut amplitudes = vec![0.0f32; source_strength.len()];
+    let mut queue = BinaryHeap::new();
+    for (cell, strength) in source_strength.iter().enumerate() {
+        if *strength > 0.0 {
+            distances[cell] = 0.0;
+            amplitudes[cell] = *strength;
+            queue.push(QueueEntry {
+                distance: 0.0,
+                cell,
+            });
+        }
+    }
+    while let Some(entry) = queue.pop() {
+        if entry.distance > distances[entry.cell] + 1e-12 {
+            continue;
+        }
+        for neighbor in &neighbors[entry.cell * D4_NEIGHBORS..(entry.cell + 1) * D4_NEIGHBORS] {
+            let target = *neighbor as usize;
+            if plate_ids[target] != plate_ids[entry.cell] {
+                continue;
+            }
+            let step = 0.5 * (areas[entry.cell].sqrt() + areas[target].sqrt());
+            let candidate = entry.distance + step;
+            let improved = candidate + 1e-12 < distances[target];
+            let tied_but_stronger = (candidate - distances[target]).abs() <= 1e-12
+                && amplitudes[entry.cell] > amplitudes[target];
+            if improved || tied_but_stronger {
+                distances[target] = candidate;
+                amplitudes[target] = amplitudes[entry.cell];
+                queue.push(QueueEntry {
+                    distance: candidate,
+                    cell: target,
+                });
+            }
+        }
+    }
+    (
+        distances
+            .into_iter()
+            .map(|value| value.min(f32::MAX as f64) as f32)
+            .collect(),
+        amplitudes,
+    )
+}
+
+fn gaussian(distance: f32, center: f32, sigma: f32) -> f32 {
+    if !distance.is_finite() {
+        return 0.0;
+    }
+    let z = (distance - center) / sigma.max(1e-6);
+    (-0.5 * z * z).exp()
+}
+
+fn km_to_radians(km: f32) -> f32 {
+    km / EARTH_RADIUS_KM
+}
+
+fn update_source(source: &mut [f32], cell: usize, value: f32) {
+    source[cell] = source[cell].max(value.clamp(0.0, 1.0));
+}
+
+fn finite_slice(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn run_elevation(
+    total: usize,
+    seed: u64,
+    collision_height_m: f32,
+    arc_height_m: f32,
+    ridge_height_m: f32,
+    trench_depth_m: f32,
+    rift_depth_m: f32,
+    areas: &[f64],
+    neighbors: &[i32],
+    plate_field: &[f32],
+    plate_components: usize,
+    crust_thickness: &[f32],
+    isostasy: &[f32],
+    uplift: &[f32],
+    subsidence: &[f32],
+    compression: &[f32],
+    extension: &[f32],
+    shear: &[f32],
+    stiffness: &[f32],
+    proto_ocean: &[f32],
+    hotspot: &[f32],
+    crust_age: &[f32],
+    rock_strength: &[f32],
+    accommodation: &[f32],
+    province_confidence: &[f32],
+    boundary_regime: &[u8],
+    boundary_confidence: &[f32],
+    crustal_out: &mut [f32],
+    orogenic_out: &mut [f32],
+    basin_out: &mut [f32],
+    bedrock_out: &mut [f32],
+    relief_out: &mut [f32],
+    confidence_out: &mut [f32],
+) -> ElevationStats {
+    let plate_ids: Vec<i32> = plate_field
+        .chunks_exact(plate_components)
+        .map(|plate| plate[0].round() as i32)
+        .collect();
+    let continental: Vec<bool> = proto_ocean.iter().map(|value| *value < 0.5).collect();
+    let mut land_area = 0.0f64;
+    let mut ocean_area = 0.0f64;
+    let mut land_isostasy = 0.0f64;
+    let mut ocean_isostasy = 0.0f64;
+    let mut land_thickness = 0.0f64;
+    let mut ocean_thickness = 0.0f64;
+    for cell in 0..total {
+        if continental[cell] {
+            land_area += areas[cell];
+            land_isostasy += isostasy[cell] as f64 * areas[cell];
+            land_thickness += crust_thickness[cell] as f64 * areas[cell];
+        } else {
+            ocean_area += areas[cell];
+            ocean_isostasy += isostasy[cell] as f64 * areas[cell];
+            ocean_thickness += crust_thickness[cell] as f64 * areas[cell];
+        }
+    }
+    let mean_land_iso = (land_isostasy / land_area.max(f64::EPSILON)) as f32;
+    let mean_ocean_iso = (ocean_isostasy / ocean_area.max(f64::EPSILON)) as f32;
+    let mean_land_thickness = (land_thickness / land_area.max(f64::EPSILON)) as f32;
+    let mean_ocean_thickness = (ocean_thickness / ocean_area.max(f64::EPSILON)) as f32;
+
+    let mut collision = vec![0.0f32; total];
+    let mut descending = vec![0.0f32; total];
+    let mut overriding = vec![0.0f32; total];
+    let mut ridge = vec![0.0f32; total];
+    let mut rift = vec![0.0f32; total];
+    let mut transform = vec![0.0f32; total];
+
+    for source in 0..total {
+        for slot in 0..D4_NEIGHBORS {
+            let target = neighbors[source * D4_NEIGHBORS + slot] as usize;
+            if source >= target {
+                continue;
+            }
+            let edge = source * D4_NEIGHBORS + slot;
+            let regime = boundary_regime[edge];
+            let confidence = boundary_confidence[edge].clamp(0.0, 1.0);
+            if confidence <= 0.0 {
+                continue;
+            }
+            let compression_signal = (0.45
+                + 0.35 * (compression[source] + compression[target])
+                + 0.10 * (uplift[source] + uplift[target]))
+                .clamp(0.0, 1.0);
+            let extension_signal =
+                (0.45 + 0.40 * (extension[source] + extension[target])).clamp(0.0, 1.0);
+            let shear_signal = (0.35 + 0.45 * (shear[source] + shear[target])).clamp(0.0, 1.0);
+            match regime {
+                REGIME_CONTINENTAL_COLLISION => {
+                    update_source(&mut collision, source, confidence * compression_signal);
+                    update_source(&mut collision, target, confidence * compression_signal);
+                }
+                REGIME_SUBDUCTION_MARGIN | REGIME_INTRA_OCEANIC_SUBDUCTION => {
+                    let source_ocean = !continental[source];
+                    let target_ocean = !continental[target];
+                    let source_density = plate_field[source * plate_components + 3];
+                    let target_density = plate_field[target * plate_components + 3];
+                    let source_descends = if source_ocean != target_ocean {
+                        source_ocean
+                    } else if (crust_age[source] - crust_age[target]).abs() > 1e-6 {
+                        crust_age[source] > crust_age[target]
+                    } else {
+                        source_density >= target_density
+                    };
+                    let (down, over) = if source_descends {
+                        (source, target)
+                    } else {
+                        (target, source)
+                    };
+                    update_source(&mut descending, down, confidence * compression_signal);
+                    update_source(&mut overriding, over, confidence * compression_signal);
+                }
+                REGIME_SPREADING_RIDGE => {
+                    update_source(&mut ridge, source, confidence * extension_signal);
+                    update_source(&mut ridge, target, confidence * extension_signal);
+                }
+                REGIME_CONTINENTAL_RIFT => {
+                    update_source(&mut rift, source, confidence * extension_signal);
+                    update_source(&mut rift, target, confidence * extension_signal);
+                }
+                REGIME_TRANSFORM => {
+                    update_source(&mut transform, source, confidence * shear_signal);
+                    update_source(&mut transform, target, confidence * shear_signal);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let (collision_distance, collision_strength) =
+        nearest_source(&collision, &plate_ids, neighbors, areas);
+    let (descending_distance, descending_strength) =
+        nearest_source(&descending, &plate_ids, neighbors, areas);
+    let (overriding_distance, overriding_strength) =
+        nearest_source(&overriding, &plate_ids, neighbors, areas);
+    let (ridge_distance, ridge_strength) = nearest_source(&ridge, &plate_ids, neighbors, areas);
+    let (rift_distance, rift_strength) = nearest_source(&rift, &plate_ids, neighbors, areas);
+    let (transform_distance, transform_strength) =
+        nearest_source(&transform, &plate_ids, neighbors, areas);
+    let noise = normalized_noise(seed, areas, neighbors);
+    let mut regional_compression = compression.to_vec();
+    smooth_graph(&mut regional_compression, neighbors, 14);
+
+    let mut elevation_min = f32::INFINITY;
+    let mut elevation_max = f32::NEG_INFINITY;
+    let mut elevation_sum = 0.0f64;
+    let mut continental_sum = 0.0f64;
+    let mut oceanic_sum = 0.0f64;
+    let mut high_area = 0.0f64;
+    let mut deep_area = 0.0f64;
+    let mut active_area = 0.0f64;
+    let mut maximum_orogenic = 0.0f32;
+    let mut maximum_basin = 0.0f32;
+    let total_area = land_area + ocean_area;
+
+    for cell in 0..total {
+        let structural_variation = noise[cell];
+        let corridor_variation = (0.72 + 0.28 * structural_variation).clamp(0.44, 1.0);
+        let crustal = if continental[cell] {
+            320.0
+                + (isostasy[cell] - mean_land_iso) * 620.0
+                + (crust_thickness[cell] - mean_land_thickness) * 52.0
+        } else {
+            let age_factor = (crust_age[cell].max(0.0) / 0.25).clamp(0.0, 1.0).sqrt();
+            -2650.0 - age_factor * 2450.0
+                + (isostasy[cell] - mean_ocean_iso) * 420.0
+                + (crust_thickness[cell] - mean_ocean_thickness) * 70.0
+        };
+
+        let collision_width = km_to_radians(230.0 + 170.0 * stiffness[cell]);
+        let collision_offset = km_to_radians(95.0 * structural_variation);
+        let collision_relief = collision_height_m
+            * collision_strength[cell]
+            * gaussian(
+                collision_distance[cell],
+                collision_offset.max(0.0),
+                collision_width,
+            )
+            * (0.78 + 0.34 * structural_variation);
+        let arc_center =
+            if continental[cell] { 190.0 } else { 145.0 } + 55.0 * structural_variation;
+        let arc_width = if continental[cell] { 115.0 } else { 82.0 };
+        let arc_relief = arc_height_m
+            * overriding_strength[cell]
+            * gaussian(
+                overriding_distance[cell],
+                km_to_radians(arc_center),
+                km_to_radians(arc_width),
+            )
+            * (0.76 + 0.42 * structural_variation);
+        let ridge_relief = if continental[cell] {
+            0.0
+        } else {
+            ridge_height_m
+                * ridge_strength[cell]
+                * gaussian(
+                    ridge_distance[cell],
+                    km_to_radians((55.0 + 45.0 * structural_variation).max(0.0)),
+                    km_to_radians(240.0),
+                )
+                * corridor_variation
+        };
+        let rift_shoulder = rift_depth_m
+            * 0.42
+            * rift_strength[cell]
+            * gaussian(
+                rift_distance[cell],
+                km_to_radians(220.0),
+                km_to_radians(115.0),
+            );
+        let transform_relief = 420.0
+            * transform_strength[cell]
+            * gaussian(transform_distance[cell], 0.0, km_to_radians(85.0))
+            * (0.55 + 0.45 * structural_variation.abs());
+        let volcanic_relief = hotspot[cell].clamp(0.0, 1.0)
+            * if continental[cell] { 1050.0 } else { 1750.0 }
+            * (0.72 + 0.34 * structural_variation);
+        let distributed_compression = if continental[cell] {
+            let compression_factor = (regional_compression[cell].clamp(0.0, 1.0) / 0.18)
+                .clamp(0.0, 1.0)
+                .powf(1.05);
+            3000.0
+                * compression_factor
+                * (0.62 + 0.38 * uplift[cell].clamp(0.0, 1.0))
+                * (0.76 + 0.32 * structural_variation)
+        } else {
+            0.0
+        };
+        let orogenic = (collision_relief
+            + arc_relief
+            + ridge_relief
+            + rift_shoulder
+            + transform_relief
+            + volcanic_relief)
+            .max(distributed_compression)
+            .max(0.0);
+
+        let accommodation_depth = accommodation[cell].clamp(0.0, 1.0)
+            * if continental[cell] { 1250.0 } else { 520.0 }
+            * (0.45 + 0.55 * subsidence[cell].clamp(0.0, 1.0));
+        let extension_depth = if continental[cell] {
+            extension[cell].clamp(0.0, 1.0) * 380.0
+        } else {
+            subsidence[cell].clamp(0.0, 1.0) * 320.0
+        };
+        let trench = trench_depth_m
+            * descending_strength[cell]
+            * gaussian(
+                descending_distance[cell],
+                km_to_radians((75.0 + 42.0 * structural_variation).max(20.0)),
+                km_to_radians(108.0),
+            )
+            * corridor_variation;
+        let forearc = trench_depth_m
+            * 0.13
+            * overriding_strength[cell]
+            * gaussian(
+                overriding_distance[cell],
+                km_to_radians(55.0),
+                km_to_radians(48.0),
+            );
+        let rift_axis = rift_depth_m
+            * rift_strength[cell]
+            * gaussian(
+                rift_distance[cell],
+                km_to_radians((48.0 + 42.0 * structural_variation).max(0.0)),
+                km_to_radians(145.0),
+            )
+            * corridor_variation;
+        let basin = (accommodation_depth + extension_depth + trench + forearc + rift_axis).max(0.0);
+
+        let background_amplitude = if continental[cell] {
+            210.0 + 430.0 * (1.0 - rock_strength[cell].clamp(0.0, 1.0))
+        } else {
+            85.0 + 95.0 * shear[cell].clamp(0.0, 1.0)
+        };
+        let background =
+            structural_variation * (background_amplitude + 0.055 * orogenic + 0.025 * basin);
+        let bedrock = crustal + orogenic - basin + background;
+        let relief = (if continental[cell] { 120.0 } else { 75.0 }
+            + 0.22 * orogenic
+            + 0.10 * basin
+            + 360.0 * shear[cell].clamp(0.0, 1.0)
+            + 260.0 * (1.0 - rock_strength[cell].clamp(0.0, 1.0)))
+        .clamp(50.0, 2200.0);
+        let boundary_evidence = (collision_strength[cell]
+            * gaussian(collision_distance[cell], 0.0, km_to_radians(700.0)))
+        .max(
+            descending_strength[cell]
+                * gaussian(descending_distance[cell], 0.0, km_to_radians(420.0)),
+        )
+        .max(
+            overriding_strength[cell]
+                * gaussian(overriding_distance[cell], 0.0, km_to_radians(520.0)),
+        )
+        .max(ridge_strength[cell] * gaussian(ridge_distance[cell], 0.0, km_to_radians(520.0)))
+        .max(rift_strength[cell] * gaussian(rift_distance[cell], 0.0, km_to_radians(420.0)))
+        .max(
+            transform_strength[cell]
+                * gaussian(transform_distance[cell], 0.0, km_to_radians(260.0)),
+        );
+        let confidence =
+            (0.28 + 0.57 * province_confidence[cell].clamp(0.0, 1.0) + 0.15 * boundary_evidence)
+                .clamp(0.0, 1.0);
+
+        crustal_out[cell] = crustal;
+        orogenic_out[cell] = orogenic;
+        basin_out[cell] = basin;
+        bedrock_out[cell] = bedrock;
+        relief_out[cell] = relief;
+        confidence_out[cell] = confidence;
+
+        elevation_min = elevation_min.min(bedrock);
+        elevation_max = elevation_max.max(bedrock);
+        elevation_sum += bedrock as f64 * areas[cell];
+        maximum_orogenic = maximum_orogenic.max(orogenic);
+        maximum_basin = maximum_basin.max(basin);
+        if continental[cell] {
+            continental_sum += bedrock as f64 * areas[cell];
+        } else {
+            oceanic_sum += bedrock as f64 * areas[cell];
+        }
+        if bedrock > 3000.0 {
+            high_area += areas[cell];
+        }
+        if bedrock < -5000.0 {
+            deep_area += areas[cell];
+        }
+        if orogenic > 250.0 || basin > 400.0 {
+            active_area += areas[cell];
+        }
+    }
+
+    ElevationStats {
+        elevation_min_m: elevation_min,
+        elevation_mean_m: (elevation_sum / total_area) as f32,
+        elevation_max_m: elevation_max,
+        continental_mean_m: (continental_sum / land_area.max(f64::EPSILON)) as f32,
+        oceanic_mean_m: (oceanic_sum / ocean_area.max(f64::EPSILON)) as f32,
+        maximum_orogenic_m: maximum_orogenic,
+        maximum_basin_m: maximum_basin,
+        high_mountain_area_fraction: high_area / total_area,
+        deep_ocean_area_fraction: deep_area / total_area,
+        active_relief_area_fraction: active_area / total_area,
+    }
+}
+
+/// Generate causal pre-erosion elevation on canonical cubed-sphere cells.
+///
+/// Returns 0 on success, 1 for invalid dimensions or pointers, 2 for invalid
+/// parameters, 3 for invalid numeric inputs, and 4 for invalid topology.
+///
+/// # Safety
+///
+/// Every input pointer must reference a readable buffer of the length implied
+/// by `cell_count` and `plate_components`. Every output pointer must reference
+/// a distinct writable `cell_count`-element buffer and must not alias any input
+/// or other output. `stats_out` may be null or must reference one writable
+/// `ElevationStats` value. Neighbor IDs must be valid global cell indices.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn elevation_run_cubed_sphere(
+    cell_count: i32,
+    seed: u64,
+    collision_height_m: f32,
+    arc_height_m: f32,
+    ridge_height_m: f32,
+    trench_depth_m: f32,
+    rift_depth_m: f32,
+    plate_components: i32,
+    area_ptr: *const f64,
+    neighbors_ptr: *const i32,
+    plate_ptr: *const f32,
+    crust_thickness_ptr: *const f32,
+    isostasy_ptr: *const f32,
+    uplift_ptr: *const f32,
+    subsidence_ptr: *const f32,
+    compression_ptr: *const f32,
+    extension_ptr: *const f32,
+    shear_ptr: *const f32,
+    stiffness_ptr: *const f32,
+    proto_ocean_ptr: *const f32,
+    hotspot_ptr: *const f32,
+    crust_age_ptr: *const f32,
+    rock_strength_ptr: *const f32,
+    accommodation_ptr: *const f32,
+    province_confidence_ptr: *const f32,
+    boundary_regime_ptr: *const u8,
+    boundary_confidence_ptr: *const f32,
+    crustal_out_ptr: *mut f32,
+    orogenic_out_ptr: *mut f32,
+    basin_out_ptr: *mut f32,
+    bedrock_out_ptr: *mut f32,
+    relief_out_ptr: *mut f32,
+    confidence_out_ptr: *mut f32,
+    stats_out: *mut ElevationStats,
+) -> i32 {
+    if cell_count <= 0
+        || plate_components < 4
+        || area_ptr.is_null()
+        || neighbors_ptr.is_null()
+        || plate_ptr.is_null()
+        || crust_thickness_ptr.is_null()
+        || isostasy_ptr.is_null()
+        || uplift_ptr.is_null()
+        || subsidence_ptr.is_null()
+        || compression_ptr.is_null()
+        || extension_ptr.is_null()
+        || shear_ptr.is_null()
+        || stiffness_ptr.is_null()
+        || proto_ocean_ptr.is_null()
+        || hotspot_ptr.is_null()
+        || crust_age_ptr.is_null()
+        || rock_strength_ptr.is_null()
+        || accommodation_ptr.is_null()
+        || province_confidence_ptr.is_null()
+        || boundary_regime_ptr.is_null()
+        || boundary_confidence_ptr.is_null()
+        || crustal_out_ptr.is_null()
+        || orogenic_out_ptr.is_null()
+        || basin_out_ptr.is_null()
+        || bedrock_out_ptr.is_null()
+        || relief_out_ptr.is_null()
+        || confidence_out_ptr.is_null()
+    {
+        return 1;
+    }
+    let parameters = [
+        collision_height_m,
+        arc_height_m,
+        ridge_height_m,
+        trench_depth_m,
+        rift_depth_m,
+    ];
+    if parameters
+        .iter()
+        .any(|value| !value.is_finite() || *value < 0.0 || *value > 20_000.0)
+    {
+        return 2;
+    }
+
+    let total = cell_count as usize;
+    let components = plate_components as usize;
+    let edge_len = match total.checked_mul(D4_NEIGHBORS) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let plate_len = match total.checked_mul(components) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let areas = unsafe { slice::from_raw_parts(area_ptr, total) };
+    let neighbors = unsafe { slice::from_raw_parts(neighbors_ptr, edge_len) };
+    let plate_field = unsafe { slice::from_raw_parts(plate_ptr, plate_len) };
+    let crust_thickness = unsafe { slice::from_raw_parts(crust_thickness_ptr, total) };
+    let isostasy = unsafe { slice::from_raw_parts(isostasy_ptr, total) };
+    let uplift = unsafe { slice::from_raw_parts(uplift_ptr, total) };
+    let subsidence = unsafe { slice::from_raw_parts(subsidence_ptr, total) };
+    let compression = unsafe { slice::from_raw_parts(compression_ptr, total) };
+    let extension = unsafe { slice::from_raw_parts(extension_ptr, total) };
+    let shear = unsafe { slice::from_raw_parts(shear_ptr, total) };
+    let stiffness = unsafe { slice::from_raw_parts(stiffness_ptr, total) };
+    let proto_ocean = unsafe { slice::from_raw_parts(proto_ocean_ptr, total) };
+    let hotspot = unsafe { slice::from_raw_parts(hotspot_ptr, total) };
+    let crust_age = unsafe { slice::from_raw_parts(crust_age_ptr, total) };
+    let rock_strength = unsafe { slice::from_raw_parts(rock_strength_ptr, total) };
+    let accommodation = unsafe { slice::from_raw_parts(accommodation_ptr, total) };
+    let province_confidence = unsafe { slice::from_raw_parts(province_confidence_ptr, total) };
+    let boundary_regime = unsafe { slice::from_raw_parts(boundary_regime_ptr, edge_len) };
+    let boundary_confidence = unsafe { slice::from_raw_parts(boundary_confidence_ptr, edge_len) };
+
+    if areas.iter().any(|area| !area.is_finite() || *area <= 0.0)
+        || plate_field.iter().any(|value| !value.is_finite())
+        || [
+            crust_thickness,
+            isostasy,
+            uplift,
+            subsidence,
+            compression,
+            extension,
+            shear,
+            stiffness,
+            proto_ocean,
+            hotspot,
+            crust_age,
+            rock_strength,
+            accommodation,
+            province_confidence,
+            boundary_confidence,
+        ]
+        .iter()
+        .any(|values| !finite_slice(values))
+    {
+        return 3;
+    }
+    for cell in 0..total {
+        let mut unique = [0i32; D4_NEIGHBORS];
+        unique.copy_from_slice(&neighbors[cell * D4_NEIGHBORS..(cell + 1) * D4_NEIGHBORS]);
+        unique.sort_unstable();
+        if unique.windows(2).any(|pair| pair[0] == pair[1])
+            || unique
+                .iter()
+                .any(|neighbor| *neighbor < 0 || *neighbor as usize >= total)
+        {
+            return 4;
+        }
+    }
+
+    let crustal_out = unsafe { slice::from_raw_parts_mut(crustal_out_ptr, total) };
+    let orogenic_out = unsafe { slice::from_raw_parts_mut(orogenic_out_ptr, total) };
+    let basin_out = unsafe { slice::from_raw_parts_mut(basin_out_ptr, total) };
+    let bedrock_out = unsafe { slice::from_raw_parts_mut(bedrock_out_ptr, total) };
+    let relief_out = unsafe { slice::from_raw_parts_mut(relief_out_ptr, total) };
+    let confidence_out = unsafe { slice::from_raw_parts_mut(confidence_out_ptr, total) };
+
+    let stats = unsafe {
+        run_elevation(
+            total,
+            seed,
+            collision_height_m,
+            arc_height_m,
+            ridge_height_m,
+            trench_depth_m,
+            rift_depth_m,
+            areas,
+            neighbors,
+            plate_field,
+            components,
+            crust_thickness,
+            isostasy,
+            uplift,
+            subsidence,
+            compression,
+            extension,
+            shear,
+            stiffness,
+            proto_ocean,
+            hotspot,
+            crust_age,
+            rock_strength,
+            accommodation,
+            province_confidence,
+            boundary_regime,
+            boundary_confidence,
+            crustal_out,
+            orogenic_out,
+            basin_out,
+            bedrock_out,
+            relief_out,
+            confidence_out,
+        )
+    };
+    if !stats_out.is_null() {
+        unsafe { *stats_out = stats };
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gaussian_peaks_at_center() {
+        assert!((gaussian(0.2, 0.2, 0.1) - 1.0).abs() < 1e-6);
+        assert!(gaussian(0.0, 0.2, 0.1) < gaussian(0.1, 0.2, 0.1));
+    }
+
+    #[test]
+    fn random_field_is_deterministic() {
+        assert_eq!(random_signed(42, 9), random_signed(42, 9));
+        assert_ne!(random_signed(42, 9), random_signed(43, 9));
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -6,6 +6,7 @@ from . import geometry  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
+from . import elevation  # noqa: F401
 from . import erosion  # noqa: F401
 
 
@@ -19,6 +20,7 @@ def ensure_builtin_stages() -> None:
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,
+        "elevation": elevation,
         "erosion": erosion,
     }
     for stage_name, module in modules.items():

--- a/src/map_maker/pipeline/stages/elevation.py
+++ b/src/map_maker/pipeline/stages/elevation.py
@@ -1,0 +1,233 @@
+"""Causal pre-erosion elevation and orogenic morphology."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+from PIL import Image
+
+from .._elevation_native import run_cubed_sphere_elevation
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+
+@dataclass(frozen=True)
+class ElevationConfig:
+    collision_height_m: float = 5200.0
+    arc_height_m: float = 2800.0
+    ridge_height_m: float = 1800.0
+    trench_depth_m: float = 3600.0
+    rift_depth_m: float = 950.0
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "ElevationConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown elevation controls: {', '.join(sorted(unknown))}")
+        values = {name: float(mapping[name]) for name in known if name in mapping}
+        config = cls(**values)
+        for name, value in asdict(config).items():
+            if not np.isfinite(value) or value < 0.0 or value > 20_000.0:
+                raise ValueError(f"{name} must be finite and in [0, 20000]")
+        return config
+
+
+def _artifact_array(result, name: str) -> np.ndarray:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        raise KeyError(f"Missing dependency artifact '{name}'")
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _result_array(result, name: str) -> np.ndarray | None:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        return None
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
+    resolution = faces.shape[1]
+    net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
+    placements = {3: (1, 0), 0: (1, 1), 2: (1, 2), 1: (1, 3), 4: (0, 1), 5: (2, 1)}
+    for face, (net_row, net_col) in placements.items():
+        row = net_row * resolution
+        col = net_col * resolution
+        net[row : row + resolution, col : col + resolution] = faces[face]
+    return net
+
+
+def _palette(
+    values: np.ndarray, stops: tuple[tuple[float, tuple[int, int, int]], ...]
+) -> np.ndarray:
+    positions = np.array([position for position, _ in stops], dtype=np.float32)
+    colors = np.array([color for _, color in stops], dtype=np.float32)
+    channels = [np.interp(values, positions, colors[:, channel]) for channel in range(3)]
+    return np.stack(channels, axis=-1).clip(0, 255).astype(np.uint8)
+
+
+def _elevation_visualizer(
+    result, request: VisualizationRequest
+) -> list[VisualizationResult] | None:
+    bedrock = _result_array(result, "BedrockElevationM")
+    crustal = _result_array(result, "CrustalElevationM")
+    orogenic = _result_array(result, "OrogenicElevationM")
+    basin = _result_array(result, "BasinDepressionM")
+    relief = _result_array(result, "TerrainReliefM")
+    if (
+        bedrock is None
+        or crustal is None
+        or orogenic is None
+        or basin is None
+        or relief is None
+        or bedrock.ndim != 3
+        or bedrock.shape[0] != 6
+    ):
+        return None
+
+    ocean_rgb = _palette(
+        bedrock,
+        (
+            (-7500.0, (5, 20, 54)),
+            (-5000.0, (15, 61, 112)),
+            (-3000.0, (37, 112, 158)),
+            (-500.0, (100, 177, 196)),
+            (1000.0, (155, 205, 208)),
+        ),
+    )
+    land_rgb = _palette(
+        bedrock,
+        (
+            (-2000.0, (45, 92, 64)),
+            (-200.0, (54, 111, 73)),
+            (500.0, (95, 137, 74)),
+            (1500.0, (157, 143, 92)),
+            (3000.0, (137, 109, 83)),
+            (5000.0, (210, 205, 190)),
+            (7500.0, (252, 252, 250)),
+        ),
+    )
+    inherited_land = crustal > -1000.0
+    elevation_rgb = np.where(inherited_land[..., None], land_rgb, ocean_rgb)
+    elevation_path = request.output_dir / "bedrock_elevation.png"
+    Image.fromarray(_cube_net_rgb(elevation_rgb), mode="RGB").save(elevation_path)
+
+    morphology_rgb = np.zeros((*orogenic.shape, 3), dtype=np.uint8)
+    morphology_rgb[..., 0] = np.clip(orogenic / 5000.0 * 255.0, 0.0, 255.0).astype(np.uint8)
+    morphology_rgb[..., 1] = np.clip(relief / 1800.0 * 190.0, 0.0, 190.0).astype(np.uint8)
+    morphology_rgb[..., 2] = np.clip(basin / 4000.0 * 255.0, 0.0, 255.0).astype(np.uint8)
+    morphology_path = request.output_dir / "orogenic_morphology.png"
+    Image.fromarray(_cube_net_rgb(morphology_rgb), mode="RGB").save(morphology_path)
+
+    return [
+        VisualizationResult(elevation_path, "BedrockElevationM", {"scale": "fixed_meters"}),
+        VisualizationResult(
+            morphology_path,
+            "OrogenicElevationM",
+            {"red": "orogenic", "green": "relief", "blue": "basin"},
+        ),
+    ]
+
+
+@stage(
+    "elevation",
+    inputs=("tectonics", "world_age", "geology"),
+    outputs=(
+        "CrustalElevationM",
+        "OrogenicElevationM",
+        "BasinDepressionM",
+        "BedrockElevationM",
+        "TerrainReliefM",
+        "ElevationConfidence",
+        "ElevationMetadata",
+    ),
+    version="v1",
+    native_libraries=("elevation_native",),
+    visualizer=_elevation_visualizer,
+)
+def elevation_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = ElevationConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("canonical elevation requires topology: cubed_sphere")
+
+    shape = context.topology.face_shape
+    handles = {
+        "CrustalElevationM": context.arena.allocate_array(
+            "elevation_crustal_m", shape, dtype=np.float32
+        ),
+        "OrogenicElevationM": context.arena.allocate_array(
+            "elevation_orogenic_m", shape, dtype=np.float32
+        ),
+        "BasinDepressionM": context.arena.allocate_array(
+            "elevation_basin_m", shape, dtype=np.float32
+        ),
+        "BedrockElevationM": context.arena.allocate_array(
+            "elevation_bedrock_m", shape, dtype=np.float32
+        ),
+        "TerrainReliefM": context.arena.allocate_array(
+            "elevation_relief_m", shape, dtype=np.float32
+        ),
+        "ElevationConfidence": context.arena.allocate_array(
+            "elevation_confidence", shape, dtype=np.float32
+        ),
+    }
+    views = {name: handle.mutable_view() for name, handle in handles.items()}
+    tectonics = deps["tectonics"]
+    world_age = deps["world_age"]
+    geology = deps["geology"]
+    seed = int(context.rng("elevation").integers(0, 2**63 - 1))
+
+    with context.timed("elevation_kernel"):
+        metadata = run_cubed_sphere_elevation(
+            seed=seed,
+            **asdict(config),
+            areas=context.topology.cell_areas,
+            neighbors=context.topology.neighbor_indices,
+            plate_field=_artifact_array(tectonics, "PlateField"),
+            crust_thickness=_artifact_array(world_age, "CrustThickness"),
+            isostasy=_artifact_array(world_age, "IsostaticOffset"),
+            uplift=_artifact_array(world_age, "UpliftRate"),
+            subsidence=_artifact_array(world_age, "SubsidenceRate"),
+            compression=_artifact_array(world_age, "TectonicCompression"),
+            extension=_artifact_array(world_age, "TectonicExtension"),
+            shear=_artifact_array(world_age, "ShearMagnitude"),
+            stiffness=_artifact_array(world_age, "LithosphereStiffness"),
+            proto_ocean=_artifact_array(world_age, "BaseOceanMask"),
+            hotspot=_artifact_array(tectonics, "HotspotMap"),
+            crust_age=_artifact_array(geology, "CrustAgeGa"),
+            rock_strength=_artifact_array(geology, "RockStrength"),
+            accommodation=_artifact_array(geology, "SedimentAccommodation"),
+            province_confidence=_artifact_array(geology, "ProvinceConfidence"),
+            boundary_regime=_artifact_array(geology, "BoundaryRegime"),
+            boundary_confidence=_artifact_array(geology, "BoundaryConfidence"),
+            crustal_out=views["CrustalElevationM"],
+            orogenic_out=views["OrogenicElevationM"],
+            basin_out=views["BasinDepressionM"],
+            bedrock_out=views["BedrockElevationM"],
+            relief_out=views["TerrainReliefM"],
+            confidence_out=views["ElevationConfidence"],
+        )
+
+    for handle in handles.values():
+        handle.seal()
+    metadata.update(
+        {
+            **asdict(config),
+            "rng_seed": seed,
+            "topology": "cubed_sphere",
+            "datum": "provisional_pre_sea_level_zero",
+            "model": "causal_pre_erosion_components_v1",
+            "history_semantics": "initial_morphology_not_eroded_present_day",
+        }
+    )
+    context.logger.log_event({"type": "elevation_summary", "stage": "elevation", **metadata})
+    return {**handles, "ElevationMetadata": metadata}
+
+
+__all__ = ["ElevationConfig", "elevation_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -138,6 +138,15 @@ def _register_geology_stage() -> str:
     return stage_name
 
 
+def _register_elevation_stage() -> str:
+    stage_name = "elevation"
+    if stage_name in registry():
+        return stage_name
+    from .stages import elevation  # noqa: F401
+
+    return stage_name
+
+
 def run_topology_visualizer(
     topology: str = "sphere",
     *,
@@ -252,7 +261,9 @@ def run_tectonics_visualizer(
 def main(args: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Produce pipeline stage visualization PNGs.")
     parser.add_argument(
-        "--stage", choices=["topology", "tectonics", "world_age", "geology"], default="topology"
+        "--stage",
+        choices=["topology", "tectonics", "world_age", "geology", "elevation"],
+        default="topology",
     )
     parser.add_argument("--config", type=Path, default=None)
     parser.add_argument(
@@ -309,8 +320,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = _register_tectonics_stage()
         elif parsed.stage == "world_age":
             stage_name = _register_world_age_stage()
-        else:
+        elif parsed.stage == "geology":
             stage_name = _register_geology_stage()
+        else:
+            stage_name = _register_elevation_stage()
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -327,7 +340,7 @@ def main(args: Iterable[str] | None = None) -> int:
     if invalid_controls:
         parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
 
-    if parsed.stage in {"world_age", "geology"}:
+    if parsed.stage in {"world_age", "geology", "elevation"}:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":
         if parsed.topology == "cubed_sphere":

--- a/tests/test_elevation.py
+++ b/tests/test_elevation.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline._elevation_native import run_cubed_sphere_elevation
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.stages.elevation import ElevationConfig
+from map_maker.pipeline.tools import main as pipeline_tools_main
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    reg = registry()
+    reg.clear()
+    for module_name in ("geometry", "tectonics", "world_age", "geology", "elevation"):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+    reg.clear()
+
+
+def _config(
+    tmp_path: Path, run_id: str, *, seed: int = 42, face_resolution: int = 32
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": face_resolution}],
+            "rng_seed": seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 16,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 4,
+                },
+                "world_age": {"world_age": 4.1},
+            },
+        }
+    )
+
+
+def _array(result, name: str) -> np.ndarray:
+    return np.asarray(result.artifact_records[name].value.array())
+
+
+def _cross_face_gradient_ratio(values: np.ndarray, neighbors: np.ndarray) -> float:
+    flat = values.reshape(-1)
+    flat_neighbors = neighbors.reshape(-1, 4)
+    face_size = values.shape[1] * values.shape[2]
+    interior: list[float] = []
+    cross_face: list[float] = []
+    for source in range(flat.size):
+        source_face = source // face_size
+        for target_value in flat_neighbors[source]:
+            target = int(target_value)
+            if source >= target:
+                continue
+            delta = abs(float(flat[source] - flat[target]))
+            if target // face_size == source_face:
+                interior.append(delta)
+            else:
+                cross_face.append(delta)
+    return float(np.mean(cross_face)) / max(float(np.mean(interior)), 1e-6)
+
+
+def test_elevation_outputs_causal_components_and_visuals(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "elevation-basic"), generate_visuals=True)
+    results = engine.run(["elevation"])
+    elevation = results["elevation"]
+    grid = engine.context.topology
+    assert isinstance(grid, CubedSphereGrid)
+
+    field_names = (
+        "CrustalElevationM",
+        "OrogenicElevationM",
+        "BasinDepressionM",
+        "BedrockElevationM",
+        "TerrainReliefM",
+        "ElevationConfidence",
+    )
+    fields = {name: _array(elevation, name) for name in field_names}
+    for field in fields.values():
+        assert field.shape == grid.face_shape
+        assert field.dtype == np.float32
+        assert np.all(np.isfinite(field))
+
+    assert np.all(fields["OrogenicElevationM"] >= 0.0)
+    assert np.all(fields["BasinDepressionM"] >= 0.0)
+    assert np.all(fields["TerrainReliefM"] > 0.0)
+    assert np.all((fields["ElevationConfidence"] >= 0.0) & (fields["ElevationConfidence"] <= 1.0))
+
+    ocean = _array(results["world_age"], "BaseOceanMask") >= 0.5
+    bedrock = fields["BedrockElevationM"]
+    assert float(np.mean(bedrock[~ocean])) > float(np.mean(bedrock[ocean])) + 2500.0
+    assert float(np.percentile(bedrock[ocean], 90)) < 0.0
+    assert float(np.std(bedrock[~ocean])) > 200.0
+    assert float(np.max(fields["OrogenicElevationM"])) > 500.0
+    assert float(np.max(fields["BasinDepressionM"])) > 500.0
+    assert _cross_face_gradient_ratio(bedrock, grid.neighbor_indices) < 2.5
+
+    metadata = elevation.artifact_records["ElevationMetadata"].value
+    assert metadata["model"] == "causal_pre_erosion_components_v1"
+    assert metadata["history_semantics"] == "initial_morphology_not_eroded_present_day"
+    assert metadata["continental_mean_m"] > metadata["oceanic_mean_m"]
+    assert metadata["elevation_min_m"] == pytest.approx(float(np.min(bedrock)), abs=1e-3)
+    assert metadata["elevation_max_m"] == pytest.approx(float(np.max(bedrock)), abs=1e-3)
+
+    visual_dir = engine.context.config.run_visual_dir() / "elevation"
+    assert (visual_dir / "bedrock_elevation.png").is_file()
+    assert (visual_dir / "orogenic_morphology.png").is_file()
+
+
+def test_elevation_is_deterministic_and_seed_sensitive(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "elevation-first", seed=17)).run(["elevation"])[
+        "elevation"
+    ]
+    second = ExecutionEngine(_config(tmp_path, "elevation-second", seed=17)).run(["elevation"])[
+        "elevation"
+    ]
+    alternate = ExecutionEngine(_config(tmp_path, "elevation-alternate", seed=18)).run(
+        ["elevation"]
+    )["elevation"]
+    for name in (
+        "CrustalElevationM",
+        "OrogenicElevationM",
+        "BasinDepressionM",
+        "BedrockElevationM",
+        "TerrainReliefM",
+        "ElevationConfidence",
+    ):
+        np.testing.assert_array_equal(_array(first, name), _array(second, name))
+    assert not np.array_equal(
+        _array(first, "BedrockElevationM"), _array(alternate, "BedrockElevationM")
+    )
+
+
+def _ffi_arguments(face_resolution: int = 8) -> tuple[dict[str, object], int, int]:
+    grid = CubedSphereGrid.create(face_resolution)
+    shape = grid.face_shape
+
+    def scalar(value: float) -> np.ndarray:
+        return np.full(shape, value, dtype=np.float32)
+
+    plate = np.zeros((*shape, 7), dtype=np.float32)
+    plate[..., 1] = 1.0
+    plate[..., 2] = 36.0
+    plate[..., 3] = 2.75
+
+    source = 0
+    target = int(grid.neighbor_indices.reshape(-1, 4)[source, 0])
+    plate.reshape(-1, 7)[source, 0] = 0.0
+    plate.reshape(-1, 7)[source, 1] = 0.0
+    plate.reshape(-1, 7)[source, 2] = 7.0
+    plate.reshape(-1, 7)[source, 3] = 3.2
+    plate.reshape(-1, 7)[target, 0] = 1.0
+
+    proto_ocean = scalar(0.0)
+    proto_ocean.reshape(-1)[source] = 1.0
+    crust_age = scalar(2.0)
+    crust_age.reshape(-1)[source] = 0.2
+    crust_age.reshape(-1)[target] = 0.05
+    regimes = np.zeros((*shape, 4), dtype=np.uint8)
+    boundary_confidence = np.zeros((*shape, 4), dtype=np.float32)
+    flat_neighbors = grid.neighbor_indices.reshape(-1, 4)
+    reverse_slot = int(np.flatnonzero(flat_neighbors[target] == source)[0])
+    regimes.reshape(-1, 4)[source, 0] = 3
+    regimes.reshape(-1, 4)[target, reverse_slot] = 3
+    boundary_confidence.reshape(-1, 4)[source, 0] = 1.0
+    boundary_confidence.reshape(-1, 4)[target, reverse_slot] = 1.0
+
+    arguments: dict[str, object] = {
+        "seed": 42,
+        "collision_height_m": 5200.0,
+        "arc_height_m": 2800.0,
+        "ridge_height_m": 1800.0,
+        "trench_depth_m": 3600.0,
+        "rift_depth_m": 950.0,
+        "areas": grid.cell_areas,
+        "neighbors": grid.neighbor_indices,
+        "plate_field": plate,
+        "crust_thickness": np.where(proto_ocean > 0.5, 7.0, 36.0).astype(np.float32),
+        "isostasy": np.where(proto_ocean > 0.5, -1.4, 2.5).astype(np.float32),
+        "uplift": scalar(0.4),
+        "subsidence": scalar(0.1),
+        "compression": scalar(0.7),
+        "extension": scalar(0.0),
+        "shear": scalar(0.0),
+        "stiffness": scalar(0.6),
+        "proto_ocean": proto_ocean,
+        "hotspot": scalar(0.0),
+        "crust_age": crust_age,
+        "rock_strength": scalar(0.7),
+        "accommodation": scalar(0.1),
+        "province_confidence": scalar(0.8),
+        "boundary_regime": regimes,
+        "boundary_confidence": boundary_confidence,
+        "crustal_out": np.empty(shape, dtype=np.float32),
+        "orogenic_out": np.empty(shape, dtype=np.float32),
+        "basin_out": np.empty(shape, dtype=np.float32),
+        "bedrock_out": np.empty(shape, dtype=np.float32),
+        "relief_out": np.empty(shape, dtype=np.float32),
+        "confidence_out": np.empty(shape, dtype=np.float32),
+    }
+    return arguments, source, target
+
+
+def test_subduction_polarity_places_trench_and_arc_on_opposite_sides():
+    arguments, source, target = _ffi_arguments()
+    run_cubed_sphere_elevation(**arguments)
+    basin = arguments["basin_out"].reshape(-1)
+    orogenic = arguments["orogenic_out"].reshape(-1)
+    assert basin[source] > basin[target] + 500.0
+    assert orogenic[target] > orogenic[source] + 100.0
+
+
+def test_elevation_ffi_rejects_overlap_and_shape():
+    arguments, _, _ = _ffi_arguments()
+    arguments["bedrock_out"] = arguments["crustal_out"]
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_cubed_sphere_elevation(**arguments)
+
+    arguments, _, _ = _ffi_arguments()
+    arguments["crust_age"] = np.empty((6, 8, 7), dtype=np.float32)
+    with pytest.raises(ValueError, match="must have shape"):
+        run_cubed_sphere_elevation(**arguments)
+
+
+def test_elevation_config_and_cli_require_explicit_valid_controls(tmp_path: Path):
+    with pytest.raises(ValueError, match="Unknown elevation controls"):
+        ElevationConfig.from_mapping({"plateau_height": 9000})
+    with pytest.raises(ValueError, match=r"in \[0, 20000\]"):
+        ElevationConfig.from_mapping({"collision_height_m": -1})
+
+    rectangular = PipelineConfig.from_mapping(
+        {
+            "topology": "sphere",
+            "resolutions": [{"height": 16, "width": 32}],
+            "run_id": "rectangular-elevation",
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+        }
+    )
+    with pytest.raises(NotImplementedError, match="requires topology: cubed_sphere"):
+        ExecutionEngine(rectangular).run(["elevation"])
+    with pytest.raises(SystemExit) as error:
+        pipeline_tools_main(["--stage", "elevation"])
+    assert error.value.code == 2

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -51,6 +51,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
     assert list(manifest["stages"]) == ["erosion", "geometry", "tectonics", "world_age"]
     assert manifest["statistics"]["land_fraction"] > 0.0
     assert set(manifest["native_libraries"]) == {
+        "elevation_native",
         "erosion_native",
         "geology_native",
         "tectonics_native",


### PR DESCRIPTION
## Summary

- add a Rust cubed-sphere elevation kernel with separate crustal, orogenic, basin, relief-prior, and confidence fields
- derive collision belts, arcs, trenches, ridges, rifts, transforms, and volcanic relief from continuous geological evidence and angular graph distance
- add deterministic persistence, fixed-meter diagnostics, CLI support, canonical configuration, and an updated elevation specification/decision
- add synthetic subduction-polarity, seam, determinism, FFI, morphology, and integration tests

## Validation

- `uv run pytest -q` (86 passed)
- `cargo test --workspace` (28 passed)
- `cargo clippy --workspace -- -D warnings`
- `uv run map-maker doctor`
- canonical seed and six-seed visual gallery review

## Scope

This is pre-erosion bedrock morphology with a provisional datum. Final sea level, erosion, hydrology, sediment routing, and atlas cartography remain later stages. The remaining straightness in some corridors is inherited from the current polygonal plate skeleton and is not hidden in the truth renders.