### PR TITLE
Refine tectonic morphology corridors

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1037,6 +1037,14 @@ distinct cross-strike profiles. Profiles cross cube-face seams through the
 canonical neighbor graph. Long structures receive coherent along-strike
 variation so they do not become uniform walls.
 
+Corridor realization rule:
+The discrete plate edge is the causal skeleton of a finite-width process
+corridor, not a mandatory terrain centerline. Multi-scale spherical curvature,
+coherent along-strike activity, regime-specific lateral offsets, and
+plate-constrained distance smoothing may realize morphology inside that
+corridor. These operations may not alter plate connectivity or move evidence
+onto unrelated plates.
+
 Ownership rule:
 Rust owns graph propagation and component synthesis. Python owns configuration,
 persistence, diagnostics, and cartographic previews.

--- a/docs/specs/07_elevation.md
+++ b/docs/specs/07_elevation.md
@@ -19,6 +19,8 @@ relief without turning geological labels into fixed elevation classes.
 - Plate crust type, thickness, density, and motion.
 - Crust thickness, isostatic offset, uplift, subsidence, compression,
   extension, shear, stiffness, and proto-ocean mask.
+- Persisted spherical hotspot events. The noisy tectonic thermal-potential
+  raster is not interpreted directly as volcanic topography.
 - Crust age, rock strength, sediment accommodation, province confidence,
   boundary regime, boundary confidence, and boundary segment identity.
 - A deterministic stage seed and versioned morphology parameters.
@@ -56,10 +58,31 @@ not elevation bins.
   elevated roughness, not a mountain wall.
 - Transform boundaries create narrow, low-amplitude structural relief and may
   orient later drainage, but do not receive collision-scale uplift.
+- Hotspot events create isolated finite-width volcanic centers on their host
+  plates; event strength and plume proxy modulate amplitude.
 
 Boundary influence is propagated by angular distance over the canonical
 neighbor graph. Profiles therefore cross cube-face seams continuously and use
 physical angular widths rather than face-local pixel widths.
+
+### Corridor Realization
+
+The plate boundary graph is a causal skeleton, not the literal centerline of
+every resulting landform. V2 realizes each active boundary as a process
+corridor:
+
+- Low-amplitude, higher-frequency spherical warp terms bend long plate edges
+  without changing plate connectivity.
+- An independent, spatially correlated activity field strengthens and weakens
+  sections along a boundary while retaining a nonzero causal floor.
+- Collision, arc, ridge, trench, and rift profiles receive coherent lateral
+  offsets within their allowed corridors.
+- Angular distance and inherited activity are smoothed only within each plate
+  before profile evaluation to suppress D4 distance quantization without
+  leaking evidence across unrelated boundaries.
+
+This realization must produce connected regional systems rather than uniform
+walls or disconnected decorative mountain patches.
 
 ## Outputs
 
@@ -90,6 +113,9 @@ physical angular widths rather than face-local pixel widths.
   contain basins; continental-sized flat plateaus are a hard visual failure.
 - Orogenic amplitude varies along long boundary segments; uniform walls are a
   hard visual failure.
+- Exact boundary spines may not dominate their process-corridor flanks by an
+  unbounded ratio, and long active segments must retain measurable amplitude
+  variation.
 - A geology class alone is insufficient to determine elevation.
 
 ## Deferred Work

--- a/src/map_maker/pipeline/native/elevation/src/lib.rs
+++ b/src/map_maker/pipeline/native/elevation/src/lib.rs
@@ -92,6 +92,29 @@ fn smooth_graph(values: &mut [f32], neighbors: &[i32], passes: usize) {
     }
 }
 
