### PR TITLE
Add seasonal cubed-sphere climate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "climate_native"
+version = "0.1.0"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "src/map_maker/pipeline/native/climate",
     "src/map_maker/pipeline/native/elevation",
     "src/map_maker/pipeline/native/erosion",
     "src/map_maker/pipeline/native/geology",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -42,3 +42,23 @@ stage_overrides:
     ridge_height_m: 1800.0
     trench_depth_m: 3600.0
     rift_depth_m: 950.0
+  climate:
+    spinup_years: 24
+    moisture_spinup_years: 3
+    moisture_steps_per_month_at_face_128: 16
+    greenhouse_offset_c: 0.0
+    land_albedo: 0.30
+    ocean_albedo: 0.28
+    olr_intercept_w_m2: 203.0
+    olr_slope_w_m2_c: 2.09
+    heat_transport_w_m2: 35.0
+    land_thermal_response: 0.22
+    ocean_thermal_response: 0.10
+    atmospheric_exchange: 0.16
+    lapse_rate_c_per_km: 6.5
+    wind_scale: 1.0
+    moisture_advection_fraction: 0.38
+    moisture_diffusion_fraction: 0.50
+    orographic_factor: 0.18
+    rain_shadow_factor: 0.70
+    runoff_base_fraction: 0.35

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -581,6 +581,18 @@ V1 non-goals:
 - ENSO-like internal variability.
 - Full atmospheric or oceanic general circulation.
 
+Implementation contract:
+- Climate consumes persisted monthly orbital forcing rather than recreating a
+  latitude-only insolation approximation.
+- Effective atmospheric orography is a persisted, smoothed land-surface field;
+  ocean bathymetry is not atmospheric elevation.
+- Horizontal wind is stored as global tangent XYZ vectors so cube-face edges do
+  not define local component discontinuities.
+- Moisture transport combines directed advection with unresolved synoptic mixing;
+  rate-limited orographic rainout must allow continental penetration.
+- The first pass writes pre-soil runoff potential only. It does not route rivers
+  or silently resolve depressions.
+
 ## Decision 013: Historical Source-To-Sink Coupling
 
 Status: approved, provisional

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -33,9 +33,10 @@
 12. Mineral and energy systems.
 13. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches stage 6 with a
+The current canonical cubed-sphere implementation reaches stage 7 with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
-relief-prior artifacts plus persisted monthly orbital forcing. The older
+relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
+climate/orography pass. The older
 rectangular compatibility path runs directly from world age into provisional
 erosion and final rendering; it is reference behavior, not the canonical stage
 order.

--- a/docs/specs/08_climate_hydrology.md
+++ b/docs/specs/08_climate_hydrology.md
@@ -1,61 +1,125 @@
-# Stage 7 – Atmospheric Circulation & Hydrology
+# Seasonal Climate And Hydrology Boundary
 
-## Objectives
-- Model global temperature, precipitation, and moisture transport.
-- Compute full drainage network with hierarchical catchments and river properties.
+## Status
+
+Canonical seasonal climate V1 is implemented on the cubed sphere. Depression-aware
+hydrology remains the next stage. Climate supplies monthly runoff potential but
+does not route water, fill lakes, create rivers, or erode channels.
+
+## Scientific Intent
+
+The climate pass must make temperature, prevailing wind, precipitation, snow,
+and runoff respond causally to orbital forcing, latitude, land/ocean thermal
+contrast, elevation, circulation, and terrain. It targets structurally plausible
+monthly climatology, not research-grade atmospheric dynamics or daily weather.
 
 ## Inputs
-- `Elevation`, `Slope`, `Topology`, `SeaSurfaceTemperature` (optional).
-- Config:
-  - Climate: `insolation_profile`, `hadley_extent`, `orographic_coeff`, `evaporation_rate`, `gpu_backend` (`metal`, `cuda`, or `cpu`).
-  - Hydrology: `flow_algorithm`, `river_thresholds`, `lake_evap_factor`, `reservoir_capacity`, `tile_size`.
 
-## Climate Pipeline
-1. **Radiative Balance**
-   - Solve simplified energy balance (zonal or spectral) using GPU tensor ops (Metal or CUDA) with fallback Rust CPU kernels.
-   - Output temperature baseline per latitude, adjust by elevation lapse rate in SIMD.
-2. **Moisture Transport**
-   - Advection-diffusion solver for moisture flux using semi-Lagrangian scheme (GPU) or vectorized Rust for CPU.
-   - Orographic precipitation: `P = base + orographic_factor * max(0, upslope_wind)` computed tile-wise using cached slope/aspect.
-   - Handle rain shadows with leeward decay using exponential attenuation.
-3. **Outputs**
-   - `TemperatureMean`, `TemperatureSeasonal` (12-month tensor or harmonic amplitudes), `TemperatureVariance`.
-   - `PrecipitationMean`, `PrecipitationSeasonal`, `PrecipitationVariance`.
-   - `MoistureFlux`, `WindVectors` (SoA buffers).
+- `planet`: monthly top-of-atmosphere insolation and solar declination.
+- `elevation`: pre-erosion bedrock and broad relief.
+- `world_age`: provisional land/ocean mask.
+- `geometry`: consumed through the dependency graph as canonical cell area,
+  latitude, XYZ unit vectors, and D4 neighbors.
 
-## Hydrology Pipeline
-1. **Flow Routing**
-   - Use D-infinity (or hex grid) implemented in Rust SIMD with optional GPU path; processed in tiles.
-   - Multi-resolution progressive refinement (coarse to fine) to reduce iterations.
-2. **Catchment Extraction**
-   - Build drainage tree: each cell links to downstream neighbor until ocean.
-   - Determine basins, sub-basins; compute Strahler/Shreve orders (graph stored in Arrow/CSR for zero-copy access).
-3. **River Geometry & Delta Detection**
-   - Extract polylines with smoothing; store multi-scale routes with jitter/curvature handling (Rust polyline fitter).
-   - Compute discharge = precipitation runoff * contributing area.
-   - Detect delta candidates at river mouths (river meets ocean, low slope); compute sediment load and stagnation metrics to feed `DeltaCatalog`.
-4. **Lake & Wetland Modeling**
-   - Fill depressions with priority-flood, consider infiltration/evaporation; produce water balance metrics.
-5. **Outputs**
-   - `HydroGraph` (Arrow/Parquet), `RiverMask` (per threshold), `CatchmentMetadata`, `LakeCatalog`, `DeltaCatalog` (river mouth metadata with discharge, sediment load, typology cues).
+The stage creates `ClimateOrographyM` by smoothing only within land or ocean
+domains over five neighbor passes. Ocean bathymetry becomes zero atmospheric
+surface height; land orography is nonnegative. This prevents abyssal depth from
+becoming a false coastal atmospheric wall while preserving broad mountain belts.
 
-## Performance
-- Climate GPU solver ~1 s (8 k grid) on MPS/CUDA; CPU fallback (Rust) aims for <2 s using multi-threading.
-- Hydrology flows using Rust + Rayon target <2 s; GPU optional for further acceleration.
-- Asynchronous pipeline overlaps climate GPU kernels with CPU hydrology preprocessing.
-- Tile-based workload ensures cache locality and allows streaming for large grids.
+## Computational Approximation
 
-- Temperature/precip summary statistics.
-- Number of basins, river segments per order.
-- Total discharge vs precipitation check.
-- Delta detection summary (count, discharge totals, fertile vs swamp indicators).
-- Temperature/precip summary statistics.
-- Number of basins, river segments per order.
-- Total discharge vs precipitation check.
+### Temperature
 
-## Testing
-- Energy balance test (no elevation) matches analytic solution.
-- Seasonal precipitation/temperature integrate to annual means within tolerance.
-- Flow routing determinism with seeded random noise; CPU/GPU parity within tolerance.
-- Catchment tree acyclic and drains to ocean or terminal lakes.
-- Discharge integrates to precipitation minus evaporation within tolerance.
+1. Linearized outgoing-longwave energy balance consumes monthly insolation,
+   land/ocean albedo, and a zero-integral meridional heat-transport tendency.
+2. Land and ocean use separate thermal response rates, producing greater land
+   seasonality and ocean lag.
+3. Neighbor exchange represents unresolved atmospheric heat transport.
+4. Positive climate orography applies a configurable environmental lapse rate.
+5. Multiple climatological years are integrated to a periodic seasonal state.
+
+### Wind
+
+1. Smooth latitude-dependent Hadley, Ferrel, and polar surface tendencies provide
+   trade winds, mid-latitude westerlies, and polar easterlies.
+2. Circulation bands migrate with solar declination.
+3. Monthly thermal gradients add pressure-gradient and Coriolis-deflected flow.
+4. Broad orography steers upslope flow.
+5. Wind is stored as a global XYZ tangent vector plus speed, avoiding cube-face
+   component discontinuities.
+
+### Moisture And Orography
+
+1. Warm ocean cells evaporate into a persistent atmospheric moisture column.
+2. Each transport step combines wind-directed advection, lateral synoptic mixing,
+   and retained local moisture.
+   The configured step count is defined at face-128 and scales with face
+   resolution so transport distance does not change merely because detail changes.
+3. Condensation responds to column loading, broad convergence, upwind ascent, and
+   leeward descent. Rainout is rate-limited so a single coarse coastal cell cannot
+   remove an entire air mass.
+4. Ocean and land condensation thresholds differ so moisture can be exported from
+   oceans and penetrate continents.
+5. A conservative graph mixing pass turns transport-cell events into a monthly
+   climatology footprint while preserving area-weighted precipitation totals.
+
+### Snow, Evaporation, And Runoff Potential
+
+- Precipitation partitions smoothly into rain and snow from monthly temperature.
+- A bounded multi-year snow store produces snowfall, melt, and snow-water
+  equivalent fields; explicit glaciers and ice sheets are not yet modeled.
+- Ocean evaporation and provisional land evaporation feed the moisture cycle.
+- Runoff potential removes bounded evaporation and applies relief/storm runoff
+  tendencies. It is a hydrology input, not discharge.
+
+## Outputs
+
+Monthly `(12, 6, n, n)` float32 fields:
+
+- `MonthlySurfaceTemperatureC`
+- `MonthlyWindSpeedMps`
+- `MonthlyPrecipitationMm`
+- `MonthlyRelativeHumidity`
+- `MonthlySnowfallMm`
+- `MonthlySnowmeltMm`
+- `MonthlySnowWaterEquivalentMm`
+- `MonthlyEvaporationMm`
+- `MonthlyRunoffPotentialMm`
+
+`MonthlyWindVectorXYZMps` adds a final length-three component. Annual fields are
+`AnnualMeanTemperatureC`, `AnnualPrecipitationMm`, and `AnnualAridityIndex`.
+`ClimateOrographyM` and `ClimateMetadata` preserve the effective driver and model
+contract for inspection and surrogate training.
+
+## Validation Gates
+
+- Monthly means/sums exactly reconstruct annual temperature and precipitation.
+- Wind vectors remain tangent to the sphere and their norms match stored speed.
+- Northern and southern mid-latitude temperature peaks are about six months apart.
+- Comparable mid-latitude oceans have lower seasonal range than land.
+- Temperature residual after latitude correction decreases with orography.
+- Precipitation changes when orography changes and remains continuous across cube
+  faces.
+- Humidity, precipitation, snow, evaporation, and runoff remain finite and
+  physically bounded; runoff cannot exceed rain plus available melt.
+- Deterministic inputs produce byte-identical, cacheable artifacts.
+- Earth-like defaults remain inside broad temperature and water-cycle plausibility
+  bounds. These are realism gates, not Earth calibration claims.
+
+## Current Limits
+
+- Prescribed circulation tendencies replace a primitive-equation atmosphere.
+- Ocean currents, sea ice, clouds, vegetation feedback, glaciers, monsoonal land
+  pressure, and transient storms are simplified or absent.
+- Land evaporation precedes explicit soils and is therefore provisional.
+- Monthly precipitation mixing is a deliberate unresolved-weather approximation.
+- All monthly fields are currently resident in memory during the stage. Face-128
+  is small, but face-1024 requires several gigabytes; month/tile streaming and
+  chunked persistence are required before very large global runs.
+
+## Hydrology Handoff
+
+The next canonical stage consumes monthly runoff potential, precipitation,
+snowmelt, evaporation, temperature, climate orography, final terrain, lithology,
+and topology. It must implement the depression/lake/spill/breach and vector river
+contracts in Decisions 004, 005, and 014. Climate does not pre-draw river lines.

