### PR TITLE
Add canonical planetary orbital forcing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "planet_native"
+version = "0.1.0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "src/map_maker/pipeline/native/elevation",
     "src/map_maker/pipeline/native/erosion",
     "src/map_maker/pipeline/native/geology",
+    "src/map_maker/pipeline/native/planet",
     "src/map_maker/pipeline/native/tectonics",
     "src/map_maker/pipeline/native/topology",
     "src/map_maker/pipeline/native/world_age",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -7,6 +7,21 @@ output_dir: out
 cache_dir: out/cache
 log_dir: out/logs
 stage_overrides:
+  planet:
+    planet_radius_earth: 1.0
+    surface_gravity_g: 1.0
+    mean_density_earth: 1.0
+    star_luminosity_solar: 1.0
+    star_effective_temperature_k: 5772.0
+    semi_major_axis_au: 1.0
+    eccentricity: 0.0167
+    obliquity_deg: 23.44
+    rotation_period_hours: 24.0
+    orbital_period_days: 365.2422
+    perihelion_day: 3.0
+    northern_vernal_equinox_day: 79.0
+    moon_mass_lunar: 1.0
+    moon_distance_km: 384400.0
   tectonics:
     num_plates: 24
     continental_fraction: 0.35

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -72,6 +72,16 @@ Derived outputs feed downstream stages:
 - Tide strength index.
 - Obliquity stability index.
 
+Implementation contract:
+- A year is represented by twelve equal-time climatological bins, not Gregorian
+  calendar months.
+- Insolation is daily-mean top-of-atmosphere shortwave forcing computed at each
+  bin midpoint from a Keplerian orbit.
+- Orbital period, perihelion day, and northern vernal equinox day are explicit
+  controls so the seasonal phase is reproducible.
+- Moon properties produce tide-strength and obliquity-stability indices in V1;
+  detailed tidal and long-term obliquity evolution remain future work.
+
 Non-goal:
 V1 does not simulate arbitrary exotic planets.
 

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -24,17 +24,18 @@
 3. Age-conditioned crust state.
 4. Connected geological provinces and boundary segments.
 5. Initial elevation and tectonic morphology.
-6. Climate pass 1.
-7. Hydrology pass 1.
-8. Erosion and sedimentation.
-9. Hydrology pass 2.
-10. Soils and biomes.
-11. Mineral and energy systems.
-12. Selected-region refinement and map export.
+6. Planetary boundary conditions and monthly orbital forcing.
+7. Climate pass 1.
+8. Hydrology pass 1.
+9. Erosion and sedimentation.
+10. Hydrology pass 2.
+11. Soils and biomes.
+12. Mineral and energy systems.
+13. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches stage 5 with a
+The current canonical cubed-sphere implementation reaches stage 6 with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
-relief-prior artifacts. The older
+relief-prior artifacts plus persisted monthly orbital forcing. The older
 rectangular compatibility path runs directly from world age into provisional
 erosion and final rendering; it is reference behavior, not the canonical stage
 order.

--- a/docs/specs/02a_planetary_forcing.md
+++ b/docs/specs/02a_planetary_forcing.md
@@ -1,0 +1,68 @@
+# Planetary Boundary Conditions And Orbital Forcing
+
+## Status
+
+V1 canonical implementation. This stage turns the approved Earth-like planet,
+star, orbit, rotation, and moon controls into deterministic forcing fields for
+modern climate and paleoclimate proxies. It does not simulate stellar evolution,
+orbital migration, atmospheric composition, tides, or obliquity evolution.
+
+## Inputs
+
+- Canonical cell area and latitude from `geometry`.
+- Dense rocky planet controls: radius, surface gravity, and mean density.
+- Star luminosity and effective temperature.
+- Semi-major axis, eccentricity, obliquity, rotation period, orbital period,
+  perihelion date, and northern vernal equinox date.
+- Moon mass and orbital distance.
+
+The V1 parameter bounds deliberately cover only plausible Earth-like water-world
+experiments. Mean incident flux is restricted to `0.65-1.5` times the Earth
+baseline. Atmospheric habitability is not implied by passing these bounds.
+
+## Approximation
+
+1. Solve Kepler's equation for the midpoint of twelve equal-duration orbital
+   intervals.
+2. Derive orbital distance and solar longitude relative to the configured
+   northern vernal equinox.
+3. Derive solar declination from obliquity.
+4. Integrate top-of-atmosphere flux over one rotation at every cubed-sphere cell,
+   including polar day and night.
+5. Area-weight diagnostics using canonical cubed-sphere steradian cell areas.
+6. Derive a normalized lunar tide-strength index proportional to `mass / distance^3`
+   and a bounded V1 obliquity-stability proxy.
+
+Months are climatological equal-time bins, not Gregorian calendar months.
+`MonthlyInsolationWm2` is daily-mean top-of-atmosphere shortwave forcing at each
+month midpoint. Climate must model albedo, atmospheric absorption, heat storage,
+and transport separately.
+
+## Outputs
+
+- `MonthlyInsolationWm2`: `(12, 6, n, n)` float32.
+- `MonthlyDaylightHours`: `(12, 6, n, n)` float32.
+- `AnnualMeanInsolationWm2`: `(6, n, n)` float32.
+- `InsolationSeasonalityWm2`: monthly maximum minus minimum.
+- `PolarLightExtremeFraction`: fraction of sampled months in polar day or night.
+- `OrbitalDistanceAU`: twelve sampled distances.
+- `SolarDeclinationRad`: twelve sampled declinations.
+- `PlanetMetadata`: parameters, model semantics, and area-weighted diagnostics.
+
+## Validation Gates
+
+- Earth defaults produce global mean top-of-atmosphere forcing near `340 W/m2`.
+- Area-weighted equatorial annual forcing exceeds polar forcing.
+- Northern and southern mid-latitude seasonal maxima are approximately six
+  months apart.
+- Circular orbits have constant orbital distance.
+- Polar day/night occurs only at high latitude for Earth-like obliquity.
+- Monthly means reproduce the persisted annual mean and seasonality fields.
+- Results are deterministic and cacheable without an RNG seed.
+
+## Downstream Contract
+
+Modern climate consumes the twelve monthly forcing fields directly. Paleoclimate
+may consume annual mean and seasonality plus a configured geological warm/cold
+offset. All forcing arrays remain persisted so climate training examples can be
+reconstructed without rerunning orbital calculations.