+fn smooth_within_plates(values: &mut [f32], plate_ids: &[i32], neighbors: &[i32], passes: usize) {
+    let mut next = values.to_vec();
+    for _ in 0..passes {
+        for cell in 0..values.len() {
+            if !values[cell].is_finite() {
+                next[cell] = values[cell];
+                continue;
+            }
+            let mut sum = values[cell] * 4.0;
+            let mut weight = 4.0f32;
+            for neighbor in &neighbors[cell * D4_NEIGHBORS..(cell + 1) * D4_NEIGHBORS] {
+                let adjacent = *neighbor as usize;
+                if plate_ids[adjacent] == plate_ids[cell] && values[adjacent].is_finite() {
+                    sum += values[adjacent];
+                    weight += 1.0;
+                }
+            }
+            next[cell] = sum / weight;
+        }
+        values.copy_from_slice(&next);
+    }
+}
+
 fn normalized_noise(seed: u64, areas: &[f64], neighbors: &[i32]) -> Vec<f32> {
     let mut broad: Vec<f32> = (0..areas.len())
         .map(|cell| random_signed(seed ^ 0xA076_1D64_78BD_642F, cell))
@@ -175,7 +198,13 @@ fn nearest_source(
     (
         distances
             .into_iter()
-            .map(|value| value.min(f32::MAX as f64) as f32)
+            .map(|value| {
+                if value.is_finite() {
+                    value.min(f32::MAX as f64) as f32
+                } else {
+                    f32::INFINITY
+                }
+            })
             .collect(),
         amplitudes,
     )
@@ -187,6 +216,12 @@ fn gaussian(distance: f32, center: f32, sigma: f32) -> f32 {
     }
     let z = (distance - center) / sigma.max(1e-6);
     (-0.5 * z * z).exp()
+}
+
+fn corridor_activity(value: f32) -> f32 {
+    let normalized = ((value + 1.0) * 0.5).clamp(0.0, 1.0);
+    let smooth = normalized * normalized * (3.0 - 2.0 * normalized);
+    0.18 + 0.82 * smooth
 }
 
 fn km_to_radians(km: f32) -> f32 {
@@ -270,6 +305,8 @@ unsafe fn run_elevation(
     let mut ridge = vec![0.0f32; total];
     let mut rift = vec![0.0f32; total];
     let mut transform = vec![0.0f32; total];
+    let noise = normalized_noise(seed, areas, neighbors);
+    let corridor_noise = normalized_noise(seed ^ 0x8EBC_6AF0_9C88_C6E3, areas, neighbors);
 
     for source in 0..total {
         for slot in 0..D4_NEIGHBORS {
@@ -283,6 +320,8 @@ unsafe fn run_elevation(
             if confidence <= 0.0 {
                 continue;
             }
+            let activity =
+                corridor_activity(0.5 * (corridor_noise[source] + corridor_noise[target]));
             let compression_signal = (0.45
                 + 0.35 * (compression[source] + compression[target])
                 + 0.10 * (uplift[source] + uplift[target]))
@@ -292,8 +331,9 @@ unsafe fn run_elevation(
             let shear_signal = (0.35 + 0.45 * (shear[source] + shear[target])).clamp(0.0, 1.0);
             match regime {
                 REGIME_CONTINENTAL_COLLISION => {
-                    update_source(&mut collision, source, confidence * compression_signal);
-                    update_source(&mut collision, target, confidence * compression_signal);
+                    let strength = confidence * compression_signal * activity;
+                    update_source(&mut collision, source, strength);
+                    update_source(&mut collision, target, strength);
                 }
                 REGIME_SUBDUCTION_MARGIN | REGIME_INTRA_OCEANIC_SUBDUCTION => {
                     let source_ocean = !continental[source];
@@ -312,39 +352,87 @@ unsafe fn run_elevation(
                     } else {
                         (target, source)
                     };
-                    update_source(&mut descending, down, confidence * compression_signal);
-                    update_source(&mut overriding, over, confidence * compression_signal);
+                    let strength = confidence * compression_signal * activity;
+                    update_source(&mut descending, down, strength);
+                    update_source(&mut overriding, over, strength);
                 }
                 REGIME_SPREADING_RIDGE => {
-                    update_source(&mut ridge, source, confidence * extension_signal);
-                    update_source(&mut ridge, target, confidence * extension_signal);
+                    let strength = confidence * extension_signal * activity;
+                    update_source(&mut ridge, source, strength);
+                    update_source(&mut ridge, target, strength);
                 }
                 REGIME_CONTINENTAL_RIFT => {
-                    update_source(&mut rift, source, confidence * extension_signal);
-                    update_source(&mut rift, target, confidence * extension_signal);
+                    let strength = confidence * extension_signal * activity;
+                    update_source(&mut rift, source, strength);
+                    update_source(&mut rift, target, strength);
                 }
                 REGIME_TRANSFORM => {
-                    update_source(&mut transform, source, confidence * shear_signal);
-                    update_source(&mut transform, target, confidence * shear_signal);
+                    let strength = confidence * shear_signal * activity;
+                    update_source(&mut transform, source, strength);
+                    update_source(&mut transform, target, strength);
                 }
                 _ => {}
             }
         }
     }
 
-    let (collision_distance, collision_strength) =
+    let (mut collision_distance, mut collision_strength) =
         nearest_source(&collision, &plate_ids, neighbors, areas);
-    let (descending_distance, descending_strength) =
+    let (mut descending_distance, mut descending_strength) =
         nearest_source(&descending, &plate_ids, neighbors, areas);
-    let (overriding_distance, overriding_strength) =
+    let (mut overriding_distance, mut overriding_strength) =
         nearest_source(&overriding, &plate_ids, neighbors, areas);
-    let (ridge_distance, ridge_strength) = nearest_source(&ridge, &plate_ids, neighbors, areas);
-    let (rift_distance, rift_strength) = nearest_source(&rift, &plate_ids, neighbors, areas);
-    let (transform_distance, transform_strength) =
+    let (mut ridge_distance, mut ridge_strength) =
+        nearest_source(&ridge, &plate_ids, neighbors, areas);
+    let (mut rift_distance, mut rift_strength) =
+        nearest_source(&rift, &plate_ids, neighbors, areas);
+    let (mut transform_distance, mut transform_strength) =
         nearest_source(&transform, &plate_ids, neighbors, areas);
-    let noise = normalized_noise(seed, areas, neighbors);
+    let (mut hotspot_distance, mut hotspot_strength) =
+        nearest_source(hotspot, &plate_ids, neighbors, areas);
+    for field in [
+        &mut collision_distance,
+        &mut descending_distance,
+        &mut overriding_distance,
+        &mut ridge_distance,
+        &mut rift_distance,
+        &mut transform_distance,
+    ] {
+        smooth_within_plates(field, &plate_ids, neighbors, 2);
+    }
+    for (distance, sources) in [
+        (&mut collision_distance, &collision),
+        (&mut descending_distance, &descending),
+        (&mut overriding_distance, &overriding),
+        (&mut ridge_distance, &ridge),
+        (&mut rift_distance, &rift),
+        (&mut transform_distance, &transform),
+    ] {
+        for (value, source) in distance.iter_mut().zip(sources.iter()) {
+            if *source > 0.0 {
+                *value = 0.0;
+            }
+        }
+    }
+    for field in [
+        &mut collision_strength,
+        &mut descending_strength,
+        &mut overriding_strength,
+        &mut ridge_strength,
+        &mut rift_strength,
+        &mut transform_strength,
+    ] {
+        smooth_within_plates(field, &plate_ids, neighbors, 3);
+    }
+    smooth_within_plates(&mut hotspot_distance, &plate_ids, neighbors, 1);
+    smooth_within_plates(&mut hotspot_strength, &plate_ids, neighbors, 2);
+    for (distance, source) in hotspot_distance.iter_mut().zip(hotspot.iter()) {
+        if *source > 0.0 {
+            *distance = 0.0;
+        }
+    }
     let mut regional_compression = compression.to_vec();
-    smooth_graph(&mut regional_compression, neighbors, 14);
+    smooth_graph(&mut regional_compression, neighbors, 30);
 
     let mut elevation_min = f32::INFINITY;
     let mut elevation_max = f32::NEG_INFINITY;
@@ -360,7 +448,7 @@ unsafe fn run_elevation(
 
     for cell in 0..total {
         let structural_variation = noise[cell];
-        let corridor_variation = (0.72 + 0.28 * structural_variation).clamp(0.44, 1.0);
+        let corridor_variation = corridor_activity(corridor_noise[cell]);
         let crustal = if continental[cell] {
             320.0
                 + (isostasy[cell] - mean_land_iso) * 620.0
@@ -372,19 +460,15 @@ unsafe fn run_elevation(
                 + (crust_thickness[cell] - mean_ocean_thickness) * 70.0
         };
 
-        let collision_width = km_to_radians(230.0 + 170.0 * stiffness[cell]);
-        let collision_offset = km_to_radians(95.0 * structural_variation);
+        let collision_width = km_to_radians(270.0 + 210.0 * stiffness[cell]);
+        let collision_offset = km_to_radians(70.0 + 85.0 * (corridor_noise[cell] + 1.0));
         let collision_relief = collision_height_m
             * collision_strength[cell]
-            * gaussian(
-                collision_distance[cell],
-                collision_offset.max(0.0),
-                collision_width,
-            )
+            * gaussian(collision_distance[cell], collision_offset, collision_width)
             * (0.78 + 0.34 * structural_variation);
         let arc_center =
-            if continental[cell] { 190.0 } else { 145.0 } + 55.0 * structural_variation;
-        let arc_width = if continental[cell] { 115.0 } else { 82.0 };
+            if continental[cell] { 190.0 } else { 150.0 } + 85.0 * corridor_noise[cell];
+        let arc_width = if continental[cell] { 145.0 } else { 110.0 };
         let arc_relief = arc_height_m
             * overriding_strength[cell]
             * gaussian(
@@ -400,8 +484,8 @@ unsafe fn run_elevation(
                 * ridge_strength[cell]
                 * gaussian(
                     ridge_distance[cell],
-                    km_to_radians((55.0 + 45.0 * structural_variation).max(0.0)),
-                    km_to_radians(240.0),
+                    km_to_radians((95.0 + 95.0 * corridor_noise[cell]).max(0.0)),
+                    km_to_radians(285.0),
                 )
                 * corridor_variation
         };
@@ -417,17 +501,23 @@ unsafe fn run_elevation(
             * transform_strength[cell]
             * gaussian(transform_distance[cell], 0.0, km_to_radians(85.0))
             * (0.55 + 0.45 * structural_variation.abs());
-        let volcanic_relief = hotspot[cell].clamp(0.0, 1.0)
-            * if continental[cell] { 1050.0 } else { 1750.0 }
+        let volcanic_relief = hotspot_strength[cell].clamp(0.0, 1.5)
+            * if continental[cell] { 1800.0 } else { 2800.0 }
+            * gaussian(
+                hotspot_distance[cell],
+                0.0,
+                km_to_radians(if continental[cell] { 220.0 } else { 165.0 }),
+            )
             * (0.72 + 0.34 * structural_variation);
         let distributed_compression = if continental[cell] {
-            let compression_factor = (regional_compression[cell].clamp(0.0, 1.0) / 0.18)
+            let compression_factor = (regional_compression[cell].clamp(0.0, 1.0) / 0.13)
                 .clamp(0.0, 1.0)
                 .powf(1.05);
             3000.0
                 * compression_factor
                 * (0.62 + 0.38 * uplift[cell].clamp(0.0, 1.0))
                 * (0.76 + 0.32 * structural_variation)
+                * (0.48 + 0.52 * corridor_variation)
         } else {
             0.0
         };
@@ -452,8 +542,8 @@ unsafe fn run_elevation(
             * descending_strength[cell]
             * gaussian(
                 descending_distance[cell],
-                km_to_radians((75.0 + 42.0 * structural_variation).max(20.0)),
-                km_to_radians(108.0),
+                km_to_radians((115.0 + 90.0 * corridor_noise[cell]).max(20.0)),
+                km_to_radians(155.0),
             )
             * corridor_variation;
         let forearc = trench_depth_m
@@ -468,8 +558,8 @@ unsafe fn run_elevation(
             * rift_strength[cell]
             * gaussian(
                 rift_distance[cell],
-                km_to_radians((48.0 + 42.0 * structural_variation).max(0.0)),
-                km_to_radians(145.0),
+                km_to_radians((95.0 + 95.0 * corridor_noise[cell]).max(0.0)),
+                km_to_radians(210.0),
             )
             * corridor_variation;
         let basin = (accommodation_depth + extension_depth + trench + forearc + rift_axis).max(0.0);

--- a/src/map_maker/pipeline/native/tectonics/src/lib.rs
+++ b/src/map_maker/pipeline/native/tectonics/src/lib.rs
@@ -956,7 +956,7 @@ fn random_unit_vector(rng: &mut ChaCha8Rng) -> SVec3 {
     SVec3::new(radius * azimuth.cos(), radius * azimuth.sin(), z)
 }
 
-fn spherical_warp_terms(seed: u64) -> [WarpTerm; 5] {
+fn spherical_warp_terms(seed: u64) -> [WarpTerm; 8] {
     let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x4A39_B70D_91C8_2E65);
     std::array::from_fn(|index| WarpTerm {
         axis: random_unit_vector(&mut rng),
@@ -1994,6 +1994,9 @@ mod tests {
     fn spherical_warp_is_deterministic_unit_length_and_nontrivial() {
         let direction = SVec3::new(0.3, -0.4, 0.866_025_403_8).normalized();
         let terms = spherical_warp_terms(42);
+        assert_eq!(terms.len(), 8);
+        assert!(terms[7].frequency > terms[4].frequency);
+        assert!(terms[7].amplitude < terms[0].amplitude);
         let first = warp_spherical_direction(direction, &terms);
         let second = warp_spherical_direction(direction, &terms);
         assert!((first.norm() - 1.0).abs() < 1e-12);

--- a/src/map_maker/pipeline/stages/elevation.py
+++ b/src/map_maker/pipeline/stages/elevation.py
@@ -52,6 +52,24 @@ def _result_array(result, name: str) -> np.ndarray | None:
     return np.asarray(value.array() if hasattr(value, "array") else value)
 
 
+def _hotspot_event_grid(result, shape: tuple[int, int, int]) -> tuple[np.ndarray, int]:
+    grid = np.zeros(shape, dtype=np.float32)
+    record = result.artifact_records.get("HotspotEvents")
+    if record is None or record.value is None:
+        raise KeyError("Missing dependency artifact 'HotspotEvents'")
+    table = record.value
+    required = {"global_cell_id", "strength", "plume_factor"}
+    if not required.issubset(set(getattr(table, "column_names", ()))):
+        raise ValueError("HotspotEvents lacks canonical cubed-sphere event columns")
+    global_ids = np.asarray(table["global_cell_id"].to_numpy(), dtype=np.int64)
+    strengths = np.asarray(table["strength"].to_numpy(), dtype=np.float32)
+    plume = np.asarray(table["plume_factor"].to_numpy(), dtype=np.float32)
+    valid = (global_ids >= 0) & (global_ids < grid.size)
+    values = strengths[valid] * (0.65 + 0.35 * plume[valid])
+    np.maximum.at(grid.reshape(-1), global_ids[valid], values)
+    return grid, int(np.count_nonzero(valid))
+
+
 def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
     resolution = faces.shape[1]
     net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
@@ -125,6 +143,32 @@ def _elevation_visualizer(
     morphology_path = request.output_dir / "orogenic_morphology.png"
     Image.fromarray(_cube_net_rgb(morphology_rgb), mode="RGB").save(morphology_path)
 
+    uplift_rgb = _palette(
+        orogenic,
+        (
+            (0.0, (3, 12, 10)),
+            (250.0, (32, 88, 62)),
+            (1000.0, (181, 125, 55)),
+            (3000.0, (224, 211, 174)),
+            (5500.0, (255, 255, 252)),
+        ),
+    )
+    uplift_path = request.output_dir / "orogenic_elevation.png"
+    Image.fromarray(_cube_net_rgb(uplift_rgb), mode="RGB").save(uplift_path)
+
+    depression_rgb = _palette(
+        basin,
+        (
+            (0.0, (4, 9, 16)),
+            (250.0, (17, 68, 91)),
+            (1000.0, (31, 124, 158)),
+            (2500.0, (112, 188, 203)),
+            (5000.0, (218, 241, 239)),
+        ),
+    )
+    depression_path = request.output_dir / "basin_depression.png"
+    Image.fromarray(_cube_net_rgb(depression_rgb), mode="RGB").save(depression_path)
+
     return [
         VisualizationResult(elevation_path, "BedrockElevationM", {"scale": "fixed_meters"}),
         VisualizationResult(
@@ -132,6 +176,8 @@ def _elevation_visualizer(
             "OrogenicElevationM",
             {"red": "orogenic", "green": "relief", "blue": "basin"},
         ),
+        VisualizationResult(uplift_path, "OrogenicElevationM", {"scale": "fixed_meters"}),
+        VisualizationResult(depression_path, "BasinDepressionM", {"scale": "fixed_meters"}),
     ]
 
 
@@ -147,7 +193,7 @@ def _elevation_visualizer(
         "ElevationConfidence",
         "ElevationMetadata",
     ),
-    version="v1",
+    version="v2",
     native_libraries=("elevation_native",),
     visualizer=_elevation_visualizer,
 )
@@ -182,6 +228,7 @@ def elevation_stage(context, deps, config_mapping: Mapping[str, object]):
     world_age = deps["world_age"]
     geology = deps["geology"]
     seed = int(context.rng("elevation").integers(0, 2**63 - 1))
+    hotspot_events, hotspot_event_count = _hotspot_event_grid(world_age, shape)
 
     with context.timed("elevation_kernel"):
         metadata = run_cubed_sphere_elevation(
@@ -199,7 +246,7 @@ def elevation_stage(context, deps, config_mapping: Mapping[str, object]):
             shear=_artifact_array(world_age, "ShearMagnitude"),
             stiffness=_artifact_array(world_age, "LithosphereStiffness"),
             proto_ocean=_artifact_array(world_age, "BaseOceanMask"),
-            hotspot=_artifact_array(tectonics, "HotspotMap"),
+            hotspot=hotspot_events,
             crust_age=_artifact_array(geology, "CrustAgeGa"),
             rock_strength=_artifact_array(geology, "RockStrength"),
             accommodation=_artifact_array(geology, "SedimentAccommodation"),
@@ -220,9 +267,10 @@ def elevation_stage(context, deps, config_mapping: Mapping[str, object]):
         {
             **asdict(config),
             "rng_seed": seed,
+            "hotspot_event_count": hotspot_event_count,
             "topology": "cubed_sphere",
             "datum": "provisional_pre_sea_level_zero",
-            "model": "causal_pre_erosion_components_v1",
+            "model": "causal_pre_erosion_components_v2",
             "history_semantics": "initial_morphology_not_eroded_present_day",
         }
     )

--- a/src/map_maker/pipeline/stages/tectonics.py
+++ b/src/map_maker/pipeline/stages/tectonics.py
@@ -192,7 +192,7 @@ def _tectonics_visualizer(
         "HotspotMap",
         "TectonicsMetadata",
     ),
-    version="v5",
+    version="v6",
     native_libraries=("tectonics_native",),
     visualizer=_tectonics_visualizer,
 )
@@ -258,7 +258,7 @@ def tectonics_stage(context, deps, config_mapping):
         shear_view = scalar_views["shear"]
         subduction_view = scalar_views["subduction"]
         hotspot_view = scalar_views["hotspot"]
-        metadata["kinematic_model"] = "spherical_angular_velocity_v1"
+        metadata["kinematic_model"] = "spherical_angular_velocity_v2"
         metadata["velocity_basis"] = "global_xyz_tangent"
     else:
         height, width = context.topology.shape

--- a/tests/test_elevation.py
+++ b/tests/test_elevation.py
@@ -107,16 +107,47 @@ def test_elevation_outputs_causal_components_and_visuals(tmp_path: Path):
     assert float(np.max(fields["BasinDepressionM"])) > 500.0
     assert _cross_face_gradient_ratio(bedrock, grid.neighbor_indices) < 2.5
 
+    regimes = _array(results["geology"], "BoundaryRegime").reshape(-1, 4)
+    segment_ids = _array(results["geology"], "BoundarySegmentID").reshape(-1, 4)
+    neighbors = grid.neighbor_indices.reshape(-1, 4)
+    active_spine = np.any(np.isin(regimes, [2, 3, 4, 5, 6]), axis=1)
+    corridor = active_spine.copy()
+    for _ in range(2):
+        corridor |= np.any(corridor[neighbors], axis=1)
+    corridor_flanks = corridor & ~active_spine
+    orogenic_flat = fields["OrogenicElevationM"].reshape(-1)
+    basin_flat = fields["BasinDepressionM"].reshape(-1)
+    assert float(np.mean(orogenic_flat[active_spine])) < 2.5 * float(
+        np.mean(orogenic_flat[corridor_flanks])
+    )
+    assert float(np.mean(basin_flat[active_spine])) < 3.0 * float(
+        np.mean(basin_flat[corridor_flanks])
+    )
+
+    segment_variation: list[float] = []
+    combined_relief = orogenic_flat + basin_flat
+    for segment_id in np.unique(segment_ids[segment_ids >= 0]):
+        cells = np.flatnonzero(np.any(segment_ids == segment_id, axis=1))
+        values = combined_relief[cells]
+        if cells.size >= 6 and float(np.mean(values)) > 100.0:
+            segment_variation.append(float(np.std(values) / np.mean(values)))
+    assert segment_variation
+    assert float(np.median(segment_variation)) > 0.20
+
     metadata = elevation.artifact_records["ElevationMetadata"].value
-    assert metadata["model"] == "causal_pre_erosion_components_v1"
+    assert metadata["model"] == "causal_pre_erosion_components_v2"
     assert metadata["history_semantics"] == "initial_morphology_not_eroded_present_day"
     assert metadata["continental_mean_m"] > metadata["oceanic_mean_m"]
     assert metadata["elevation_min_m"] == pytest.approx(float(np.min(bedrock)), abs=1e-3)
     assert metadata["elevation_max_m"] == pytest.approx(float(np.max(bedrock)), abs=1e-3)
+    hotspot_events = results["world_age"].artifact_records["HotspotEvents"].value
+    assert metadata["hotspot_event_count"] == hotspot_events.num_rows
 
     visual_dir = engine.context.config.run_visual_dir() / "elevation"
     assert (visual_dir / "bedrock_elevation.png").is_file()
     assert (visual_dir / "orogenic_morphology.png").is_file()
+    assert (visual_dir / "orogenic_elevation.png").is_file()
+    assert (visual_dir / "basin_depression.png").is_file()
 
 
 def test_elevation_is_deterministic_and_seed_sensitive(tmp_path: Path):

--- a/tests/test_tectonics.py
+++ b/tests/test_tectonics.py
@@ -184,7 +184,7 @@ def test_cubed_sphere_tectonics_is_seam_free_tangent_and_connected(
     assert convergence.shape == grid.face_shape
     assert np.unique(plate[..., 0]).size == plate_count
     assert metadata["velocity_basis"] == "global_xyz_tangent"
-    assert metadata["kinematic_model"] == "spherical_angular_velocity_v1"
+    assert metadata["kinematic_model"] == "spherical_angular_velocity_v2"
 
     velocity = plate[..., 4:7]
     tangent_error = np.abs(np.sum(velocity * grid.xyz, axis=-1))


### PR DESCRIPTION
## Summary

- add higher-frequency, low-amplitude spherical plate warp terms to curve long boundary segments while preserving connectivity
- realize active boundaries as finite-width, laterally offset corridors with coherent along-strike activity variation
- smooth graph distance and activity within host plates to remove D4 quantization without leaking evidence across boundaries
- derive volcanic relief from sparse persisted hotspot events instead of the noisy thermal-potential raster
- add fixed-scale uplift and basin truth renders plus anti-linearity, segment-variation, event-contract, polarity, seam, and determinism gates
- version the revised canonical models as tectonics v6 and elevation v2 and document the corridor realization contract

## Validation

- `uv run pytest -q` (86 passed)
- `cargo test --workspace` (28 passed)
- `cargo clippy --workspace -- -D warnings`
- `uv run map-maker-build-native`
- `uv run map-maker doctor`
- final six-seed morphology gallery review

## Visual result

The previous ruler-straight diagonal scars no longer dominate bedrock output. Fixed-seed uplift spine/flank ratios are approximately 0.9-1.03 and basin spine/flank ratios 1.5-1.95, with 7-14 sparse hotspot events per world.