--- a/readme.md
+++ b/readme.md
@@ -71,11 +71,11 @@ Rerunning the same configuration reuses the stage cache. The current executable
 stack includes tectonics, crust/world-age fields, erosion/sedimentation, dataset
 persistence, diagnostics, and final cartography. The canonical cubed-sphere path
 now reaches connected geological provinces, boundary segments, causal
-pre-erosion elevation/orogenic morphology, and monthly orbital forcing. Explicit
-geological event history, spherical erosion, routed
-hydrology, climate, soils, biomes, and regional refinement remain implementation
-milestones; the current output is a functional prototype rather than an
-atlas-grade world.
+pre-erosion elevation/orogenic morphology, monthly orbital forcing, and seasonal
+climate/orographic precipitation. Explicit geological event history, spherical
+erosion, routed hydrology, soils, biomes, and regional refinement remain
+implementation milestones; the current output is a functional prototype rather
+than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -126,6 +126,9 @@ uv run map-maker-pipeline --stage elevation --config configs/cubed_sphere_crust_
 
 # Canonical planetary boundary conditions and monthly orbital forcing
 uv run map-maker-pipeline --stage planet --config configs/cubed_sphere_crust_state.yaml
+
+# Canonical seasonal temperature, wind, precipitation, snow, and runoff potential
+uv run map-maker-pipeline --stage climate --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
 SIMULATION_NATIVE_LIBRARIES = (
+    "climate_native",
     "elevation_native",
     "erosion_native",
     "geology_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from ._native import library_filename, workspace_root
 
 NATIVE_LIBRARIES = (
+    "climate_native",
     "elevation_native",
     "erosion_native",
     "geology_native",

--- a/src/map_maker/pipeline/_climate_native.py
+++ b/src/map_maker/pipeline/_climate_native.py
@@ -1,0 +1,309 @@
+"""Rust-backed bindings for canonical cubed-sphere seasonal climate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from cffi import FFI
+
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+CUBED_SPHERE_CLIMATE_ABI_VERSION = 1
+
+_CDEF = """
+typedef struct {
+    float global_mean_temperature_c;
+    float land_mean_temperature_c;
+    float ocean_mean_temperature_c;
+    float minimum_monthly_temperature_c;
+    float maximum_monthly_temperature_c;
+    float global_mean_annual_precipitation_mm;
+    float land_mean_annual_precipitation_mm;
+    float dry_land_area_fraction;
+    float wet_land_area_fraction;
+    float persistent_snow_land_area_fraction;
+    float maximum_wind_speed_m_s;
+} ClimateStats;
+
+uint32_t cubed_sphere_climate_abi_version(void);
+int32_t climate_run_cubed_sphere(
+    int32_t cell_count,
+    int32_t spinup_years,
+    int32_t moisture_spinup_years,
+    int32_t moisture_steps_per_month,
+    double greenhouse_offset_c,
+    double land_albedo,
+    double ocean_albedo,
+    double olr_intercept_w_m2,
+    double olr_slope_w_m2_c,
+    double heat_transport_w_m2,
+    double land_thermal_response,
+    double ocean_thermal_response,
+    double atmospheric_exchange,
+    double lapse_rate_c_per_km,
+    double wind_scale,
+    double moisture_advection_fraction,
+    double moisture_diffusion_fraction,
+    double orographic_factor,
+    double rain_shadow_factor,
+    double runoff_base_fraction,
+    const double* area,
+    const int32_t* neighbors,
+    const float* xyz,
+    const double* latitude,
+    const float* elevation,
+    const float* relief,
+    const float* ocean,
+    const float* insolation,
+    const float* declination,
+    float* climate_orography,
+    float* temperature,
+    float* wind_xyz,
+    float* wind_speed,
+    float* precipitation,
+    float* humidity,
+    float* snowfall,
+    float* snowmelt,
+    float* snowpack,
+    float* evaporation,
+    float* runoff,
+    float* annual_temperature,
+    float* annual_precipitation,
+    float* aridity,
+    ClimateStats* stats_out
+);
+"""
+
+
+def _read_array(array: np.ndarray, *, name: str, dtype: np.dtype) -> np.ndarray:
+    value = np.asarray(array)
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must be {dtype}, got {value.dtype}")
+    if not value.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"{name} must be contiguous")
+    if not value.flags["ALIGNED"]:
+        raise ValueError(f"{name} must be aligned")
+    return value
+
+
+def _write_float32(array: np.ndarray, *, name: str) -> np.ndarray:
+    value = _read_array(array, name=name, dtype=np.dtype(np.float32))
+    if not value.flags.writeable:
+        raise ValueError(f"{name} must be writable")
+    return value
+
+
+def _require_disjoint(inputs: dict[str, np.ndarray], outputs: dict[str, np.ndarray]) -> None:
+    output_items = list(outputs.items())
+    for index, (first_name, first) in enumerate(output_items):
+        for second_name, second in output_items[index + 1 :]:
+            if np.shares_memory(first, second):
+                raise ValueError(f"{first_name} and {second_name} buffers must not overlap")
+        for input_name, input_array in inputs.items():
+            if np.shares_memory(first, input_array):
+                raise ValueError(f"{first_name} and {input_name} buffers must not overlap")
+
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+native_library_info("climate_native")
+_lib = _ffi.dlopen(str(native_library_path("climate_native")))
+try:
+    _cubed_sphere_abi = int(_lib.cubed_sphere_climate_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError(
+        "climate_native lacks the cubed-sphere API; rebuild native libraries"
+    ) from exc
+if _cubed_sphere_abi != CUBED_SPHERE_CLIMATE_ABI_VERSION:
+    raise NativeLibraryAbiError(
+        "climate_native cubed-sphere ABI "
+        f"{_cubed_sphere_abi} does not match expected {CUBED_SPHERE_CLIMATE_ABI_VERSION}"
+    )
+
+
+def run_cubed_sphere_climate(
+    *,
+    spinup_years: int,
+    moisture_spinup_years: int,
+    moisture_steps_per_month: int,
+    greenhouse_offset_c: float,
+    land_albedo: float,
+    ocean_albedo: float,
+    olr_intercept_w_m2: float,
+    olr_slope_w_m2_c: float,
+    heat_transport_w_m2: float,
+    land_thermal_response: float,
+    ocean_thermal_response: float,
+    atmospheric_exchange: float,
+    lapse_rate_c_per_km: float,
+    wind_scale: float,
+    moisture_advection_fraction: float,
+    moisture_diffusion_fraction: float,
+    orographic_factor: float,
+    rain_shadow_factor: float,
+    runoff_base_fraction: float,
+    areas: np.ndarray,
+    neighbors: np.ndarray,
+    xyz: np.ndarray,
+    latitudes: np.ndarray,
+    elevation: np.ndarray,
+    relief: np.ndarray,
+    ocean: np.ndarray,
+    insolation: np.ndarray,
+    declination: np.ndarray,
+    climate_orography_out: np.ndarray,
+    temperature_out: np.ndarray,
+    wind_xyz_out: np.ndarray,
+    wind_speed_out: np.ndarray,
+    precipitation_out: np.ndarray,
+    humidity_out: np.ndarray,
+    snowfall_out: np.ndarray,
+    snowmelt_out: np.ndarray,
+    snowpack_out: np.ndarray,
+    evaporation_out: np.ndarray,
+    runoff_out: np.ndarray,
+    annual_temperature_out: np.ndarray,
+    annual_precipitation_out: np.ndarray,
+    aridity_out: np.ndarray,
+) -> dict[str, Any]:
+    area_array = _read_array(areas, name="areas", dtype=np.dtype(np.float64))
+    if (
+        area_array.ndim != 3
+        or area_array.shape[0] != 6
+        or area_array.shape[1] != area_array.shape[2]
+    ):
+        raise ValueError("areas must have shape (6, n, n)")
+    shape = area_array.shape
+    monthly_shape = (12, *shape)
+    input_arrays = {
+        "areas": area_array,
+        "neighbors": _read_array(neighbors, name="neighbors", dtype=np.dtype(np.int32)),
+        "xyz": _read_array(xyz, name="xyz", dtype=np.dtype(np.float32)),
+        "latitudes": _read_array(latitudes, name="latitudes", dtype=np.dtype(np.float64)),
+        "elevation": _read_array(elevation, name="elevation", dtype=np.dtype(np.float32)),
+        "relief": _read_array(relief, name="relief", dtype=np.dtype(np.float32)),
+        "ocean": _read_array(ocean, name="ocean", dtype=np.dtype(np.float32)),
+        "insolation": _read_array(insolation, name="insolation", dtype=np.dtype(np.float32)),
+        "declination": _read_array(declination, name="declination", dtype=np.dtype(np.float32)),
+    }
+    expected_input_shapes = {
+        "areas": shape,
+        "neighbors": (*shape, 4),
+        "xyz": (*shape, 3),
+        "latitudes": shape,
+        "elevation": shape,
+        "relief": shape,
+        "ocean": shape,
+        "insolation": monthly_shape,
+        "declination": (12,),
+    }
+    for name, expected_shape in expected_input_shapes.items():
+        if input_arrays[name].shape != expected_shape:
+            raise ValueError(f"{name} must have shape {expected_shape}")
+
+    output_arrays = {
+        name: _write_float32(array, name=name)
+        for name, array in {
+            "climate_orography_out": climate_orography_out,
+            "temperature_out": temperature_out,
+            "wind_xyz_out": wind_xyz_out,
+            "wind_speed_out": wind_speed_out,
+            "precipitation_out": precipitation_out,
+            "humidity_out": humidity_out,
+            "snowfall_out": snowfall_out,
+            "snowmelt_out": snowmelt_out,
+            "snowpack_out": snowpack_out,
+            "evaporation_out": evaporation_out,
+            "runoff_out": runoff_out,
+            "annual_temperature_out": annual_temperature_out,
+            "annual_precipitation_out": annual_precipitation_out,
+            "aridity_out": aridity_out,
+        }.items()
+    }
+    expected_output_shapes = {
+        "climate_orography_out": shape,
+        "temperature_out": monthly_shape,
+        "wind_xyz_out": (*monthly_shape, 3),
+        "wind_speed_out": monthly_shape,
+        "precipitation_out": monthly_shape,
+        "humidity_out": monthly_shape,
+        "snowfall_out": monthly_shape,
+        "snowmelt_out": monthly_shape,
+        "snowpack_out": monthly_shape,
+        "evaporation_out": monthly_shape,
+        "runoff_out": monthly_shape,
+        "annual_temperature_out": shape,
+        "annual_precipitation_out": shape,
+        "aridity_out": shape,
+    }
+    for name, expected_shape in expected_output_shapes.items():
+        if output_arrays[name].shape != expected_shape:
+            raise ValueError(f"{name} must have shape {expected_shape}")
+    _require_disjoint(input_arrays, output_arrays)
+
+    stats = _ffi.new("ClimateStats*")
+    status = int(
+        _lib.climate_run_cubed_sphere(
+            int(np.prod(shape, dtype=np.int64)),
+            int(spinup_years),
+            int(moisture_spinup_years),
+            int(moisture_steps_per_month),
+            float(greenhouse_offset_c),
+            float(land_albedo),
+            float(ocean_albedo),
+            float(olr_intercept_w_m2),
+            float(olr_slope_w_m2_c),
+            float(heat_transport_w_m2),
+            float(land_thermal_response),
+            float(ocean_thermal_response),
+            float(atmospheric_exchange),
+            float(lapse_rate_c_per_km),
+            float(wind_scale),
+            float(moisture_advection_fraction),
+            float(moisture_diffusion_fraction),
+            float(orographic_factor),
+            float(rain_shadow_factor),
+            float(runoff_base_fraction),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", input_arrays["areas"])),
+            _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", input_arrays["neighbors"])),
+            _ffi.cast("float*", _ffi.from_buffer("float[]", input_arrays["xyz"])),
+            _ffi.cast("double*", _ffi.from_buffer("double[]", input_arrays["latitudes"])),
+            *(
+                _ffi.cast("float*", _ffi.from_buffer("float[]", input_arrays[name]))
+                for name in ("elevation", "relief", "ocean", "insolation", "declination")
+            ),
+            *(
+                _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays[name]))
+                for name in expected_output_shapes
+            ),
+            stats,
+        )
+    )
+    if status != 0:
+        messages = {
+            1: "invalid dimensions or null buffers",
+            2: "invalid climate controls",
+            3: "non-finite climate inputs",
+            4: "invalid cubed-sphere topology",
+        }
+        raise ValueError(
+            f"cubed-sphere climate kernel failed: {messages.get(status, f'status {status}')}"
+        )
+
+    return {
+        "global_mean_temperature_c": float(stats.global_mean_temperature_c),
+        "land_mean_temperature_c": float(stats.land_mean_temperature_c),
+        "ocean_mean_temperature_c": float(stats.ocean_mean_temperature_c),
+        "minimum_monthly_temperature_c": float(stats.minimum_monthly_temperature_c),
+        "maximum_monthly_temperature_c": float(stats.maximum_monthly_temperature_c),
+        "global_mean_annual_precipitation_mm": float(stats.global_mean_annual_precipitation_mm),
+        "land_mean_annual_precipitation_mm": float(stats.land_mean_annual_precipitation_mm),
+        "dry_land_area_fraction": float(stats.dry_land_area_fraction),
+        "wet_land_area_fraction": float(stats.wet_land_area_fraction),
+        "persistent_snow_land_area_fraction": float(stats.persistent_snow_land_area_fraction),
+        "maximum_wind_speed_m_s": float(stats.maximum_wind_speed_m_s),
+    }
+
+
+__all__ = ["CUBED_SPHERE_CLIMATE_ABI_VERSION", "run_cubed_sphere_climate"]

--- a/src/map_maker/pipeline/native/climate/Cargo.toml
+++ b/src/map_maker/pipeline/native/climate/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "climate_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/climate/src/lib.rs
+++ b/src/map_maker/pipeline/native/climate/src/lib.rs
@@ -1,0 +1,977 @@
+use std::f64::consts::PI;
+use std::slice;
+
+const MONTHS: usize = 12;
+const NEIGHBORS: usize = 4;
+const VECTOR_COMPONENTS: usize = 3;
+const DAYS_PER_MONTH: f64 = 365.2422 / 12.0;
+
+#[repr(C)]
+pub struct ClimateStats {
+    pub global_mean_temperature_c: f32,
+    pub land_mean_temperature_c: f32,
+    pub ocean_mean_temperature_c: f32,
+    pub minimum_monthly_temperature_c: f32,
+    pub maximum_monthly_temperature_c: f32,
+    pub global_mean_annual_precipitation_mm: f32,
+    pub land_mean_annual_precipitation_mm: f32,
+    pub dry_land_area_fraction: f32,
+    pub wet_land_area_fraction: f32,
+    pub persistent_snow_land_area_fraction: f32,
+    pub maximum_wind_speed_m_s: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn climate_native_abi_version() -> u32 {
+    2
+}
+
+#[no_mangle]
+pub extern "C" fn cubed_sphere_climate_abi_version() -> u32 {
+    1
+}
+
+fn dot(first: [f64; 3], second: [f64; 3]) -> f64 {
+    first[0] * second[0] + first[1] * second[1] + first[2] * second[2]
+}
+
+fn cross(first: [f64; 3], second: [f64; 3]) -> [f64; 3] {
+    [
+        first[1] * second[2] - first[2] * second[1],
+        first[2] * second[0] - first[0] * second[2],
+        first[0] * second[1] - first[1] * second[0],
+    ]
+}
+
+fn norm(vector: [f64; 3]) -> f64 {
+    dot(vector, vector).sqrt()
+}
+
+fn normalized(vector: [f64; 3]) -> [f64; 3] {
+    let length = norm(vector).max(1e-12);
+    [vector[0] / length, vector[1] / length, vector[2] / length]
+}
+
+fn radial_at(xyz: &[f32], cell: usize) -> [f64; 3] {
+    let offset = cell * VECTOR_COMPONENTS;
+    [
+        f64::from(xyz[offset]),
+        f64::from(xyz[offset + 1]),
+        f64::from(xyz[offset + 2]),
+    ]
+}
+
+fn tangent_basis(radial: [f64; 3]) -> ([f64; 3], [f64; 3]) {
+    let horizontal = (radial[0] * radial[0] + radial[1] * radial[1]).sqrt();
+    let east = if horizontal > 1e-10 {
+        [-radial[1] / horizontal, radial[0] / horizontal, 0.0]
+    } else {
+        [0.0, 1.0, 0.0]
+    };
+    let north = normalized(cross(radial, east));
+    (east, north)
+}
+
+fn tangent_direction(source: [f64; 3], target: [f64; 3]) -> ([f64; 3], f64) {
+    let cosine = dot(source, target).clamp(-1.0, 1.0);
+    let angle = cosine.acos().max(1e-9);
+    let projected = [
+        target[0] - cosine * source[0],
+        target[1] - cosine * source[1],
+        target[2] - cosine * source[2],
+    ];
+    (normalized(projected), angle)
+}
+
+fn interpolate(points: &[(f64, f64)], position: f64) -> f64 {
+    if position <= points[0].0 {
+        return points[0].1;
+    }
+    for pair in points.windows(2) {
+        let (left_x, left_y) = pair[0];
+        let (right_x, right_y) = pair[1];
+        if position <= right_x {
+            let weight = (position - left_x) / (right_x - left_x);
+            return left_y + weight * (right_y - left_y);
+        }
+    }
+    points[points.len() - 1].1
+}
+
+fn circulation_components(latitude: f64, declination: f64) -> (f64, f64) {
+    let shifted = (latitude - 0.25 * declination).clamp(-PI / 2.0, PI / 2.0);
+    let absolute_degrees = shifted.abs().to_degrees();
+    let zonal = interpolate(
+        &[
+            (0.0, -2.0),
+            (15.0, -7.5),
+            (30.0, 0.0),
+            (50.0, 11.5),
+            (65.0, 0.0),
+            (80.0, -5.0),
+            (90.0, 0.0),
+        ],
+        absolute_degrees,
+    );
+    let northward_in_northern_hemisphere = interpolate(
+        &[
+            (0.0, 0.0),
+            (15.0, -2.2),
+            (30.0, 0.0),
+            (45.0, 1.5),
+            (60.0, 0.0),
+            (75.0, -1.0),
+            (90.0, 0.0),
+        ],
+        absolute_degrees,
+    );
+    let meridional = northward_in_northern_hemisphere * shifted.signum();
+    (zonal, meridional)
+}
+
+fn moisture_capacity_mm(temperature_c: f64) -> f64 {
+    (7.5 * (0.07 * temperature_c).exp()).clamp(1.5, 75.0)
+}
+
+fn smooth_orography(
+    total: usize,
+    neighbors: &[i32],
+    ocean: &[f32],
+    elevation: &[f32],
+    output: &mut [f32],
+) {
+    output.copy_from_slice(elevation);
+    let mut next = vec![0.0f32; total];
+    for _ in 0..5 {
+        for cell in 0..total {
+            let is_ocean = ocean[cell] >= 0.5;
+            let mut neighbor_sum = 0.0f64;
+            let mut neighbor_count = 0usize;
+            for edge in 0..NEIGHBORS {
+                let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                if (ocean[neighbor] >= 0.5) == is_ocean {
+                    neighbor_sum += f64::from(output[neighbor]);
+                    neighbor_count += 1;
+                }
+            }
+            next[cell] = if neighbor_count == 0 {
+                output[cell]
+            } else {
+                (0.48 * f64::from(output[cell]) + 0.52 * neighbor_sum / neighbor_count as f64)
+                    as f32
+            };
+        }
+        output.copy_from_slice(&next);
+    }
+    for cell in 0..total {
+        output[cell] = if ocean[cell] >= 0.5 {
+            0.0
+        } else {
+            output[cell].max(0.0)
+        };
+    }
+}
+
+fn mix_monthly_field(total: usize, neighbors: &[i32], areas: &[f64], field: &mut [f32]) {
+    let mut mixed = vec![0.0f32; total];
+    for month in 0..MONTHS {
+        let month_offset = month * total;
+        let original_total = (0..total)
+            .map(|cell| f64::from(field[month_offset + cell]) * areas[cell])
+            .sum::<f64>();
+        // Monthly climatology represents unresolved synoptic weather, so mix
+        // the cell-scale transport signal over a roughly 400 km footprint.
+        for _ in 0..16 {
+            for cell in 0..total {
+                let neighbor_mean = (0..NEIGHBORS)
+                    .map(|edge| {
+                        let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                        f64::from(field[month_offset + neighbor])
+                    })
+                    .sum::<f64>()
+                    / NEIGHBORS as f64;
+                mixed[cell] =
+                    (0.72 * f64::from(field[month_offset + cell]) + 0.28 * neighbor_mean) as f32;
+            }
+            field[month_offset..month_offset + total].copy_from_slice(&mixed);
+        }
+        let mixed_total = (0..total)
+            .map(|cell| f64::from(field[month_offset + cell]) * areas[cell])
+            .sum::<f64>();
+        let correction = if mixed_total > 0.0 {
+            original_total / mixed_total
+        } else {
+            1.0
+        };
+        for cell in 0..total {
+            field[month_offset + cell] =
+                (f64::from(field[month_offset + cell]) * correction) as f32;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_temperature(
+    total: usize,
+    spinup_years: usize,
+    greenhouse_offset_c: f64,
+    land_albedo: f64,
+    ocean_albedo: f64,
+    olr_intercept_w_m2: f64,
+    olr_slope_w_m2_c: f64,
+    heat_transport_w_m2: f64,
+    land_thermal_response: f64,
+    ocean_thermal_response: f64,
+    atmospheric_exchange: f64,
+    lapse_rate_c_per_km: f64,
+    neighbors: &[i32],
+    latitudes: &[f64],
+    elevation: &[f32],
+    ocean: &[f32],
+    insolation: &[f32],
+    temperature: &mut [f32],
+) {
+    let equilibrium = |cell: usize, forcing: f64| -> f64 {
+        let latitude_sine = latitudes[cell].sin();
+        let transport = heat_transport_w_m2 * (3.0 * latitude_sine.powi(2) - 1.0);
+        let albedo = if ocean[cell] >= 0.5 {
+            ocean_albedo
+        } else {
+            land_albedo
+        };
+        let lapse = lapse_rate_c_per_km * f64::from(elevation[cell]).max(0.0) / 1000.0;
+        (((1.0 - albedo) * forcing + transport - olr_intercept_w_m2) / olr_slope_w_m2_c
+            + greenhouse_offset_c
+            - lapse)
+            .clamp(-95.0, 75.0)
+    };
+
+    let mut state = vec![0.0f64; total];
+    let mut next = vec![0.0f64; total];
+    for cell in 0..total {
+        let annual_forcing = (0..MONTHS)
+            .map(|month| f64::from(insolation[month * total + cell]))
+            .sum::<f64>()
+            / MONTHS as f64;
+        state[cell] = equilibrium(cell, annual_forcing);
+    }
+
+    for year in 0..spinup_years {
+        for month in 0..MONTHS {
+            for cell in 0..total {
+                let neighbor_mean = (0..NEIGHBORS)
+                    .map(|edge| state[neighbors[cell * NEIGHBORS + edge] as usize])
+                    .sum::<f64>()
+                    / NEIGHBORS as f64;
+                let response = if ocean[cell] >= 0.5 {
+                    ocean_thermal_response
+                } else {
+                    land_thermal_response
+                };
+                let target = equilibrium(cell, f64::from(insolation[month * total + cell]));
+                next[cell] = (state[cell]
+                    + response * (target - state[cell])
+                    + atmospheric_exchange * (neighbor_mean - state[cell]))
+                    .clamp(-95.0, 70.0);
+            }
+            state.copy_from_slice(&next);
+            if year + 1 == spinup_years {
+                for cell in 0..total {
+                    temperature[month * total + cell] = state[cell] as f32;
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_wind(
+    total: usize,
+    wind_scale: f64,
+    neighbors: &[i32],
+    xyz: &[f32],
+    latitudes: &[f64],
+    elevation: &[f32],
+    declination: &[f32],
+    temperature: &[f32],
+    wind_xyz: &mut [f32],
+    wind_speed: &mut [f32],
+) {
+    for month in 0..MONTHS {
+        for cell in 0..total {
+            let radial = radial_at(xyz, cell);
+            let (east, north) = tangent_basis(radial);
+            let (zonal, meridional) =
+                circulation_components(latitudes[cell], f64::from(declination[month]));
+            let mut thermal_gradient = [0.0f64; 3];
+            let mut terrain_gradient = [0.0f64; 3];
+            let center_temperature = f64::from(temperature[month * total + cell]);
+            let center_elevation = f64::from(elevation[cell]);
+            for edge in 0..NEIGHBORS {
+                let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                let (direction, angle) = tangent_direction(radial, radial_at(xyz, neighbor));
+                let temperature_delta =
+                    f64::from(temperature[month * total + neighbor]) - center_temperature;
+                let elevation_delta = f64::from(elevation[neighbor]) - center_elevation;
+                for component in 0..VECTOR_COMPONENTS {
+                    thermal_gradient[component] += temperature_delta / angle * direction[component];
+                    terrain_gradient[component] += elevation_delta / angle * direction[component];
+                }
+            }
+            let thermal_magnitude = norm(thermal_gradient);
+            let thermal_direction = normalized(thermal_gradient);
+            let geostrophic_direction = normalized(cross(radial, thermal_direction));
+            let thermal_flow = (thermal_magnitude * 0.025).clamp(0.0, 2.5);
+            let geostrophic_flow =
+                (thermal_magnitude * 0.035).clamp(0.0, 3.5) * latitudes[cell].signum();
+            let mut wind = [0.0f64; 3];
+            for component in 0..VECTOR_COMPONENTS {
+                wind[component] = wind_scale
+                    * (zonal * east[component]
+                        + meridional * north[component]
+                        + thermal_flow * thermal_direction[component]
+                        + geostrophic_flow * geostrophic_direction[component]);
+            }
+
+            let terrain_magnitude = norm(terrain_gradient);
+            if terrain_magnitude > 1e-9 {
+                let terrain_direction = normalized(terrain_gradient);
+                let uphill_component = dot(wind, terrain_direction).max(0.0);
+                for component in 0..VECTOR_COMPONENTS {
+                    wind[component] -= 0.3 * uphill_component * terrain_direction[component];
+                }
+            }
+            let radial_leak = dot(wind, radial);
+            for component in 0..VECTOR_COMPONENTS {
+                wind[component] -= radial_leak * radial[component];
+            }
+            let speed = norm(wind);
+            wind_speed[month * total + cell] = speed as f32;
+            let output_offset = (month * total + cell) * VECTOR_COMPONENTS;
+            for component in 0..VECTOR_COMPONENTS {
+                wind_xyz[output_offset + component] = wind[component] as f32;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_moisture(
+    total: usize,
+    spinup_years: usize,
+    steps_per_month: usize,
+    advection_fraction: f64,
+    diffusion_fraction: f64,
+    orographic_factor: f64,
+    rain_shadow_factor: f64,
+    neighbors: &[i32],
+    xyz: &[f32],
+    elevation: &[f32],
+    ocean: &[f32],
+    temperature: &[f32],
+    wind_xyz: &[f32],
+    precipitation: &mut [f32],
+    humidity: &mut [f32],
+    evaporation: &mut [f32],
+) {
+    precipitation.fill(0.0);
+    humidity.fill(0.0);
+    evaporation.fill(0.0);
+    let mut moisture = vec![0.0f64; total];
+    let mut next = vec![0.0f64; total];
+    let mut upslope = vec![0.0f64; total];
+    let mut downslope = vec![0.0f64; total];
+    for cell in 0..total {
+        let capacity = moisture_capacity_mm(f64::from(temperature[cell]));
+        moisture[cell] = capacity * if ocean[cell] >= 0.5 { 0.78 } else { 0.45 };
+    }
+    let retained_fraction = 1.0 - advection_fraction - diffusion_fraction;
+    let step_days = DAYS_PER_MONTH / steps_per_month as f64;
+
+    for year in 0..spinup_years {
+        for month in 0..MONTHS {
+            for cell in 0..total {
+                let radial = radial_at(xyz, cell);
+                let wind_offset = (month * total + cell) * VECTOR_COMPONENTS;
+                let wind = [
+                    f64::from(wind_xyz[wind_offset]),
+                    f64::from(wind_xyz[wind_offset + 1]),
+                    f64::from(wind_xyz[wind_offset + 2]),
+                ];
+                let wind_direction = normalized(wind);
+                let mut weight_sum = 0.0;
+                let mut upwind_elevation = 0.0;
+                for edge in 0..NEIGHBORS {
+                    let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                    let (direction, _) = tangent_direction(radial, radial_at(xyz, neighbor));
+                    let weight = (-dot(wind_direction, direction)).max(0.0).powi(2);
+                    weight_sum += weight;
+                    upwind_elevation += weight * f64::from(elevation[neighbor]);
+                }
+                if weight_sum > 1e-10 {
+                    upwind_elevation /= weight_sum;
+                } else {
+                    upwind_elevation = (0..NEIGHBORS)
+                        .map(|edge| {
+                            let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                            f64::from(elevation[neighbor])
+                        })
+                        .sum::<f64>()
+                        / NEIGHBORS as f64;
+                }
+                let elevation_delta = f64::from(elevation[cell]) - upwind_elevation;
+                upslope[cell] = (elevation_delta / 1000.0).max(0.0);
+                downslope[cell] = (-elevation_delta / 1000.0).max(0.0);
+            }
+
+            for _ in 0..steps_per_month {
+                next.fill(0.0);
+                for cell in 0..total {
+                    let temperature_c = f64::from(temperature[month * total + cell]);
+                    let capacity = moisture_capacity_mm(temperature_c);
+                    let relative_humidity = (moisture[cell] / capacity).clamp(0.0, 1.2);
+                    let warmth = ((temperature_c + 15.0) / 35.0).clamp(0.15, 1.5);
+                    let evaporation_rate = if ocean[cell] >= 0.5 {
+                        6.2 * warmth * (1.0 - 0.45 * relative_humidity.min(1.0))
+                    } else {
+                        0.85 * warmth * relative_humidity.min(1.0)
+                    };
+                    let evaporated = evaporation_rate.max(0.0) * step_days;
+                    if year + 1 == spinup_years {
+                        evaporation[month * total + cell] += evaporated as f32;
+                    }
+                    let available = moisture[cell] + evaporated;
+                    next[cell] += available * retained_fraction;
+                    let diffuse_packet = available * diffusion_fraction / NEIGHBORS as f64;
+                    for edge in 0..NEIGHBORS {
+                        let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                        next[neighbor] += diffuse_packet;
+                    }
+
+                    let radial = radial_at(xyz, cell);
+                    let wind_offset = (month * total + cell) * VECTOR_COMPONENTS;
+                    let wind = normalized([
+                        f64::from(wind_xyz[wind_offset]),
+                        f64::from(wind_xyz[wind_offset + 1]),
+                        f64::from(wind_xyz[wind_offset + 2]),
+                    ]);
+                    let mut weights = [0.0f64; NEIGHBORS];
+                    let mut weight_sum = 0.0;
+                    for (edge, weight) in weights.iter_mut().enumerate() {
+                        let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                        let (direction, _) = tangent_direction(radial, radial_at(xyz, neighbor));
+                        *weight = dot(wind, direction).max(0.0).powi(2);
+                        weight_sum += *weight;
+                    }
+                    if weight_sum <= 1e-10 {
+                        next[cell] += available * advection_fraction;
+                    } else {
+                        for (edge, weight) in weights.iter().enumerate() {
+                            let neighbor = neighbors[cell * NEIGHBORS + edge] as usize;
+                            next[neighbor] += available * advection_fraction * *weight / weight_sum;
+                        }
+                    }
+                }
+
+                for cell in 0..total {
+                    let capacity =
+                        moisture_capacity_mm(f64::from(temperature[month * total + cell]));
+                    let is_ocean = ocean[cell] >= 0.5;
+                    let shadow = (-rain_shadow_factor * downslope[cell]).exp();
+                    let background_rate: f64 = if is_ocean { 0.0001 } else { 0.015 };
+                    let background = next[cell] * (background_rate * step_days).min(0.22) * shadow;
+                    let saturation_threshold = if is_ocean { 10.0 } else { 1.1 };
+                    let supersaturation =
+                        (next[cell] - saturation_threshold * capacity).max(0.0) * 0.03;
+                    let orographic = if is_ocean {
+                        0.0
+                    } else {
+                        next[cell] * (1.0 - (-orographic_factor * upslope[cell]).exp()) * 0.65
+                    };
+                    let condensed =
+                        (background + supersaturation + orographic).min(next[cell] * 0.05);
+                    next[cell] -= condensed;
+                    if year + 1 == spinup_years {
+                        precipitation[month * total + cell] += condensed as f32;
+                    }
+                }
+                moisture.copy_from_slice(&next);
+            }
+
+            if year + 1 == spinup_years {
+                for cell in 0..total {
+                    let capacity =
+                        moisture_capacity_mm(f64::from(temperature[month * total + cell]));
+                    humidity[month * total + cell] =
+                        (moisture[cell] / capacity).clamp(0.0, 1.0) as f32;
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_surface_water(
+    total: usize,
+    runoff_base_fraction: f64,
+    ocean: &[f32],
+    relief: &[f32],
+    temperature: &[f32],
+    precipitation: &[f32],
+    evaporation: &[f32],
+    snowfall: &mut [f32],
+    snowmelt: &mut [f32],
+    snowpack: &mut [f32],
+    runoff: &mut [f32],
+) {
+    snowfall.fill(0.0);
+    snowmelt.fill(0.0);
+    snowpack.fill(0.0);
+    runoff.fill(0.0);
+    let mut stored_snow = vec![0.0f64; total];
+    for year in 0..24 {
+        for month in 0..MONTHS {
+            for cell in 0..total {
+                let offset = month * total + cell;
+                if ocean[cell] >= 0.5 {
+                    stored_snow[cell] = 0.0;
+                    continue;
+                }
+                let temperature_c = f64::from(temperature[offset]);
+                let snow_fraction = ((2.0 - temperature_c) / 5.0).clamp(0.0, 1.0);
+                let fallen = f64::from(precipitation[offset]) * snow_fraction;
+                stored_snow[cell] += fallen;
+                let melt_capacity = temperature_c.max(0.0) * 12.0;
+                let melted = stored_snow[cell].min(melt_capacity);
+                stored_snow[cell] -= melted;
+                let sublimated = stored_snow[cell].min(0.004 * stored_snow[cell] + 0.2);
+                stored_snow[cell] = (stored_snow[cell] - sublimated).min(5000.0);
+                if year == 23 {
+                    snowfall[offset] = fallen as f32;
+                    snowmelt[offset] = melted as f32;
+                    snowpack[offset] = stored_snow[cell] as f32;
+                }
+            }
+        }
+    }
+
+    for month in 0..MONTHS {
+        for cell in 0..total {
+            let offset = month * total + cell;
+            if ocean[cell] >= 0.5 {
+                continue;
+            }
+            let rain = (f64::from(precipitation[offset]) - f64::from(snowfall[offset])).max(0.0);
+            let available = rain + f64::from(snowmelt[offset]);
+            let effective_evaporation = f64::from(evaporation[offset]).min(0.85 * available);
+            let relief_factor = (f64::from(relief[cell]) / 1500.0).clamp(0.0, 1.0);
+            let storm_factor = (f64::from(precipitation[offset]) / 200.0).clamp(0.0, 1.0);
+            let runoff_fraction =
+                (runoff_base_fraction + 0.25 * relief_factor + 0.15 * storm_factor)
+                    .clamp(0.0, 0.95);
+            runoff[offset] =
+                ((available - effective_evaporation).max(0.0) * runoff_fraction) as f32;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn summarize(
+    total: usize,
+    areas: &[f64],
+    ocean: &[f32],
+    temperature: &[f32],
+    precipitation: &[f32],
+    evaporation: &[f32],
+    snowpack: &[f32],
+    wind_speed: &[f32],
+    annual_temperature: &mut [f32],
+    annual_precipitation: &mut [f32],
+    aridity: &mut [f32],
+) -> ClimateStats {
+    let mut total_area = 0.0;
+    let mut land_area = 0.0;
+    let mut ocean_area = 0.0;
+    let mut global_temperature_sum = 0.0;
+    let mut land_temperature_sum = 0.0;
+    let mut ocean_temperature_sum = 0.0;
+    let mut global_precipitation_sum = 0.0;
+    let mut land_precipitation_sum = 0.0;
+    let mut dry_land_area = 0.0;
+    let mut wet_land_area = 0.0;
+    let mut snow_land_area = 0.0;
+    let mut minimum_temperature = f32::INFINITY;
+    let mut maximum_temperature = f32::NEG_INFINITY;
+    let mut maximum_wind = 0.0f32;
+
+    for cell in 0..total {
+        let mut temperature_sum = 0.0f32;
+        let mut precipitation_sum = 0.0f32;
+        let mut evaporation_sum = 0.0f32;
+        let mut maximum_snowpack = 0.0f32;
+        for month in 0..MONTHS {
+            let offset = month * total + cell;
+            let temperature_value = temperature[offset];
+            temperature_sum += temperature_value;
+            precipitation_sum += precipitation[offset];
+            evaporation_sum += evaporation[offset];
+            maximum_snowpack = maximum_snowpack.max(snowpack[offset]);
+            minimum_temperature = minimum_temperature.min(temperature_value);
+            maximum_temperature = maximum_temperature.max(temperature_value);
+            maximum_wind = maximum_wind.max(wind_speed[offset]);
+        }
+        let mean_temperature = temperature_sum / MONTHS as f32;
+        annual_temperature[cell] = mean_temperature;
+        annual_precipitation[cell] = precipitation_sum;
+        aridity[cell] = precipitation_sum / evaporation_sum.max(1.0);
+        let area = areas[cell];
+        total_area += area;
+        global_temperature_sum += f64::from(mean_temperature) * area;
+        global_precipitation_sum += f64::from(precipitation_sum) * area;
+        if ocean[cell] >= 0.5 {
+            ocean_area += area;
+            ocean_temperature_sum += f64::from(mean_temperature) * area;
+        } else {
+            land_area += area;
+            land_temperature_sum += f64::from(mean_temperature) * area;
+            land_precipitation_sum += f64::from(precipitation_sum) * area;
+            if precipitation_sum < 250.0 {
+                dry_land_area += area;
+            }
+            if precipitation_sum > 2000.0 {
+                wet_land_area += area;
+            }
+            if maximum_snowpack > 100.0 {
+                snow_land_area += area;
+            }
+        }
+    }
+
+    ClimateStats {
+        global_mean_temperature_c: (global_temperature_sum / total_area) as f32,
+        land_mean_temperature_c: (land_temperature_sum / land_area) as f32,
+        ocean_mean_temperature_c: (ocean_temperature_sum / ocean_area) as f32,
+        minimum_monthly_temperature_c: minimum_temperature,
+        maximum_monthly_temperature_c: maximum_temperature,
+        global_mean_annual_precipitation_mm: (global_precipitation_sum / total_area) as f32,
+        land_mean_annual_precipitation_mm: (land_precipitation_sum / land_area) as f32,
+        dry_land_area_fraction: (dry_land_area / land_area) as f32,
+        wet_land_area_fraction: (wet_land_area / land_area) as f32,
+        persistent_snow_land_area_fraction: (snow_land_area / land_area) as f32,
+        maximum_wind_speed_m_s: maximum_wind,
+    }
+}
+
+/// Compute a structurally realistic monthly climate on a canonical cubed sphere.
+///
+/// Returns 0 on success, 1 for invalid dimensions/pointers, 2 for invalid
+/// controls, 3 for invalid numeric inputs, and 4 for invalid topology.
+///
+/// # Safety
+///
+/// All input pointers must reference the documented readable lengths. Outputs
+/// must reference distinct writable buffers of the documented lengths and must
+/// not alias any input. `stats_out` may be null or reference one writable value.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn climate_run_cubed_sphere(
+    cell_count: i32,
+    spinup_years: i32,
+    moisture_spinup_years: i32,
+    moisture_steps_per_month: i32,
+    greenhouse_offset_c: f64,
+    land_albedo: f64,
+    ocean_albedo: f64,
+    olr_intercept_w_m2: f64,
+    olr_slope_w_m2_c: f64,
+    heat_transport_w_m2: f64,
+    land_thermal_response: f64,
+    ocean_thermal_response: f64,
+    atmospheric_exchange: f64,
+    lapse_rate_c_per_km: f64,
+    wind_scale: f64,
+    moisture_advection_fraction: f64,
+    moisture_diffusion_fraction: f64,
+    orographic_factor: f64,
+    rain_shadow_factor: f64,
+    runoff_base_fraction: f64,
+    area_ptr: *const f64,
+    neighbor_ptr: *const i32,
+    xyz_ptr: *const f32,
+    latitude_ptr: *const f64,
+    elevation_ptr: *const f32,
+    relief_ptr: *const f32,
+    ocean_ptr: *const f32,
+    insolation_ptr: *const f32,
+    declination_ptr: *const f32,
+    climate_orography_ptr: *mut f32,
+    temperature_ptr: *mut f32,
+    wind_xyz_ptr: *mut f32,
+    wind_speed_ptr: *mut f32,
+    precipitation_ptr: *mut f32,
+    humidity_ptr: *mut f32,
+    snowfall_ptr: *mut f32,
+    snowmelt_ptr: *mut f32,
+    snowpack_ptr: *mut f32,
+    evaporation_ptr: *mut f32,
+    runoff_ptr: *mut f32,
+    annual_temperature_ptr: *mut f32,
+    annual_precipitation_ptr: *mut f32,
+    aridity_ptr: *mut f32,
+    stats_out: *mut ClimateStats,
+) -> i32 {
+    if cell_count <= 0
+        || area_ptr.is_null()
+        || neighbor_ptr.is_null()
+        || xyz_ptr.is_null()
+        || latitude_ptr.is_null()
+        || elevation_ptr.is_null()
+        || relief_ptr.is_null()
+        || ocean_ptr.is_null()
+        || insolation_ptr.is_null()
+        || declination_ptr.is_null()
+        || climate_orography_ptr.is_null()
+        || temperature_ptr.is_null()
+        || wind_xyz_ptr.is_null()
+        || wind_speed_ptr.is_null()
+        || precipitation_ptr.is_null()
+        || humidity_ptr.is_null()
+        || snowfall_ptr.is_null()
+        || snowmelt_ptr.is_null()
+        || snowpack_ptr.is_null()
+        || evaporation_ptr.is_null()
+        || runoff_ptr.is_null()
+        || annual_temperature_ptr.is_null()
+        || annual_precipitation_ptr.is_null()
+        || aridity_ptr.is_null()
+    {
+        return 1;
+    }
+    let controls = [
+        greenhouse_offset_c,
+        land_albedo,
+        ocean_albedo,
+        olr_intercept_w_m2,
+        olr_slope_w_m2_c,
+        heat_transport_w_m2,
+        land_thermal_response,
+        ocean_thermal_response,
+        atmospheric_exchange,
+        lapse_rate_c_per_km,
+        wind_scale,
+        moisture_advection_fraction,
+        moisture_diffusion_fraction,
+        orographic_factor,
+        rain_shadow_factor,
+        runoff_base_fraction,
+    ];
+    if spinup_years < 2
+        || moisture_spinup_years < 1
+        || moisture_steps_per_month < 2
+        || controls.iter().any(|value| !value.is_finite())
+        || !(0.0..1.0).contains(&land_albedo)
+        || !(0.0..1.0).contains(&ocean_albedo)
+        || olr_slope_w_m2_c <= 0.0
+        || !(0.0..=1.0).contains(&land_thermal_response)
+        || !(0.0..=1.0).contains(&ocean_thermal_response)
+        || !(0.0..=1.0).contains(&atmospheric_exchange)
+        || land_thermal_response + atmospheric_exchange > 1.0
+        || ocean_thermal_response + atmospheric_exchange > 1.0
+        || lapse_rate_c_per_km < 0.0
+        || wind_scale <= 0.0
+        || moisture_advection_fraction < 0.0
+        || moisture_diffusion_fraction < 0.0
+        || moisture_advection_fraction + moisture_diffusion_fraction > 1.0
+        || orographic_factor < 0.0
+        || rain_shadow_factor < 0.0
+        || !(0.0..=1.0).contains(&runoff_base_fraction)
+    {
+        return 2;
+    }
+
+    let total = cell_count as usize;
+    let monthly_len = match total.checked_mul(MONTHS) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let edge_len = match total.checked_mul(NEIGHBORS) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let xyz_len = match total.checked_mul(VECTOR_COMPONENTS) {
+        Some(value) => value,
+        None => return 1,
+    };
+    let wind_len = match monthly_len.checked_mul(VECTOR_COMPONENTS) {
+        Some(value) => value,
+        None => return 1,
+    };
+
+    let areas = unsafe { slice::from_raw_parts(area_ptr, total) };
+    let neighbors = unsafe { slice::from_raw_parts(neighbor_ptr, edge_len) };
+    let xyz = unsafe { slice::from_raw_parts(xyz_ptr, xyz_len) };
+    let latitudes = unsafe { slice::from_raw_parts(latitude_ptr, total) };
+    let elevation = unsafe { slice::from_raw_parts(elevation_ptr, total) };
+    let relief = unsafe { slice::from_raw_parts(relief_ptr, total) };
+    let ocean = unsafe { slice::from_raw_parts(ocean_ptr, total) };
+    let insolation = unsafe { slice::from_raw_parts(insolation_ptr, monthly_len) };
+    let declination = unsafe { slice::from_raw_parts(declination_ptr, MONTHS) };
+    if areas
+        .iter()
+        .any(|value| !value.is_finite() || *value <= 0.0)
+        || xyz.iter().any(|value| !value.is_finite())
+        || latitudes
+            .iter()
+            .any(|value| !value.is_finite() || value.abs() > PI / 2.0 + 1e-9)
+        || elevation.iter().any(|value| !value.is_finite())
+        || relief
+            .iter()
+            .any(|value| !value.is_finite() || *value < 0.0)
+        || ocean
+            .iter()
+            .any(|value| !value.is_finite() || !(0.0..=1.0).contains(value))
+        || insolation
+            .iter()
+            .any(|value| !value.is_finite() || *value < 0.0)
+        || declination.iter().any(|value| !value.is_finite())
+    {
+        return 3;
+    }
+    let ocean_cells = ocean.iter().filter(|value| **value >= 0.5).count();
+    if ocean_cells == 0 || ocean_cells == total {
+        return 3;
+    }
+    if neighbors
+        .iter()
+        .any(|neighbor| *neighbor < 0 || *neighbor as usize >= total)
+    {
+        return 4;
+    }
+
+    let climate_orography = unsafe { slice::from_raw_parts_mut(climate_orography_ptr, total) };
+    let temperature = unsafe { slice::from_raw_parts_mut(temperature_ptr, monthly_len) };
+    let wind_xyz = unsafe { slice::from_raw_parts_mut(wind_xyz_ptr, wind_len) };
+    let wind_speed = unsafe { slice::from_raw_parts_mut(wind_speed_ptr, monthly_len) };
+    let precipitation = unsafe { slice::from_raw_parts_mut(precipitation_ptr, monthly_len) };
+    let humidity = unsafe { slice::from_raw_parts_mut(humidity_ptr, monthly_len) };
+    let snowfall = unsafe { slice::from_raw_parts_mut(snowfall_ptr, monthly_len) };
+    let snowmelt = unsafe { slice::from_raw_parts_mut(snowmelt_ptr, monthly_len) };
+    let snowpack = unsafe { slice::from_raw_parts_mut(snowpack_ptr, monthly_len) };
+    let evaporation = unsafe { slice::from_raw_parts_mut(evaporation_ptr, monthly_len) };
+    let runoff = unsafe { slice::from_raw_parts_mut(runoff_ptr, monthly_len) };
+    let annual_temperature = unsafe { slice::from_raw_parts_mut(annual_temperature_ptr, total) };
+    let annual_precipitation =
+        unsafe { slice::from_raw_parts_mut(annual_precipitation_ptr, total) };
+    let aridity = unsafe { slice::from_raw_parts_mut(aridity_ptr, total) };
+
+    smooth_orography(total, neighbors, ocean, elevation, climate_orography);
+    run_temperature(
+        total,
+        spinup_years as usize,
+        greenhouse_offset_c,
+        land_albedo,
+        ocean_albedo,
+        olr_intercept_w_m2,
+        olr_slope_w_m2_c,
+        heat_transport_w_m2,
+        land_thermal_response,
+        ocean_thermal_response,
+        atmospheric_exchange,
+        lapse_rate_c_per_km,
+        neighbors,
+        latitudes,
+        climate_orography,
+        ocean,
+        insolation,
+        temperature,
+    );
+    run_wind(
+        total,
+        wind_scale,
+        neighbors,
+        xyz,
+        latitudes,
+        climate_orography,
+        declination,
+        temperature,
+        wind_xyz,
+        wind_speed,
+    );
+    run_moisture(
+        total,
+        moisture_spinup_years as usize,
+        moisture_steps_per_month as usize,
+        moisture_advection_fraction,
+        moisture_diffusion_fraction,
+        orographic_factor,
+        rain_shadow_factor,
+        neighbors,
+        xyz,
+        climate_orography,
+        ocean,
+        temperature,
+        wind_xyz,
+        precipitation,
+        humidity,
+        evaporation,
+    );
+    mix_monthly_field(total, neighbors, areas, precipitation);
+    run_surface_water(
+        total,
+        runoff_base_fraction,
+        ocean,
+        relief,
+        temperature,
+        precipitation,
+        evaporation,
+        snowfall,
+        snowmelt,
+        snowpack,
+        runoff,
+    );
+    let stats = summarize(
+        total,
+        areas,
+        ocean,
+        temperature,
+        precipitation,
+        evaporation,
+        snowpack,
+        wind_speed,
+        annual_temperature,
+        annual_precipitation,
+        aridity,
+    );
+    if !stats_out.is_null() {
+        unsafe { *stats_out = stats };
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moisture_capacity_increases_with_temperature() {
+        assert!(moisture_capacity_mm(25.0) > moisture_capacity_mm(10.0));
+        assert!(moisture_capacity_mm(10.0) > moisture_capacity_mm(-10.0));
+    }
+
+    #[test]
+    fn circulation_has_trades_and_westerlies() {
+        let tropical = circulation_components(15.0f64.to_radians(), 0.0);
+        let midlatitude = circulation_components(50.0f64.to_radians(), 0.0);
+        assert!(tropical.0 < 0.0);
+        assert!(midlatitude.0 > 0.0);
+    }
+
+    #[test]
+    fn tangent_basis_is_orthonormal() {
+        let radial = normalized([0.6, 0.4, 0.7]);
+        let (east, north) = tangent_basis(radial);
+        assert!(dot(radial, east).abs() < 1e-12);
+        assert!(dot(radial, north).abs() < 1e-12);
+        assert!(dot(east, north).abs() < 1e-12);
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -4,6 +4,7 @@ import importlib
 
 from . import geometry  # noqa: F401
 from . import planet  # noqa: F401
+from . import climate  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -19,6 +20,7 @@ def ensure_builtin_stages() -> None:
     modules = {
         "geometry": geometry,
         "planet": planet,
+        "climate": climate,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/climate.py
+++ b/src/map_maker/pipeline/stages/climate.py
@@ -1,0 +1,365 @@
+"""Seasonal energy-balance climate and orographic moisture transport."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+from PIL import Image
+
+from .._climate_native import run_cubed_sphere_climate
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+
+@dataclass(frozen=True)
+class ClimateConfig:
+    spinup_years: int = 24
+    moisture_spinup_years: int = 3
+    moisture_steps_per_month_at_face_128: int = 16
+    greenhouse_offset_c: float = 0.0
+    land_albedo: float = 0.30
+    ocean_albedo: float = 0.28
+    olr_intercept_w_m2: float = 203.0
+    olr_slope_w_m2_c: float = 2.09
+    heat_transport_w_m2: float = 35.0
+    land_thermal_response: float = 0.22
+    ocean_thermal_response: float = 0.10
+    atmospheric_exchange: float = 0.16
+    lapse_rate_c_per_km: float = 6.5
+    wind_scale: float = 1.0
+    moisture_advection_fraction: float = 0.38
+    moisture_diffusion_fraction: float = 0.50
+    orographic_factor: float = 0.18
+    rain_shadow_factor: float = 0.70
+    runoff_base_fraction: float = 0.35
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "ClimateConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown climate controls: {', '.join(sorted(unknown))}")
+        integer_names = {
+            "spinup_years",
+            "moisture_spinup_years",
+            "moisture_steps_per_month_at_face_128",
+        }
+        values: dict[str, int | float] = {}
+        for name in known:
+            if name not in mapping:
+                continue
+            values[name] = int(mapping[name]) if name in integer_names else float(mapping[name])
+        config = cls(**values)
+        for name, value in asdict(config).items():
+            if not np.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+
+        integer_bounds = {
+            "spinup_years": (2, 200),
+            "moisture_spinup_years": (1, 20),
+            "moisture_steps_per_month_at_face_128": (2, 64),
+        }
+        float_bounds = {
+            "greenhouse_offset_c": (-20.0, 20.0),
+            "land_albedo": (0.05, 0.80),
+            "ocean_albedo": (0.02, 0.60),
+            "olr_intercept_w_m2": (100.0, 300.0),
+            "olr_slope_w_m2_c": (0.5, 5.0),
+            "heat_transport_w_m2": (0.0, 120.0),
+            "land_thermal_response": (0.01, 0.80),
+            "ocean_thermal_response": (0.01, 0.50),
+            "atmospheric_exchange": (0.0, 0.50),
+            "lapse_rate_c_per_km": (3.0, 10.0),
+            "wind_scale": (0.25, 3.0),
+            "moisture_advection_fraction": (0.0, 0.95),
+            "moisture_diffusion_fraction": (0.0, 0.50),
+            "orographic_factor": (0.0, 2.0),
+            "rain_shadow_factor": (0.0, 3.0),
+            "runoff_base_fraction": (0.0, 0.80),
+        }
+        config_values = asdict(config)
+        for name, (minimum, maximum) in {**integer_bounds, **float_bounds}.items():
+            value = config_values[name]
+            if not minimum <= value <= maximum:
+                raise ValueError(f"{name} must be in [{minimum}, {maximum}]")
+        if config.ocean_thermal_response >= config.land_thermal_response:
+            raise ValueError("ocean_thermal_response must be lower than land_thermal_response")
+        if config.land_thermal_response + config.atmospheric_exchange > 1.0:
+            raise ValueError("land thermal response plus atmospheric exchange must not exceed 1")
+        if config.ocean_thermal_response + config.atmospheric_exchange > 1.0:
+            raise ValueError("ocean thermal response plus atmospheric exchange must not exceed 1")
+        if config.moisture_advection_fraction + config.moisture_diffusion_fraction > 1.0:
+            raise ValueError("moisture advection plus diffusion must not exceed 1")
+        return config
+
+
+def _artifact_array(result, name: str) -> np.ndarray:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        raise KeyError(f"Missing dependency artifact '{name}'")
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _result_array(result, name: str) -> np.ndarray | None:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        return None
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _cube_net_rgb(faces: np.ndarray) -> np.ndarray:
+    resolution = faces.shape[1]
+    net = np.zeros((resolution * 3, resolution * 4, 3), dtype=np.uint8)
+    placements = {3: (1, 0), 0: (1, 1), 2: (1, 2), 1: (1, 3), 4: (0, 1), 5: (2, 1)}
+    for face, (net_row, net_col) in placements.items():
+        row = net_row * resolution
+        col = net_col * resolution
+        net[row : row + resolution, col : col + resolution] = faces[face]
+    return net
+
+
+def _palette(
+    values: np.ndarray, stops: tuple[tuple[float, tuple[int, int, int]], ...]
+) -> np.ndarray:
+    positions = np.asarray([position for position, _ in stops], dtype=np.float32)
+    colors = np.asarray([color for _, color in stops], dtype=np.float32)
+    channels = [np.interp(values, positions, colors[:, channel]) for channel in range(3)]
+    return np.stack(channels, axis=-1).clip(0, 255).astype(np.uint8)
+
+
+def _montage(monthly: np.ndarray, palette_stops) -> np.ndarray:
+    month_nets = [_cube_net_rgb(_palette(monthly[month], palette_stops)) for month in range(12)]
+    panel_height, panel_width = month_nets[0].shape[:2]
+    result = np.zeros((3 * panel_height, 4 * panel_width, 3), dtype=np.uint8)
+    for month, month_net in enumerate(month_nets):
+        row, col = divmod(month, 4)
+        result[
+            row * panel_height : (row + 1) * panel_height,
+            col * panel_width : (col + 1) * panel_width,
+        ] = month_net
+    return result
+
+
+TEMPERATURE_PALETTE = (
+    (-60.0, (17, 28, 74)),
+    (-30.0, (39, 87, 145)),
+    (-10.0, (112, 166, 190)),
+    (0.0, (210, 230, 216)),
+    (12.0, (115, 164, 91)),
+    (24.0, (224, 191, 83)),
+    (35.0, (193, 89, 53)),
+    (50.0, (104, 30, 39)),
+)
+
+PRECIPITATION_PALETTE = (
+    (0.0, (94, 62, 45)),
+    (100.0, (161, 118, 68)),
+    (300.0, (210, 184, 108)),
+    (600.0, (111, 154, 87)),
+    (1200.0, (48, 130, 115)),
+    (2200.0, (40, 102, 151)),
+    (4000.0, (205, 230, 235)),
+)
+
+
+def _climate_visualizer(result, request: VisualizationRequest) -> list[VisualizationResult] | None:
+    monthly_temperature = _result_array(result, "MonthlySurfaceTemperatureC")
+    monthly_precipitation = _result_array(result, "MonthlyPrecipitationMm")
+    annual_temperature = _result_array(result, "AnnualMeanTemperatureC")
+    annual_precipitation = _result_array(result, "AnnualPrecipitationMm")
+    wind = _result_array(result, "MonthlyWindVectorXYZMps")
+    speed = _result_array(result, "MonthlyWindSpeedMps")
+    if any(
+        value is None
+        for value in (
+            monthly_temperature,
+            monthly_precipitation,
+            annual_temperature,
+            annual_precipitation,
+            wind,
+            speed,
+        )
+    ):
+        return None
+    assert monthly_temperature is not None
+    assert monthly_precipitation is not None
+    assert annual_temperature is not None
+    assert annual_precipitation is not None
+    assert wind is not None
+    assert speed is not None
+
+    outputs: list[VisualizationResult] = []
+    annual_temperature_path = request.output_dir / "annual_temperature.png"
+    Image.fromarray(
+        _cube_net_rgb(_palette(annual_temperature, TEMPERATURE_PALETTE)), mode="RGB"
+    ).save(annual_temperature_path)
+    outputs.append(
+        VisualizationResult(
+            annual_temperature_path, "AnnualMeanTemperatureC", {"scale_c": [-60, 50]}
+        )
+    )
+
+    annual_precipitation_path = request.output_dir / "annual_precipitation.png"
+    Image.fromarray(
+        _cube_net_rgb(_palette(annual_precipitation, PRECIPITATION_PALETTE)), mode="RGB"
+    ).save(annual_precipitation_path)
+    outputs.append(
+        VisualizationResult(
+            annual_precipitation_path,
+            "AnnualPrecipitationMm",
+            {"scale_mm_year": [0, 4000]},
+        )
+    )
+
+    temperature_months_path = request.output_dir / "monthly_temperature.png"
+    Image.fromarray(_montage(monthly_temperature, TEMPERATURE_PALETTE), mode="RGB").save(
+        temperature_months_path
+    )
+    outputs.append(
+        VisualizationResult(temperature_months_path, "MonthlySurfaceTemperatureC", {"months": 12})
+    )
+
+    monthly_precipitation_scale = tuple(
+        (position / 12.0, color) for position, color in PRECIPITATION_PALETTE
+    )
+    precipitation_months_path = request.output_dir / "monthly_precipitation.png"
+    Image.fromarray(_montage(monthly_precipitation, monthly_precipitation_scale), mode="RGB").save(
+        precipitation_months_path
+    )
+    outputs.append(
+        VisualizationResult(precipitation_months_path, "MonthlyPrecipitationMm", {"months": 12})
+    )
+
+    mean_wind = np.mean(wind, axis=0)
+    mean_speed = np.mean(speed, axis=0)
+    wind_direction = 0.5 + 0.5 * mean_wind / np.maximum(mean_speed[..., None], 1e-6)
+    brightness = np.clip(0.35 + mean_speed / 18.0, 0.35, 1.0)
+    wind_rgb = (wind_direction * brightness[..., None] * 255.0).clip(0, 255).astype(np.uint8)
+    wind_path = request.output_dir / "prevailing_wind.png"
+    Image.fromarray(_cube_net_rgb(wind_rgb), mode="RGB").save(wind_path)
+    outputs.append(
+        VisualizationResult(
+            wind_path,
+            "MonthlyWindVectorXYZMps",
+            {"rgb": "global_xyz_direction", "brightness": "mean_speed"},
+        )
+    )
+    return outputs
+
+
+MONTHLY_SCALAR_OUTPUTS = (
+    "MonthlySurfaceTemperatureC",
+    "MonthlyWindSpeedMps",
+    "MonthlyPrecipitationMm",
+    "MonthlyRelativeHumidity",
+    "MonthlySnowfallMm",
+    "MonthlySnowmeltMm",
+    "MonthlySnowWaterEquivalentMm",
+    "MonthlyEvaporationMm",
+    "MonthlyRunoffPotentialMm",
+)
+
+
+@stage(
+    "climate",
+    inputs=("planet", "elevation", "world_age"),
+    outputs=(
+        *MONTHLY_SCALAR_OUTPUTS,
+        "MonthlyWindVectorXYZMps",
+        "ClimateOrographyM",
+        "AnnualMeanTemperatureC",
+        "AnnualPrecipitationMm",
+        "AnnualAridityIndex",
+        "ClimateMetadata",
+    ),
+    version="v1",
+    native_libraries=("climate_native",),
+    visualizer=_climate_visualizer,
+)
+def climate_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = ClimateConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("canonical climate requires topology: cubed_sphere")
+
+    shape = context.topology.face_shape
+    monthly_shape = (12, *shape)
+    artifact_shapes = {
+        **{name: monthly_shape for name in MONTHLY_SCALAR_OUTPUTS},
+        "MonthlyWindVectorXYZMps": (*monthly_shape, 3),
+        "ClimateOrographyM": shape,
+        "AnnualMeanTemperatureC": shape,
+        "AnnualPrecipitationMm": shape,
+        "AnnualAridityIndex": shape,
+    }
+    handles = {
+        name: context.arena.allocate_array(f"climate_{name.lower()}", artifact_shape, np.float32)
+        for name, artifact_shape in artifact_shapes.items()
+    }
+    views = {name: handle.mutable_view() for name, handle in handles.items()}
+    planet = deps["planet"]
+    elevation = deps["elevation"]
+    world_age = deps["world_age"]
+    effective_moisture_steps = max(
+        2,
+        round(config.moisture_steps_per_month_at_face_128 * context.topology.face_resolution / 128),
+    )
+    kernel_controls = asdict(config)
+    kernel_controls.pop("moisture_steps_per_month_at_face_128")
+
+    with context.timed("seasonal_climate_kernel"):
+        metadata = run_cubed_sphere_climate(
+            **kernel_controls,
+            moisture_steps_per_month=effective_moisture_steps,
+            areas=context.topology.cell_areas,
+            neighbors=context.topology.neighbor_indices,
+            xyz=context.topology.xyz,
+            latitudes=context.topology.latitude,
+            elevation=_artifact_array(elevation, "BedrockElevationM"),
+            relief=_artifact_array(elevation, "TerrainReliefM"),
+            ocean=_artifact_array(world_age, "BaseOceanMask"),
+            insolation=_artifact_array(planet, "MonthlyInsolationWm2"),
+            declination=_artifact_array(planet, "SolarDeclinationRad"),
+            climate_orography_out=views["ClimateOrographyM"],
+            temperature_out=views["MonthlySurfaceTemperatureC"],
+            wind_xyz_out=views["MonthlyWindVectorXYZMps"],
+            wind_speed_out=views["MonthlyWindSpeedMps"],
+            precipitation_out=views["MonthlyPrecipitationMm"],
+            humidity_out=views["MonthlyRelativeHumidity"],
+            snowfall_out=views["MonthlySnowfallMm"],
+            snowmelt_out=views["MonthlySnowmeltMm"],
+            snowpack_out=views["MonthlySnowWaterEquivalentMm"],
+            evaporation_out=views["MonthlyEvaporationMm"],
+            runoff_out=views["MonthlyRunoffPotentialMm"],
+            annual_temperature_out=views["AnnualMeanTemperatureC"],
+            annual_precipitation_out=views["AnnualPrecipitationMm"],
+            aridity_out=views["AnnualAridityIndex"],
+        )
+
+    for handle in handles.values():
+        handle.seal()
+    planet_metadata = planet.artifact_records["PlanetMetadata"].value
+    metadata.update(
+        {
+            **asdict(config),
+            "effective_moisture_steps_per_month": effective_moisture_steps,
+            "transport_reference_face_resolution": 128,
+            "topology": "cubed_sphere",
+            "model": "seasonal_energy_moisture_climate_v1",
+            "month_semantics": planet_metadata["forcing_semantics"],
+            "temperature_semantics": "surface_air_energy_balance_with_elevation_lapse",
+            "wind_semantics": "global_xyz_tangent_vector",
+            "precipitation_semantics": "advected_moisture_with_orographic_condensation",
+            "evaporation_semantics": "ocean_actual_and_provisional_land_actual",
+            "runoff_semantics": "pre_soil_routing_potential",
+        }
+    )
+    context.logger.log_event({"type": "climate_summary", "stage": "climate", **metadata})
+    return {**handles, "ClimateMetadata": metadata}
+
+
+__all__ = ["ClimateConfig", "climate_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -262,7 +262,15 @@ def main(args: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Produce pipeline stage visualization PNGs.")
     parser.add_argument(
         "--stage",
-        choices=["topology", "planet", "tectonics", "world_age", "geology", "elevation"],
+        choices=[
+            "topology",
+            "planet",
+            "tectonics",
+            "world_age",
+            "geology",
+            "elevation",
+            "climate",
+        ],
         default="topology",
     )
     parser.add_argument("--config", type=Path, default=None)
@@ -324,8 +332,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = _register_world_age_stage()
         elif parsed.stage == "geology":
             stage_name = _register_geology_stage()
-        else:
+        elif parsed.stage == "elevation":
             stage_name = _register_elevation_stage()
+        else:
+            stage_name = "climate"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -342,7 +352,7 @@ def main(args: Iterable[str] | None = None) -> int:
     if invalid_controls:
         parser.error("cubed_sphere tectonics does not use " + ", ".join(invalid_controls))
 
-    if parsed.stage in {"planet", "world_age", "geology", "elevation"}:
+    if parsed.stage in {"planet", "world_age", "geology", "elevation", "climate"}:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":
         if parsed.topology == "cubed_sphere":

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline._climate_native import run_cubed_sphere_climate
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.stages.climate import ClimateConfig
+from map_maker.pipeline.tools import main as pipeline_tools_main
+
+
+@pytest.fixture(autouse=True)
+def _ensure_climate_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(tmp_path: Path, run_id: str, *, seed: int = 17) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 20}],
+            "rng_seed": seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 12,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+            },
+        }
+    )
+
+
+def _array(result, name: str) -> np.ndarray:
+    return np.asarray(result.artifact_records[name].value.array())
+
+
+def _cross_face_gradient_ratio(values: np.ndarray, neighbors: np.ndarray) -> float:
+    flat = values.reshape(-1)
+    flat_neighbors = neighbors.reshape(-1, 4)
+    face_size = values.shape[1] * values.shape[2]
+    interior: list[float] = []
+    cross_face: list[float] = []
+    for source in range(flat.size):
+        source_face = source // face_size
+        for target_value in flat_neighbors[source]:
+            target = int(target_value)
+            if source >= target:
+                continue
+            delta = abs(float(flat[source] - flat[target]))
+            if target // face_size == source_face:
+                interior.append(delta)
+            else:
+                cross_face.append(delta)
+    return float(np.mean(cross_face)) / max(float(np.mean(interior)), 1e-6)
+
+
+def test_climate_outputs_seasonal_causal_fields_and_visuals(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "climate-basic"), generate_visuals=True)
+    results = engine.run(["climate"])
+    climate = results["climate"]
+    grid = engine.context.topology
+    assert isinstance(grid, CubedSphereGrid)
+
+    monthly_names = (
+        "MonthlySurfaceTemperatureC",
+        "MonthlyWindSpeedMps",
+        "MonthlyPrecipitationMm",
+        "MonthlyRelativeHumidity",
+        "MonthlySnowfallMm",
+        "MonthlySnowmeltMm",
+        "MonthlySnowWaterEquivalentMm",
+        "MonthlyEvaporationMm",
+        "MonthlyRunoffPotentialMm",
+    )
+    monthly = {name: _array(climate, name) for name in monthly_names}
+    for field in monthly.values():
+        assert field.shape == (12, *grid.face_shape)
+        assert field.dtype == np.float32
+        assert np.all(np.isfinite(field))
+    for name in monthly_names[1:]:
+        assert np.all(monthly[name] >= 0.0)
+    assert np.all(monthly["MonthlyRelativeHumidity"] <= 1.0)
+    assert np.all(monthly["MonthlySnowfallMm"] <= monthly["MonthlyPrecipitationMm"] + 1e-4)
+    assert np.all(
+        monthly["MonthlyRunoffPotentialMm"]
+        <= monthly["MonthlyPrecipitationMm"] + monthly["MonthlySnowmeltMm"] + 1e-4
+    )
+
+    wind = _array(climate, "MonthlyWindVectorXYZMps")
+    assert wind.shape == (12, *grid.face_shape, 3)
+    speed = monthly["MonthlyWindSpeedMps"]
+    np.testing.assert_allclose(np.linalg.norm(wind, axis=-1), speed, rtol=2e-5, atol=2e-5)
+    radial_leak = np.sum(wind * grid.xyz[None, ...], axis=-1)
+    assert float(np.max(np.abs(radial_leak))) < 1e-4
+    assert float(np.percentile(speed, 95)) > 5.0
+
+    annual_temperature = _array(climate, "AnnualMeanTemperatureC")
+    annual_precipitation = _array(climate, "AnnualPrecipitationMm")
+    aridity = _array(climate, "AnnualAridityIndex")
+    orography = _array(climate, "ClimateOrographyM")
+    np.testing.assert_allclose(
+        annual_temperature,
+        np.mean(monthly["MonthlySurfaceTemperatureC"], axis=0),
+        atol=1e-4,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        annual_precipitation,
+        np.sum(monthly["MonthlyPrecipitationMm"], axis=0),
+        atol=1e-3,
+        rtol=1e-6,
+    )
+    assert np.all(np.isfinite(aridity)) and np.all(aridity >= 0.0)
+
+    ocean = _array(results["world_age"], "BaseOceanMask") >= 0.5
+    assert np.all(orography[ocean] == 0.0)
+    assert np.all(orography[~ocean] >= 0.0)
+    assert float(np.max(orography[~ocean])) > 500.0
+    assert 100.0 < float(np.mean(annual_precipitation[~ocean])) < 2500.0
+
+    land = ~ocean
+    predictors = np.column_stack(
+        (np.ones(np.count_nonzero(land)), np.sin(grid.latitude[land]) ** 2)
+    )
+    coefficients, *_ = np.linalg.lstsq(predictors, annual_temperature[land], rcond=None)
+    temperature_residual = annual_temperature[land] - predictors @ coefficients
+    assert float(np.corrcoef(temperature_residual, orography[land])[0, 1]) < -0.25
+
+    midlatitude = (np.abs(grid.latitude) >= np.deg2rad(20.0)) & (
+        np.abs(grid.latitude) <= np.deg2rad(50.0)
+    )
+    seasonal_range = np.ptp(monthly["MonthlySurfaceTemperatureC"], axis=0)
+    assert float(np.median(seasonal_range[midlatitude & ocean])) < float(
+        np.median(seasonal_range[midlatitude & land])
+    )
+    north_index = int(np.argmin(np.abs(grid.latitude.reshape(-1) - np.deg2rad(45.0))))
+    south_index = int(np.argmin(np.abs(grid.latitude.reshape(-1) + np.deg2rad(45.0))))
+    flattened_temperature = monthly["MonthlySurfaceTemperatureC"].reshape(12, -1)
+    separation = abs(
+        int(np.argmax(flattened_temperature[:, north_index]))
+        - int(np.argmax(flattened_temperature[:, south_index]))
+    )
+    assert min(separation, 12 - separation) in {5, 6}
+
+    assert _cross_face_gradient_ratio(annual_temperature, grid.neighbor_indices) < 2.5
+    assert _cross_face_gradient_ratio(annual_precipitation, grid.neighbor_indices) < 3.0
+    metadata = climate.artifact_records["ClimateMetadata"].value
+    assert metadata["model"] == "seasonal_energy_moisture_climate_v1"
+    assert metadata["effective_moisture_steps_per_month"] == 2
+    assert metadata["transport_reference_face_resolution"] == 128
+    assert -10.0 < metadata["global_mean_temperature_c"] < 30.0
+    assert 100.0 < metadata["global_mean_annual_precipitation_mm"] < 2500.0
+    assert 0.0 < metadata["dry_land_area_fraction"] < 0.98
+
+    visual_dir = engine.context.config.run_visual_dir() / "climate"
+    for filename in (
+        "annual_temperature.png",
+        "annual_precipitation.png",
+        "monthly_temperature.png",
+        "monthly_precipitation.png",
+        "prevailing_wind.png",
+    ):
+        assert (visual_dir / filename).is_file()
+
+
+def test_climate_is_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "climate-first")).run(["climate"])["climate"]
+    second = ExecutionEngine(_config(tmp_path, "climate-second")).run(["climate"])["climate"]
+    for name in (
+        "MonthlySurfaceTemperatureC",
+        "MonthlyWindVectorXYZMps",
+        "MonthlyPrecipitationMm",
+        "MonthlyRunoffPotentialMm",
+        "AnnualMeanTemperatureC",
+        "AnnualPrecipitationMm",
+    ):
+        np.testing.assert_array_equal(_array(first, name), _array(second, name))
+    assert second.stats is not None and second.stats.cache_hit
+
+
+def _ffi_arguments(face_resolution: int = 6) -> dict[str, object]:
+    grid = CubedSphereGrid.create(face_resolution)
+    shape = grid.face_shape
+    monthly_shape = (12, *shape)
+    ocean = np.ascontiguousarray((grid.longitude < 0.0).astype(np.float32))
+    elevation = np.ascontiguousarray(
+        np.where(ocean >= 0.5, -3000.0, 1800.0 * np.maximum(grid.xyz[..., 2], 0.0)),
+        dtype=np.float32,
+    )
+    insolation = np.empty(monthly_shape, dtype=np.float32)
+    for month in range(12):
+        seasonal = 80.0 * np.sin((month + 0.5) / 12.0 * 2.0 * np.pi) * np.sin(grid.latitude)
+        insolation[month] = 330.0 + 90.0 * np.cos(grid.latitude) + seasonal
+    outputs = {
+        "climate_orography_out": np.empty(shape, dtype=np.float32),
+        "temperature_out": np.empty(monthly_shape, dtype=np.float32),
+        "wind_xyz_out": np.empty((*monthly_shape, 3), dtype=np.float32),
+        "wind_speed_out": np.empty(monthly_shape, dtype=np.float32),
+        "precipitation_out": np.empty(monthly_shape, dtype=np.float32),
+        "humidity_out": np.empty(monthly_shape, dtype=np.float32),
+        "snowfall_out": np.empty(monthly_shape, dtype=np.float32),
+        "snowmelt_out": np.empty(monthly_shape, dtype=np.float32),
+        "snowpack_out": np.empty(monthly_shape, dtype=np.float32),
+        "evaporation_out": np.empty(monthly_shape, dtype=np.float32),
+        "runoff_out": np.empty(monthly_shape, dtype=np.float32),
+        "annual_temperature_out": np.empty(shape, dtype=np.float32),
+        "annual_precipitation_out": np.empty(shape, dtype=np.float32),
+        "aridity_out": np.empty(shape, dtype=np.float32),
+    }
+    return {
+        "spinup_years": 4,
+        "moisture_spinup_years": 2,
+        "moisture_steps_per_month": 4,
+        "greenhouse_offset_c": 0.0,
+        "land_albedo": 0.30,
+        "ocean_albedo": 0.28,
+        "olr_intercept_w_m2": 203.0,
+        "olr_slope_w_m2_c": 2.09,
+        "heat_transport_w_m2": 35.0,
+        "land_thermal_response": 0.22,
+        "ocean_thermal_response": 0.10,
+        "atmospheric_exchange": 0.16,
+        "lapse_rate_c_per_km": 6.5,
+        "wind_scale": 1.0,
+        "moisture_advection_fraction": 0.38,
+        "moisture_diffusion_fraction": 0.50,
+        "orographic_factor": 0.18,
+        "rain_shadow_factor": 0.70,
+        "runoff_base_fraction": 0.35,
+        "areas": grid.cell_areas,
+        "neighbors": grid.neighbor_indices,
+        "xyz": grid.xyz,
+        "latitudes": grid.latitude,
+        "elevation": elevation,
+        "relief": np.ascontiguousarray(np.maximum(elevation, 100.0), dtype=np.float32),
+        "ocean": ocean,
+        "insolation": insolation,
+        "declination": np.zeros(12, dtype=np.float32),
+        **outputs,
+    }
+
+
+def test_climate_ffi_is_orography_sensitive_and_rejects_invalid_buffers():
+    mountainous = _ffi_arguments()
+    run_cubed_sphere_climate(**mountainous)
+    flat = _ffi_arguments()
+    flat["elevation"] = np.where(np.asarray(flat["ocean"]) >= 0.5, -3000.0, 0.0).astype(np.float32)
+    run_cubed_sphere_climate(**flat)
+    assert not np.array_equal(mountainous["temperature_out"], flat["temperature_out"])
+    assert not np.array_equal(mountainous["precipitation_out"], flat["precipitation_out"])
+
+    overlapping = _ffi_arguments()
+    overlapping["annual_precipitation_out"] = overlapping["annual_temperature_out"]
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_cubed_sphere_climate(**overlapping)
+
+    invalid_shape = _ffi_arguments()
+    invalid_shape["wind_xyz_out"] = np.empty((12, 6, 6, 6, 2), dtype=np.float32)
+    with pytest.raises(ValueError, match="must have shape"):
+        run_cubed_sphere_climate(**invalid_shape)
+
+
+def test_climate_config_and_cli_reject_invalid_controls():
+    with pytest.raises(ValueError, match="Unknown climate controls"):
+        ClimateConfig.from_mapping({"paint_climate_zones": True})
+    with pytest.raises(ValueError, match="lower than land"):
+        ClimateConfig.from_mapping({"land_thermal_response": 0.1, "ocean_thermal_response": 0.2})
+    with pytest.raises(ValueError, match="advection plus diffusion"):
+        ClimateConfig.from_mapping(
+            {"moisture_advection_fraction": 0.8, "moisture_diffusion_fraction": 0.4}
+        )
+    with pytest.raises(SystemExit):
+        pipeline_tools_main(["--stage", "climate"])

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -51,6 +51,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
     assert list(manifest["stages"]) == ["erosion", "geometry", "tectonics", "world_age"]
     assert manifest["statistics"]["land_fraction"] > 0.0
     assert set(manifest["native_libraries"]) == {
+        "climate_native",
         "elevation_native",
         "erosion_native",
         "geology_native",


### PR DESCRIPTION
## Summary
- add a Rust seasonal energy-balance climate with land/ocean thermal inertia and tangent XYZ winds
- add graph moisture transport, smoothed atmospheric orography, rain shadows, snow, evaporation, and runoff potential
- persist monthly/annual training-ready fields and add diagnostics, documentation, resolution scaling, and physical gates

## Canonical face-128 diagnostics
- global mean temperature: 17.29 C
- global mean precipitation: 855.94 mm/year
- land mean precipitation: 455.30 mm/year
- climate kernel and visuals: ~1.9 s with cached dependencies

## Verification
- uv run pytest -q (94 passed)
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- six-seed climate gallery at face-64