--- a/readme.md
+++ b/readme.md
@@ -70,9 +70,9 @@ uv run map-maker generate --width 1024 --height 512 --seed 8675309
 Rerunning the same configuration reuses the stage cache. The current executable
 stack includes tectonics, crust/world-age fields, erosion/sedimentation, dataset
 persistence, diagnostics, and final cartography. The canonical cubed-sphere path
-now reaches connected geological provinces, boundary segments, and causal
-pre-erosion elevation/orogenic morphology. Explicit geological event history,
-spherical erosion, routed
+now reaches connected geological provinces, boundary segments, causal
+pre-erosion elevation/orogenic morphology, and monthly orbital forcing. Explicit
+geological event history, spherical erosion, routed
 hydrology, climate, soils, biomes, and regional refinement remain implementation
 milestones; the current output is a functional prototype rather than an
 atlas-grade world.
@@ -123,6 +123,9 @@ uv run map-maker-pipeline --stage geology --config configs/cubed_sphere_crust_st
 
 # Canonical pre-erosion bedrock elevation and orogenic morphology
 uv run map-maker-pipeline --stage elevation --config configs/cubed_sphere_crust_state.yaml
+
+# Canonical planetary boundary conditions and monthly orbital forcing
+uv run map-maker-pipeline --stage planet --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -14,6 +14,7 @@ SIMULATION_NATIVE_LIBRARIES = (
     "elevation_native",
     "erosion_native",
     "geology_native",
+    "planet_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -12,6 +12,7 @@ NATIVE_LIBRARIES = (
     "elevation_native",
     "erosion_native",
     "geology_native",
+    "planet_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/pipeline/_planet_native.py
+++ b/src/map_maker/pipeline/_planet_native.py
@@ -1,0 +1,212 @@
+"""Rust-backed bindings for canonical cubed-sphere planetary forcing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from cffi import FFI
+
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+CUBED_SPHERE_PLANET_ABI_VERSION = 1
+
+_CDEF = """
+typedef struct {
+    float global_mean_insolation_w_m2;
+    float equatorial_mean_insolation_w_m2;
+    float polar_mean_insolation_w_m2;
+    float mean_seasonality_w_m2;
+    float maximum_monthly_insolation_w_m2;
+    float minimum_orbital_distance_au;
+    float maximum_orbital_distance_au;
+    float tide_strength_index;
+    float obliquity_stability_index;
+} PlanetStats;
+
+uint32_t cubed_sphere_planet_abi_version(void);
+int32_t planet_run_cubed_sphere(
+    int32_t cell_count,
+    double star_luminosity_solar,
+    double semi_major_axis_au,
+    double eccentricity,
+    double obliquity_radians,
+    double rotation_period_hours,
+    double orbital_period_days,
+    double perihelion_day,
+    double northern_vernal_equinox_day,
+    double moon_mass_lunar,
+    double moon_distance_km,
+    const double* area,
+    const double* latitude,
+    float* monthly_insolation,
+    float* monthly_daylight,
+    float* annual_mean,
+    float* seasonality,
+    float* polar_extreme_fraction,
+    float* orbital_distance,
+    float* solar_declination,
+    PlanetStats* stats_out
+);
+"""
+
+
+def _read_float64(array: np.ndarray, *, name: str) -> np.ndarray:
+    value = np.asarray(array)
+    if value.dtype != np.float64:
+        raise ValueError(f"{name} must be float64, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    return value
+
+
+def _write_float32(array: np.ndarray, *, name: str) -> np.ndarray:
+    value = np.asarray(array)
+    if value.dtype != np.float32:
+        raise ValueError(f"{name} must be float32, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    if not value.flags.writeable:
+        raise ValueError(f"{name} must be writable")
+    return value
+
+
+def _require_disjoint(inputs: dict[str, np.ndarray], outputs: dict[str, np.ndarray]) -> None:
+    output_items = list(outputs.items())
+    for index, (first_name, first) in enumerate(output_items):
+        for second_name, second in output_items[index + 1 :]:
+            if np.shares_memory(first, second):
+                raise ValueError(f"{first_name} and {second_name} buffers must not overlap")
+        for input_name, input_array in inputs.items():
+            if np.shares_memory(first, input_array):
+                raise ValueError(f"{first_name} and {input_name} buffers must not overlap")
+
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+native_library_info("planet_native")
+_lib = _ffi.dlopen(str(native_library_path("planet_native")))
+try:
+    _cubed_sphere_abi = int(_lib.cubed_sphere_planet_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "planet_native lacks the cubed-sphere API; rebuild native libraries"
+    ) from exc
+if _cubed_sphere_abi != CUBED_SPHERE_PLANET_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "planet_native cubed-sphere ABI "
+        f"{_cubed_sphere_abi} does not match expected {CUBED_SPHERE_PLANET_ABI_VERSION}"
+    )
+
+
+def run_cubed_sphere_planet(
+    *,
+    star_luminosity_solar: float,
+    semi_major_axis_au: float,
+    eccentricity: float,
+    obliquity_radians: float,
+    rotation_period_hours: float,
+    orbital_period_days: float,
+    perihelion_day: float,
+    northern_vernal_equinox_day: float,
+    moon_mass_lunar: float,
+    moon_distance_km: float,
+    areas: np.ndarray,
+    latitudes: np.ndarray,
+    monthly_insolation_out: np.ndarray,
+    monthly_daylight_out: np.ndarray,
+    annual_mean_out: np.ndarray,
+    seasonality_out: np.ndarray,
+    polar_extreme_fraction_out: np.ndarray,
+    orbital_distance_out: np.ndarray,
+    solar_declination_out: np.ndarray,
+) -> dict[str, Any]:
+    area_array = _read_float64(areas, name="areas")
+    latitude_array = _read_float64(latitudes, name="latitudes")
+    if (
+        area_array.ndim != 3
+        or area_array.shape[0] != 6
+        or area_array.shape[1] != area_array.shape[2]
+    ):
+        raise ValueError("areas must have shape (6, n, n)")
+    shape = area_array.shape
+    if latitude_array.shape != shape:
+        raise ValueError(f"latitudes must have shape {shape}")
+
+    output_arrays = {
+        name: _write_float32(array, name=name)
+        for name, array in {
+            "monthly_insolation_out": monthly_insolation_out,
+            "monthly_daylight_out": monthly_daylight_out,
+            "annual_mean_out": annual_mean_out,
+            "seasonality_out": seasonality_out,
+            "polar_extreme_fraction_out": polar_extreme_fraction_out,
+            "orbital_distance_out": orbital_distance_out,
+            "solar_declination_out": solar_declination_out,
+        }.items()
+    }
+    expected_shapes = {
+        "monthly_insolation_out": (12, *shape),
+        "monthly_daylight_out": (12, *shape),
+        "annual_mean_out": shape,
+        "seasonality_out": shape,
+        "polar_extreme_fraction_out": shape,
+        "orbital_distance_out": (12,),
+        "solar_declination_out": (12,),
+    }
+    for name, expected_shape in expected_shapes.items():
+        if output_arrays[name].shape != expected_shape:
+            raise ValueError(f"{name} must have shape {expected_shape}")
+    _require_disjoint({"areas": area_array, "latitudes": latitude_array}, output_arrays)
+
+    stats = _ffi.new("PlanetStats*")
+    status = int(
+        _lib.planet_run_cubed_sphere(
+            int(np.prod(shape, dtype=np.int64)),
+            float(star_luminosity_solar),
+            float(semi_major_axis_au),
+            float(eccentricity),
+            float(obliquity_radians),
+            float(rotation_period_hours),
+            float(orbital_period_days),
+            float(perihelion_day),
+            float(northern_vernal_equinox_day),
+            float(moon_mass_lunar),
+            float(moon_distance_km),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", area_array)),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", latitude_array)),
+            *(
+                _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays[name]))
+                for name in expected_shapes
+            ),
+            stats,
+        )
+    )
+    if status != 0:
+        messages = {
+            1: "invalid dimensions or null buffers",
+            2: "invalid orbital parameters",
+            3: "non-finite geometry inputs",
+        }
+        raise ValueError(
+            f"cubed-sphere planet kernel failed: {messages.get(status, f'status {status}')}"
+        )
+
+    return {
+        "global_mean_insolation_w_m2": float(stats.global_mean_insolation_w_m2),
+        "equatorial_mean_insolation_w_m2": float(stats.equatorial_mean_insolation_w_m2),
+        "polar_mean_insolation_w_m2": float(stats.polar_mean_insolation_w_m2),
+        "mean_seasonality_w_m2": float(stats.mean_seasonality_w_m2),
+        "maximum_monthly_insolation_w_m2": float(stats.maximum_monthly_insolation_w_m2),
+        "minimum_orbital_distance_au": float(stats.minimum_orbital_distance_au),
+        "maximum_orbital_distance_au": float(stats.maximum_orbital_distance_au),
+        "tide_strength_index": float(stats.tide_strength_index),
+        "obliquity_stability_index": float(stats.obliquity_stability_index),
+    }
+
+
+__all__ = ["CUBED_SPHERE_PLANET_ABI_VERSION", "run_cubed_sphere_planet"]

--- a/src/map_maker/pipeline/native/planet/Cargo.toml
+++ b/src/map_maker/pipeline/native/planet/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "planet_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/planet/src/lib.rs
+++ b/src/map_maker/pipeline/native/planet/src/lib.rs
@@ -1,0 +1,336 @@
+use std::f64::consts::{PI, TAU};
+use std::slice;
+
+const MONTHS: usize = 12;
+const SOLAR_CONSTANT_W_M2: f64 = 1361.0;
+
+#[repr(C)]
+pub struct PlanetStats {
+    pub global_mean_insolation_w_m2: f32,
+    pub equatorial_mean_insolation_w_m2: f32,
+    pub polar_mean_insolation_w_m2: f32,
+    pub mean_seasonality_w_m2: f32,
+    pub maximum_monthly_insolation_w_m2: f32,
+    pub minimum_orbital_distance_au: f32,
+    pub maximum_orbital_distance_au: f32,
+    pub tide_strength_index: f32,
+    pub obliquity_stability_index: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn planet_native_abi_version() -> u32 {
+    2
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_planet_abi_version() -> u32 {
+    1
+}
+
+fn solve_eccentric_anomaly(mean_anomaly: f64, eccentricity: f64) -> f64 {
+    let mut eccentric_anomaly = mean_anomaly + eccentricity * mean_anomaly.sin();
+    for _ in 0..10 {
+        let residual = eccentric_anomaly - eccentricity * eccentric_anomaly.sin() - mean_anomaly;
+        let derivative = 1.0 - eccentricity * eccentric_anomaly.cos();
+        eccentric_anomaly -= residual / derivative.max(1e-12);
+    }
+    eccentric_anomaly
+}
+
+fn orbital_state(day: f64, period: f64, perihelion_day: f64, eccentricity: f64) -> (f64, f64) {
+    let mean_anomaly = (TAU * (day - perihelion_day) / period).rem_euclid(TAU);
+    let eccentric_anomaly = solve_eccentric_anomaly(mean_anomaly, eccentricity);
+    let true_anomaly = 2.0
+        * ((1.0 + eccentricity).sqrt() * (0.5 * eccentric_anomaly).sin())
+            .atan2((1.0 - eccentricity).sqrt() * (0.5 * eccentric_anomaly).cos());
+    let normalized_distance = 1.0 - eccentricity * eccentric_anomaly.cos();
+    (true_anomaly, normalized_distance)
+}
+
+fn daily_mean_insolation(latitude: f64, declination: f64, solar_flux: f64) -> (f64, f64) {
+    let cosine_hour_angle = -latitude.tan() * declination.tan();
+    let sunset_hour_angle = if cosine_hour_angle >= 1.0 {
+        0.0
+    } else if cosine_hour_angle <= -1.0 {
+        PI
+    } else {
+        cosine_hour_angle.acos()
+    };
+    let daily_mean = solar_flux / PI
+        * (sunset_hour_angle * latitude.sin() * declination.sin()
+            + latitude.cos() * declination.cos() * sunset_hour_angle.sin());
+    (daily_mean.max(0.0), sunset_hour_angle / PI)
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn run_planet(
+    total: usize,
+    star_luminosity_solar: f64,
+    semi_major_axis_au: f64,
+    eccentricity: f64,
+    obliquity_radians: f64,
+    rotation_period_hours: f64,
+    orbital_period_days: f64,
+    perihelion_day: f64,
+    northern_vernal_equinox_day: f64,
+    moon_mass_lunar: f64,
+    moon_distance_km: f64,
+    areas: &[f64],
+    latitudes: &[f64],
+    monthly_insolation: &mut [f32],
+    monthly_daylight: &mut [f32],
+    annual_mean: &mut [f32],
+    seasonality: &mut [f32],
+    polar_extreme_fraction: &mut [f32],
+    orbital_distance: &mut [f32],
+    solar_declination: &mut [f32],
+) -> PlanetStats {
+    let (vernal_true_anomaly, _) = orbital_state(
+        northern_vernal_equinox_day,
+        orbital_period_days,
+        perihelion_day,
+        eccentricity,
+    );
+    let baseline_solar_flux =
+        SOLAR_CONSTANT_W_M2 * star_luminosity_solar / semi_major_axis_au.powi(2);
+
+    for month in 0..MONTHS {
+        let day = (month as f64 + 0.5) / MONTHS as f64 * orbital_period_days;
+        let (true_anomaly, normalized_distance) =
+            orbital_state(day, orbital_period_days, perihelion_day, eccentricity);
+        let distance_au = semi_major_axis_au * normalized_distance;
+        let solar_longitude = true_anomaly - vernal_true_anomaly;
+        let declination = (obliquity_radians.sin() * solar_longitude.sin()).asin();
+        orbital_distance[month] = distance_au as f32;
+        solar_declination[month] = declination as f32;
+        let solar_flux = baseline_solar_flux / normalized_distance.powi(2);
+        for cell in 0..total {
+            let (insolation, daylight_fraction) =
+                daily_mean_insolation(latitudes[cell], declination, solar_flux);
+            monthly_insolation[month * total + cell] = insolation as f32;
+            monthly_daylight[month * total + cell] =
+                (rotation_period_hours * daylight_fraction) as f32;
+        }
+    }
+
+    let mut global_sum = 0.0f64;
+    let mut equatorial_sum = 0.0f64;
+    let mut equatorial_area = 0.0f64;
+    let mut polar_sum = 0.0f64;
+    let mut polar_area = 0.0f64;
+    let mut seasonality_sum = 0.0f64;
+    let mut maximum_monthly = 0.0f32;
+    let total_area: f64 = areas.iter().sum();
+    for cell in 0..total {
+        let mut sum = 0.0f32;
+        let mut minimum = f32::INFINITY;
+        let mut maximum = f32::NEG_INFINITY;
+        let mut extreme_months = 0usize;
+        for month in 0..MONTHS {
+            let value = monthly_insolation[month * total + cell];
+            let daylight = monthly_daylight[month * total + cell];
+            sum += value;
+            minimum = minimum.min(value);
+            maximum = maximum.max(value);
+            maximum_monthly = maximum_monthly.max(value);
+            if daylight <= rotation_period_hours as f32 * 0.01
+                || daylight >= rotation_period_hours as f32 * 0.99
+            {
+                extreme_months += 1;
+            }
+        }
+        let mean = sum / MONTHS as f32;
+        let amplitude = maximum - minimum;
+        annual_mean[cell] = mean;
+        seasonality[cell] = amplitude;
+        polar_extreme_fraction[cell] = extreme_months as f32 / MONTHS as f32;
+        global_sum += mean as f64 * areas[cell];
+        seasonality_sum += amplitude as f64 * areas[cell];
+        let absolute_latitude = latitudes[cell].abs();
+        if absolute_latitude <= 15.0f64.to_radians() {
+            equatorial_sum += mean as f64 * areas[cell];
+            equatorial_area += areas[cell];
+        }
+        if absolute_latitude >= 66.5f64.to_radians() {
+            polar_sum += mean as f64 * areas[cell];
+            polar_area += areas[cell];
+        }
+    }
+
+    let tide_strength = if moon_mass_lunar <= 0.0 {
+        0.0
+    } else {
+        moon_mass_lunar * (384_400.0 / moon_distance_km).powi(3)
+    };
+    let stability = (0.35 + 0.65 * tide_strength / (0.5 + tide_strength)).clamp(0.0, 1.0);
+    PlanetStats {
+        global_mean_insolation_w_m2: (global_sum / total_area) as f32,
+        equatorial_mean_insolation_w_m2: (equatorial_sum / equatorial_area) as f32,
+        polar_mean_insolation_w_m2: (polar_sum / polar_area) as f32,
+        mean_seasonality_w_m2: (seasonality_sum / total_area) as f32,
+        maximum_monthly_insolation_w_m2: maximum_monthly,
+        minimum_orbital_distance_au: orbital_distance
+            .iter()
+            .copied()
+            .fold(f32::INFINITY, f32::min),
+        maximum_orbital_distance_au: orbital_distance
+            .iter()
+            .copied()
+            .fold(f32::NEG_INFINITY, f32::max),
+        tide_strength_index: tide_strength as f32,
+        obliquity_stability_index: stability as f32,
+    }
+}
+
+/// Compute twelve equal-time monthly orbital forcing fields.
+///
+/// Returns 0 on success, 1 for invalid dimensions or pointers, 2 for invalid
+/// parameters, and 3 for invalid numeric inputs.
+///
+/// # Safety
+///
+/// Input pointers must reference `cell_count` readable values. Monthly output
+/// pointers must reference `12 * cell_count` distinct writable values; annual
+/// outputs must reference `cell_count` values; orbital outputs must reference
+/// twelve values. Outputs must not alias inputs or each other. `stats_out` may
+/// be null or must reference one writable `PlanetStats`.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn planet_run_cubed_sphere(
+    cell_count: i32,
+    star_luminosity_solar: f64,
+    semi_major_axis_au: f64,
+    eccentricity: f64,
+    obliquity_radians: f64,
+    rotation_period_hours: f64,
+    orbital_period_days: f64,
+    perihelion_day: f64,
+    northern_vernal_equinox_day: f64,
+    moon_mass_lunar: f64,
+    moon_distance_km: f64,
+    area_ptr: *const f64,
+    latitude_ptr: *const f64,
+    monthly_insolation_ptr: *mut f32,
+    monthly_daylight_ptr: *mut f32,
+    annual_mean_ptr: *mut f32,
+    seasonality_ptr: *mut f32,
+    polar_extreme_fraction_ptr: *mut f32,
+    orbital_distance_ptr: *mut f32,
+    solar_declination_ptr: *mut f32,
+    stats_out: *mut PlanetStats,
+) -> i32 {
+    if cell_count <= 0
+        || area_ptr.is_null()
+        || latitude_ptr.is_null()
+        || monthly_insolation_ptr.is_null()
+        || monthly_daylight_ptr.is_null()
+        || annual_mean_ptr.is_null()
+        || seasonality_ptr.is_null()
+        || polar_extreme_fraction_ptr.is_null()
+        || orbital_distance_ptr.is_null()
+        || solar_declination_ptr.is_null()
+    {
+        return 1;
+    }
+    let parameters = [
+        star_luminosity_solar,
+        semi_major_axis_au,
+        eccentricity,
+        obliquity_radians,
+        rotation_period_hours,
+        orbital_period_days,
+        perihelion_day,
+        northern_vernal_equinox_day,
+        moon_mass_lunar,
+        moon_distance_km,
+    ];
+    if parameters.iter().any(|value| !value.is_finite())
+        || star_luminosity_solar <= 0.0
+        || semi_major_axis_au <= 0.0
+        || !(0.0..0.95).contains(&eccentricity)
+        || !(0.0..=PI / 2.0).contains(&obliquity_radians)
+        || rotation_period_hours <= 0.0
+        || orbital_period_days <= 0.0
+        || !(0.0..orbital_period_days).contains(&perihelion_day)
+        || !(0.0..orbital_period_days).contains(&northern_vernal_equinox_day)
+        || moon_mass_lunar < 0.0
+        || moon_distance_km <= 0.0
+    {
+        return 2;
+    }
+    let total = cell_count as usize;
+    let monthly_len = match total.checked_mul(MONTHS) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let areas = unsafe { slice::from_raw_parts(area_ptr, total) };
+    let latitudes = unsafe { slice::from_raw_parts(latitude_ptr, total) };
+    if areas
+        .iter()
+        .any(|value| !value.is_finite() || *value <= 0.0)
+        || latitudes
+            .iter()
+            .any(|value| !value.is_finite() || value.abs() > PI / 2.0 + 1e-9)
+    {
+        return 3;
+    }
+    let monthly_insolation =
+        unsafe { slice::from_raw_parts_mut(monthly_insolation_ptr, monthly_len) };
+    let monthly_daylight = unsafe { slice::from_raw_parts_mut(monthly_daylight_ptr, monthly_len) };
+    let annual_mean = unsafe { slice::from_raw_parts_mut(annual_mean_ptr, total) };
+    let seasonality = unsafe { slice::from_raw_parts_mut(seasonality_ptr, total) };
+    let polar_extreme_fraction =
+        unsafe { slice::from_raw_parts_mut(polar_extreme_fraction_ptr, total) };
+    let orbital_distance = unsafe { slice::from_raw_parts_mut(orbital_distance_ptr, MONTHS) };
+    let solar_declination = unsafe { slice::from_raw_parts_mut(solar_declination_ptr, MONTHS) };
+    let stats = unsafe {
+        run_planet(
+            total,
+            star_luminosity_solar,
+            semi_major_axis_au,
+            eccentricity,
+            obliquity_radians,
+            rotation_period_hours,
+            orbital_period_days,
+            perihelion_day,
+            northern_vernal_equinox_day,
+            moon_mass_lunar,
+            moon_distance_km,
+            areas,
+            latitudes,
+            monthly_insolation,
+            monthly_daylight,
+            annual_mean,
+            seasonality,
+            polar_extreme_fraction,
+            orbital_distance,
+            solar_declination,
+        )
+    };
+    if !stats_out.is_null() {
+        unsafe { *stats_out = stats };
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circular_orbit_has_constant_distance() {
+        let (_, first) = orbital_state(10.0, 365.0, 3.0, 0.0);
+        let (_, second) = orbital_state(200.0, 365.0, 3.0, 0.0);
+        assert!((first - 1.0).abs() < 1e-12);
+        assert!((second - first).abs() < 1e-12);
+    }
+
+    #[test]
+    fn polar_daylight_extremes_are_opposite() {
+        let north = daily_mean_insolation(80.0f64.to_radians(), 23.0f64.to_radians(), 1361.0);
+        let south = daily_mean_insolation(-80.0f64.to_radians(), 23.0f64.to_radians(), 1361.0);
+        assert!(north.1 > 0.99);
+        assert!(south.1 < 0.01);
+        assert!(north.0 > south.0);
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -3,6 +3,7 @@
 import importlib
 
 from . import geometry  # noqa: F401
+from . import planet  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -17,6 +18,7 @@ def ensure_builtin_stages() -> None:
 
     modules = {
         "geometry": geometry,
+        "planet": planet,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/planet.py
+++ b/src/map_maker/pipeline/stages/planet.py
@@ -1,0 +1,222 @@
+"""Planetary boundary conditions and monthly orbital forcing."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+from PIL import Image
+
+from .._planet_native import run_cubed_sphere_planet
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+
+@dataclass(frozen=True)
+class PlanetConfig:
+    planet_radius_earth: float = 1.0
+    surface_gravity_g: float = 1.0
+    mean_density_earth: float = 1.0
+    star_luminosity_solar: float = 1.0
+    star_effective_temperature_k: float = 5772.0
+    semi_major_axis_au: float = 1.0
+    eccentricity: float = 0.0167
+    obliquity_deg: float = 23.44
+    rotation_period_hours: float = 24.0
+    orbital_period_days: float = 365.2422
+    perihelion_day: float = 3.0
+    northern_vernal_equinox_day: float = 79.0
+    moon_mass_lunar: float = 1.0
+    moon_distance_km: float = 384_400.0
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "PlanetConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown planet controls: {', '.join(sorted(unknown))}")
+        values = {name: float(mapping[name]) for name in known if name in mapping}
+        config = cls(**values)
+        for name, value in asdict(config).items():
+            if not np.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+
+        bounds = {
+            "planet_radius_earth": (0.7, 1.5),
+            "surface_gravity_g": (0.7, 1.5),
+            "mean_density_earth": (0.7, 1.5),
+            "star_luminosity_solar": (0.1, 3.0),
+            "star_effective_temperature_k": (3500.0, 7500.0),
+            "semi_major_axis_au": (0.3, 3.0),
+            "eccentricity": (0.0, 0.3),
+            "obliquity_deg": (0.0, 60.0),
+            "rotation_period_hours": (8.0, 72.0),
+            "orbital_period_days": (60.0, 1500.0),
+            "moon_mass_lunar": (0.0, 81.3),
+            "moon_distance_km": (20_000.0, 2_000_000.0),
+        }
+        values_dict = asdict(config)
+        for name, (minimum, maximum) in bounds.items():
+            value = values_dict[name]
+            if not minimum <= value <= maximum:
+                raise ValueError(f"{name} must be in [{minimum}, {maximum}]")
+        if not 0.0 <= config.perihelion_day < config.orbital_period_days:
+            raise ValueError("perihelion_day must fall within the orbital year")
+        if not 0.0 <= config.northern_vernal_equinox_day < config.orbital_period_days:
+            raise ValueError("northern_vernal_equinox_day must fall within the orbital year")
+        mean_flux_ratio = config.star_luminosity_solar / config.semi_major_axis_au**2
+        if not 0.65 <= mean_flux_ratio <= 1.5:
+            raise ValueError("star_luminosity_solar / semi_major_axis_au^2 must be in [0.65, 1.5]")
+        return config
+
+
+def _result_array(result, name: str) -> np.ndarray | None:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        return None
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
+    resolution = faces.shape[1]
+    net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
+    placements = {3: (1, 0), 0: (1, 1), 2: (1, 2), 1: (1, 3), 4: (0, 1), 5: (2, 1)}
+    for face, (net_row, net_col) in placements.items():
+        row = net_row * resolution
+        col = net_col * resolution
+        net[row : row + resolution, col : col + resolution] = faces[face]
+    return net
+
+
+def _solar_palette(values: np.ndarray, maximum: float) -> np.ndarray:
+    stops = np.array([0.0, 0.12, 0.3, 0.5, 0.72, 1.0], dtype=np.float32) * maximum
+    colors = np.array(
+        [
+            (4, 9, 25),
+            (31, 50, 103),
+            (42, 120, 142),
+            (132, 175, 96),
+            (232, 173, 68),
+            (255, 245, 198),
+        ],
+        dtype=np.float32,
+    )
+    channels = [np.interp(values, stops, colors[:, channel]) for channel in range(3)]
+    return np.stack(channels, axis=-1).clip(0, 255).astype(np.uint8)
+
+
+def _planet_visualizer(result, request: VisualizationRequest) -> list[VisualizationResult] | None:
+    monthly = _result_array(result, "MonthlyInsolationWm2")
+    annual = _result_array(result, "AnnualMeanInsolationWm2")
+    seasonality = _result_array(result, "InsolationSeasonalityWm2")
+    if monthly is None or annual is None or seasonality is None or monthly.ndim != 4:
+        return None
+
+    annual_path = request.output_dir / "annual_mean_insolation.png"
+    Image.fromarray(_cube_net_rgb(_solar_palette(annual, 500.0)), mode="RGB").save(annual_path)
+    seasonality_path = request.output_dir / "insolation_seasonality.png"
+    Image.fromarray(_cube_net_rgb(_solar_palette(seasonality, 900.0)), mode="RGB").save(
+        seasonality_path
+    )
+
+    month_nets = [_cube_net_rgb(_solar_palette(monthly[month], 600.0)) for month in range(12)]
+    panel_height, panel_width = month_nets[0].shape[:2]
+    montage = np.zeros((3 * panel_height, 4 * panel_width, 3), dtype=np.uint8)
+    for month, month_net in enumerate(month_nets):
+        row, col = divmod(month, 4)
+        montage[
+            row * panel_height : (row + 1) * panel_height,
+            col * panel_width : (col + 1) * panel_width,
+        ] = month_net
+    monthly_path = request.output_dir / "monthly_insolation.png"
+    Image.fromarray(montage, mode="RGB").save(monthly_path)
+    return [
+        VisualizationResult(annual_path, "AnnualMeanInsolationWm2", {"scale_w_m2": [0, 500]}),
+        VisualizationResult(seasonality_path, "InsolationSeasonalityWm2", {"scale_w_m2": [0, 900]}),
+        VisualizationResult(
+            monthly_path, "MonthlyInsolationWm2", {"months": 12, "scale_w_m2": [0, 600]}
+        ),
+    ]
+
+
+@stage(
+    "planet",
+    inputs=("geometry",),
+    outputs=(
+        "MonthlyInsolationWm2",
+        "MonthlyDaylightHours",
+        "AnnualMeanInsolationWm2",
+        "InsolationSeasonalityWm2",
+        "PolarLightExtremeFraction",
+        "OrbitalDistanceAU",
+        "SolarDeclinationRad",
+        "PlanetMetadata",
+    ),
+    version="v1",
+    native_libraries=("planet_native",),
+    visualizer=_planet_visualizer,
+)
+def planet_stage(context, deps, config_mapping: Mapping[str, object]):
+    del deps
+    config = PlanetConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("canonical planetary forcing requires topology: cubed_sphere")
+
+    shape = context.topology.face_shape
+    artifact_shapes = {
+        "MonthlyInsolationWm2": (12, *shape),
+        "MonthlyDaylightHours": (12, *shape),
+        "AnnualMeanInsolationWm2": shape,
+        "InsolationSeasonalityWm2": shape,
+        "PolarLightExtremeFraction": shape,
+        "OrbitalDistanceAU": (12,),
+        "SolarDeclinationRad": (12,),
+    }
+    handles = {
+        name: context.arena.allocate_array(f"planet_{name.lower()}", artifact_shape, np.float32)
+        for name, artifact_shape in artifact_shapes.items()
+    }
+    views = {name: handle.mutable_view() for name, handle in handles.items()}
+
+    with context.timed("planet_forcing_kernel"):
+        metadata = run_cubed_sphere_planet(
+            star_luminosity_solar=config.star_luminosity_solar,
+            semi_major_axis_au=config.semi_major_axis_au,
+            eccentricity=config.eccentricity,
+            obliquity_radians=np.deg2rad(config.obliquity_deg),
+            rotation_period_hours=config.rotation_period_hours,
+            orbital_period_days=config.orbital_period_days,
+            perihelion_day=config.perihelion_day,
+            northern_vernal_equinox_day=config.northern_vernal_equinox_day,
+            moon_mass_lunar=config.moon_mass_lunar,
+            moon_distance_km=config.moon_distance_km,
+            areas=context.topology.cell_areas,
+            latitudes=context.topology.latitude,
+            monthly_insolation_out=views["MonthlyInsolationWm2"],
+            monthly_daylight_out=views["MonthlyDaylightHours"],
+            annual_mean_out=views["AnnualMeanInsolationWm2"],
+            seasonality_out=views["InsolationSeasonalityWm2"],
+            polar_extreme_fraction_out=views["PolarLightExtremeFraction"],
+            orbital_distance_out=views["OrbitalDistanceAU"],
+            solar_declination_out=views["SolarDeclinationRad"],
+        )
+
+    for handle in handles.values():
+        handle.seal()
+    metadata.update(
+        {
+            **asdict(config),
+            "topology": "cubed_sphere",
+            "forcing_semantics": "twelve_equal_time_monthly_daily_means",
+            "solar_constant_w_m2": 1361.0,
+            "model": "keplerian_orbital_forcing_v1",
+        }
+    )
+    context.logger.log_event({"type": "planet_summary", "stage": "planet", **metadata})
+    return {**handles, "PlanetMetadata": metadata}
+
+
+__all__ = ["PlanetConfig", "planet_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -262,7 +262,7 @@ def main(args: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Produce pipeline stage visualization PNGs.")
     parser.add_argument(
         "--stage",
-        choices=["topology", "tectonics", "world_age", "geology", "elevation"],
+        choices=["topology", "planet", "tectonics", "world_age", "geology", "elevation"],
         default="topology",
     )
     parser.add_argument("--config", type=Path, default=None)
@@ -316,6 +316,8 @@ def main(args: Iterable[str] | None = None) -> int:
             parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
         if parsed.stage == "topology":
             stage_name = "geometry"
+        elif parsed.stage == "planet":
+            stage_name = "planet"
         elif parsed.stage == "tectonics":
             stage_name = _register_tectonics_stage()
         elif parsed.stage == "world_age":
@@ -340,7 +342,7 @@ def main(args: Iterable[str] | None = None) -> int:
     if invalid_controls:
         parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
 
-    if parsed.stage in {"world_age", "geology", "elevation"}:
+    if parsed.stage in {"planet", "world_age", "geology", "elevation"}:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":
         if parsed.topology == "cubed_sphere":

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -54,6 +54,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
         "elevation_native",
         "erosion_native",
         "geology_native",
+        "planet_native",
         "tectonics_native",
         "topology_native",
         "world_age_native",

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline._planet_native import run_cubed_sphere_planet
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.stages.planet import PlanetConfig
+from map_maker.pipeline.tools import main as pipeline_tools_main
+
+
+@pytest.fixture(autouse=True)
+def _ensure_planet_registered():
+    registry().clear()
+    for module_name in ("geometry", "planet"):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(tmp_path: Path, run_id: str, **planet_overrides: float) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 24}],
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {"planet": planet_overrides},
+        }
+    )
+
+
+def _array(result, name: str) -> np.ndarray:
+    return np.asarray(result.artifact_records[name].value.array())
+
+
+def test_planet_outputs_earth_forcing_and_visuals(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "earth-forcing"), generate_visuals=True)
+    results = engine.run(["planet"])
+    planet = results["planet"]
+    grid = engine.context.topology
+    assert isinstance(grid, CubedSphereGrid)
+
+    monthly = _array(planet, "MonthlyInsolationWm2")
+    daylight = _array(planet, "MonthlyDaylightHours")
+    annual = _array(planet, "AnnualMeanInsolationWm2")
+    seasonality = _array(planet, "InsolationSeasonalityWm2")
+    polar_extreme = _array(planet, "PolarLightExtremeFraction")
+    orbital_distance = _array(planet, "OrbitalDistanceAU")
+    declination = _array(planet, "SolarDeclinationRad")
+
+    assert monthly.shape == (12, *grid.face_shape)
+    assert daylight.shape == monthly.shape
+    for field in (monthly, daylight, annual, seasonality, polar_extreme):
+        assert field.dtype == np.float32
+        assert np.all(np.isfinite(field))
+    assert np.all(monthly >= 0.0)
+    assert np.all((daylight >= 0.0) & (daylight <= 24.0))
+    assert np.all((polar_extreme >= 0.0) & (polar_extreme <= 1.0))
+    np.testing.assert_allclose(annual, np.mean(monthly, axis=0), rtol=0.0, atol=1e-4)
+    np.testing.assert_allclose(seasonality, np.ptp(monthly, axis=0), rtol=0.0, atol=1e-4)
+
+    global_mean = float(np.average(annual, weights=grid.cell_areas))
+    assert global_mean == pytest.approx(340.3, abs=1.0)
+    equatorial = np.abs(grid.latitude) <= np.deg2rad(15.0)
+    polar = np.abs(grid.latitude) >= np.deg2rad(66.5)
+    assert float(np.mean(annual[equatorial])) > float(np.mean(annual[polar])) + 150.0
+    assert float(np.max(polar_extreme[polar])) > 0.0
+    assert float(np.max(polar_extreme[equatorial])) == 0.0
+
+    latitude_flat = grid.latitude.reshape(-1)
+    north_index = int(np.argmin(np.abs(latitude_flat - np.deg2rad(45.0))))
+    south_index = int(np.argmin(np.abs(latitude_flat + np.deg2rad(45.0))))
+    north_peak = int(np.argmax(monthly.reshape(12, -1)[:, north_index]))
+    south_peak = int(np.argmax(monthly.reshape(12, -1)[:, south_index]))
+    separation = abs(north_peak - south_peak)
+    assert min(separation, 12 - separation) in {5, 6}
+
+    assert orbital_distance.shape == (12,)
+    assert declination.shape == (12,)
+    assert float(np.min(orbital_distance)) == pytest.approx(0.9837, abs=0.002)
+    assert float(np.max(orbital_distance)) == pytest.approx(1.0163, abs=0.002)
+    assert float(np.max(np.abs(declination))) == pytest.approx(np.deg2rad(23.44), abs=0.01)
+
+    metadata = planet.artifact_records["PlanetMetadata"].value
+    assert metadata["model"] == "keplerian_orbital_forcing_v1"
+    assert metadata["forcing_semantics"] == "twelve_equal_time_monthly_daily_means"
+    assert metadata["global_mean_insolation_w_m2"] == pytest.approx(global_mean, abs=1e-3)
+    assert metadata["tide_strength_index"] == pytest.approx(1.0)
+    assert metadata["obliquity_stability_index"] > 0.5
+
+    visual_dir = engine.context.config.run_visual_dir() / "planet"
+    assert (visual_dir / "annual_mean_insolation.png").is_file()
+    assert (visual_dir / "insolation_seasonality.png").is_file()
+    assert (visual_dir / "monthly_insolation.png").is_file()
+
+
+def test_planet_is_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "planet-first")).run(["planet"])["planet"]
+    second = ExecutionEngine(_config(tmp_path, "planet-second")).run(["planet"])["planet"]
+    for name in (
+        "MonthlyInsolationWm2",
+        "MonthlyDaylightHours",
+        "AnnualMeanInsolationWm2",
+        "InsolationSeasonalityWm2",
+        "PolarLightExtremeFraction",
+        "OrbitalDistanceAU",
+        "SolarDeclinationRad",
+    ):
+        np.testing.assert_array_equal(_array(first, name), _array(second, name))
+    assert second.stats is not None and second.stats.cache_hit
+
+
+def _ffi_arguments(face_resolution: int = 6) -> dict[str, object]:
+    grid = CubedSphereGrid.create(face_resolution)
+    shape = grid.face_shape
+    return {
+        "star_luminosity_solar": 1.0,
+        "semi_major_axis_au": 1.0,
+        "eccentricity": 0.0167,
+        "obliquity_radians": np.deg2rad(23.44),
+        "rotation_period_hours": 24.0,
+        "orbital_period_days": 365.2422,
+        "perihelion_day": 3.0,
+        "northern_vernal_equinox_day": 79.0,
+        "moon_mass_lunar": 1.0,
+        "moon_distance_km": 384_400.0,
+        "areas": grid.cell_areas,
+        "latitudes": grid.latitude,
+        "monthly_insolation_out": np.empty((12, *shape), dtype=np.float32),
+        "monthly_daylight_out": np.empty((12, *shape), dtype=np.float32),
+        "annual_mean_out": np.empty(shape, dtype=np.float32),
+        "seasonality_out": np.empty(shape, dtype=np.float32),
+        "polar_extreme_fraction_out": np.empty(shape, dtype=np.float32),
+        "orbital_distance_out": np.empty(12, dtype=np.float32),
+        "solar_declination_out": np.empty(12, dtype=np.float32),
+    }
+
+
+def test_planet_ffi_rejects_overlapping_and_invalid_buffers():
+    arguments = _ffi_arguments()
+    arguments["seasonality_out"] = arguments["annual_mean_out"]
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_cubed_sphere_planet(**arguments)
+
+    arguments = _ffi_arguments()
+    arguments["monthly_insolation_out"] = np.empty((11, 6, 6, 6), dtype=np.float32)
+    with pytest.raises(ValueError, match="must have shape"):
+        run_cubed_sphere_planet(**arguments)
+
+    arguments = _ffi_arguments()
+    arguments["latitudes"] = np.asarray(arguments["latitudes"], dtype=np.float32)
+    with pytest.raises(ValueError, match="must be float64"):
+        run_cubed_sphere_planet(**arguments)
+
+
+def test_planet_config_and_cli_reject_invalid_controls(tmp_path: Path):
+    with pytest.raises(ValueError, match="Unknown planet controls"):
+        PlanetConfig.from_mapping({"painted_latitude_bands": 3})
+    with pytest.raises(ValueError, match="must be in"):
+        PlanetConfig.from_mapping({"eccentricity": 0.7})
+    with pytest.raises(ValueError, match="must be in"):
+        PlanetConfig.from_mapping({"star_luminosity_solar": 0.2, "semi_major_axis_au": 1.0})
+
+    rectangular = PipelineConfig.from_mapping(
+        {
+            "topology": "sphere",
+            "resolutions": [{"height": 16, "width": 32}],
+            "run_id": "rectangular-planet",
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+        }
+    )
+    with pytest.raises(NotImplementedError, match="cubed_sphere"):
+        ExecutionEngine(rectangular).run(["planet"])
+    with pytest.raises(SystemExit):
+        pipeline_tools_main(["--stage", "planet"])


### PR DESCRIPTION
## Summary
- add deterministic Keplerian monthly forcing on the canonical cubed sphere
- persist insolation, daylight, orbital, and lunar diagnostic artifacts
- add configuration, visual diagnostics, docs, and physical regression gates

## Verification
- uv run pytest -q (90 passed)
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings