### PR TITLE
Add fractional coarse-cell water coverage

### DIFF
--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -64,10 +64,12 @@ stage_overrides:
     runoff_base_fraction: 0.35
   hydrology:
     minimum_depression_depth_m: 20.0
-    wetland_maximum_depth_m: 35.0
+    wetland_mean_depth_m: 35.0
     endorheic_aridity_threshold: 0.35
     maximum_fill_time_years: 50000.0
     lake_seepage_mm_year: 30.0
+    subgrid_relief_scale: 1.0
+    subgrid_connected_basin_fraction: 0.50
     breach_score_threshold: 0.58
     maximum_breach_incision_m: 800.0
     breach_length_cells: 4

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1075,3 +1075,39 @@ Failure rule:
 Continental-sized flat plateaus, uniform boundary walls, cube-face seams,
 arbitrary class-to-height painting, and loss of inherited islands are hard
 failures.
+
+## Decision 022: Fractional Coarse Surface Coverage
+
+Status: approved, provisional
+
+Decision:
+Coarse cells are mixed-cover containers rather than atomic terrain labels.
+Surface classes whose physical features are commonly smaller than a cell must
+store area fractions. Hydrologic feature identity and drainage topology remain
+explicit and discrete.
+
+Hydrology rule:
+- Permanent lake and wetland coverage are separate fractions in `[0, 1]`.
+- Lakes retain waterbody identity, level, area, volume, inflow, outflow, spill
+  point, and downstream graph relationships.
+- Rivers remain vector reaches with physical width and discharge rather than
+  converting every crossed cell into a river cell.
+- A sparse cell-to-waterbody table records membership and covered physical area.
+
+Subgrid rule:
+Unresolved terrain relief defines a provisional cell hypsometry. Lake level and
+connected-basin occupancy determine fractional inundation and volume. This is a
+computational approximation, not a substitute for refined bathymetry.
+
+Refinement rule:
+Regional refinement spatially realizes parent fractions while preserving parent
+waterbody identity, drainage connectivity, aggregate area, storage, and flux.
+Refined geometry may redistribute coverage inside the parent. It may instantiate
+multiple minor waterbody objects from explicitly unresolved parent coverage, but
+may not change aggregate water area, storage, or major connectivity merely to
+improve appearance.
+
+Classification rule:
+Permanent lakes, present-day wetlands, seasonal floodplains, and paleowetlands
+are distinct products. Paleowetlands may contribute to geological resource
+history, including coal formation, but are not counted as present-day lakes.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -100,28 +100,51 @@ integrated into `map-maker validate`:
   under arid low inflow, overflow under sustained wet inflow, and breach only
   when the configured erosion criterion is met.
 
-A provisional six-seed face-64 audit produced:
+A fractional-water six-seed face-64 audit produced:
 
 | Metric | Observed range |
 | --- | ---: |
-| Registered lakes | 40-67 |
-| Open lake outlets | 30-46 |
-| Breach events | 0-4 |
-| Lake-covered land cells | 2.8-5.1% |
-| Closed-drainage land | 2.7-22.3% |
+| Permanent lakes | 34-58 |
+| Wetlands | 0-1 |
+| Open lake outlets | 28-53 |
+| Fractional lake area / land | 0.55-1.76% |
+| Fractional wetland area / land | 0-0.007% |
+| Closed-drainage land | 0.94-6.15% |
 
-The generated review sheet is
-`out/hydrology-gallery/hydrology-gallery.png`. These ranges are observations,
-not accepted Earth calibration bands.
+Three face-128 seeds produced `2.16-2.70%` permanent lake area, `0.009-0.067%`
+shallow-water wetland area, and `8.8-24.7%` closed-drainage land. The canonical
+seed reports `2.70%` lake area and passes the provisional Earth-like `1.5-4.0%` lake-area
+band. The band covers published natural-lake estimates of approximately 1.8% of
+all land in [HydroLAKES](https://doi.org/10.1038/ncomms13603) and 3.7% of
+nonglaciated land when much smaller lakes are included in the
+[high-resolution inventory](https://doi.org/10.1002/2014GL060641). It is a
+validation diagnostic, not a global-area clamp.
 
-Resolution stability currently fails. Three face-128 worlds placed roughly
-26-36% of land into closed drainage, materially above the face-64 sweep. Finer
-elevation exposes additional local depressions that can capture drainage which
-the coarse pass sent onward. Do not tune this away with a resolution-specific
-lake count. The required fix is hierarchical hydrology: preserve accepted coarse
-trunk connectivity and flux while refining local basins, tributaries, wetlands,
-and channels. Until that constraint exists, closed-drainage and lake statistics
-are provisional and Pass 1 is not calibrated for arbitrary resolution.
+The previous whole-cell lake statistic is retired as an area estimate. Coarse
+support cells now carry `LakeFraction` and `WetlandFraction`; area diagnostics
+weight those fractions by physical cubed-sphere cell area. These ranges remain
+observations, not proof of calibrated lake morphology or bathymetry.
+
+Lake depth remains provisional. The canonical face-128 seed stores about
+`458,000 km3` in permanent lakes with an area-weighted mean depth near `95 m`.
+That is high relative to Earth and is not accepted as calibrated; sedimentary
+infilling, explicit basin age, glacial excavation, and resolved bathymetric
+hypsometry are still absent.
+
+The shallow-water wetland class remains sparse after classification was corrected
+to use equilibrium subgrid mean depth instead of coarse-cell depth. Ecological
+wetlands require hydroperiod, water table, soils, and vegetation and are not
+calibrated by this lake-depression pass.
+
+Resolution stability still fails. Fractional area removes whole-cell inflation,
+but face-128 worlds retain materially more lakes and closed drainage than the
+face-64 sweep. Finer elevation exposes additional local depressions that can
+capture drainage which the coarse pass sent onward. Do not tune this away with a
+resolution-specific lake count. The required fix is hierarchical hydrology:
+preserve accepted coarse trunk connectivity and flux while refining local basins,
+tributaries, wetlands, and channels. Until that constraint exists, closed-drainage
+and lake statistics are provisional and Pass 1 is not calibrated for arbitrary
+resolution.
 
 ## Calibration Rule
 

--- a/docs/specs/08_climate_hydrology.md
+++ b/docs/specs/08_climate_hydrology.md
@@ -139,16 +139,23 @@ contract for inspection and surrogate training.
 3. The whole upstream catchment contributes monthly runoff. Lake evaporation and
    geology-modulated seepage are subtracted to estimate storage balance and fill
    time.
-4. Shallow systems may remain wetlands. Water-limited systems remain closed;
-   sustained positive balance produces an open outlet. Open systems retain a
-   visible lake while passing accumulated discharge downstream.
+4. Systems with shallow subgrid area-weighted mean depth may remain wetlands.
+   Water-limited systems remain closed; sustained positive balance produces an
+   open outlet. Open systems retain a visible lake while passing accumulated
+   discharge downstream.
 5. Depression nodes are evaluated upstream-to-downstream. Net outflow from an
    upstream open or breached basin contributes to the next depression's monthly
    inflow and can turn a previously terminal lake into a fill-spill lake chain.
-6. Closed lake surface area is an equilibrium subset of the depression, selected
-   from the deepest cells until water loss balances inflow. The whole depression
-   remains part of the drainage basin; it is not all painted as water.
-7. Sustained overflow, available head, discharge, weak rock, and low accommodation
+6. A coarse cell is a container, not an atomic land-cover label. `TerrainReliefM`
+   defines a uniform unresolved elevation distribution around the coarse bedrock
+   elevation. Intersecting a lake level with that distribution produces continuous
+   water area and integrated volume. A connected-basin fraction prevents all
+   hypsometrically low subgrid terrain from being assigned to one water body.
+7. Open lakes use the spill elevation. Closed lakes solve a deterministic
+   area-versus-level curve until evaporation and seepage balance inflow. Each
+   participating cell receives a `LakeFraction` or `WetlandFraction` in `[0, 1]`;
+   the whole depression remains part of the drainage basin.
+8. Sustained overflow, available head, discharge, weak rock, and low accommodation
    produce a breach score. Accepted breaches carve a short coarse outlet path,
    record gorge incision and a sediment pulse, and trigger a second priority flood.
 
@@ -163,9 +170,10 @@ contract for inspection and surrogate training.
   Registered open-water evaporation and seepage are removed at lake outlets
   before discharge continues downstream. Every land cell receives a basin ID and
   propagated sink type.
-- River cells are selected from physical discharge and contributing area. Lake
-  interiors are excluded from channels while flow still accumulates through open
-  water bodies.
+- River cells are selected from physical discharge and contributing area.
+  Provisional BFS routing inside a preserved depression is never emitted as river
+  geometry, including in mixed shoreline cells. Discharge still traverses the
+  drainage graph; refined inlet, lake-crossing, and outlet geometry is deferred.
 - Junction-to-junction reaches form the canonical river graph. Exact cubed-sphere
   cell paths are retained for refinement and a two-pass spherical corner-cutting
   generalization writes smooth unit-XYZ polylines for rendering.
@@ -175,15 +183,18 @@ contract for inspection and surrogate training.
 
 ### Persistent Outputs
 
-Raster support fields include depression/lake IDs and classes, potential fill
-depth, hydrologic elevation, breach incision, receiver IDs, tangent flow vectors,
-slope, contributing area, monthly and mean discharge, velocity, stream power,
-basin and sink IDs, river corridor, and floodplain potential.
+Raster support fields include depression/lake IDs and classes, fractional lake
+and wetland coverage, potential fill depth, hydrologic elevation, breach incision,
+receiver IDs, tangent flow vectors, slope, contributing area, monthly and mean
+discharge, velocity, stream power, basin and sink IDs, river corridor, and
+floodplain potential.
 
-Arrow products are `DepressionCatalog`, `LakeCatalog`, `BreachCatalog`,
-`BasinCatalog`, `DrainageGraph`, and `RiverReachCatalog`. `HydrologyMetadata`
-records physical controls, counts, distribution diagnostics, conservation error,
-and artifact semantics.
+Arrow products are `DepressionCatalog`, separate `LakeCatalog` and
+`WetlandCatalog` products, `WaterBodyCellCatalog`, `BreachCatalog`, `BasinCatalog`,
+`DrainageGraph`, and `RiverReachCatalog`. `WaterBodyCellCatalog` is the sparse
+cell-to-waterbody relation and records covered area, class, and both fractions.
+`HydrologyMetadata` records physical controls, counts, area-weighted diagnostics,
+conservation error, and artifact semantics.
 
 ### Hard Gates
 
@@ -196,6 +207,8 @@ and artifact semantics.
 - Flow vectors are tangent unit vectors on routed cells.
 - Reach IDs and downstream references are valid and the reach graph is acyclic.
 - Exact and smoothed reach geometries share endpoints and remain on the unit sphere.
+- Lake and wetland fractions are finite, bounded by `[0, 1]`, mutually exclusive,
+  and reproduce catalog water area when weighted by physical cell area.
 - Identical inputs produce byte-identical arrays and Arrow tables.
 
 ### Current Hydrology Limits
@@ -209,6 +222,17 @@ and artifact semantics.
 - Land evaporation is provisional and not a dedicated open-water potential
   evaporation field. Lake extent and endorheic statistics therefore remain
   calibration targets.
+- The connected-basin fraction is a coarse subgrid approximation. Hierarchical
+  refinement must replace it with resolved local hypsometry and approach atomic
+  coverage only where the refined cell is genuinely uniform.
+- Depression discovery still begins from coarse mean elevation, and the current
+  sparse membership product has at most one resolved waterbody per cell. It does
+  not yet discover several independent minor lakes inside one coarse cell.
+  Refinement may instantiate those from explicitly unresolved fractional water
+  while preserving parent area and storage.
+- Fractional area is now Earth-plausible in the face-128 audit, but lake depth
+  and total volume remain high. Basin-age sediment infill and explicit
+  bathymetric refinement are required before lake volume is calibrated.
 - Groundwater, infiltration, losing/intermittent reaches, glaciers, engineered
   channels, and explicit delta distributary growth are absent or represented only
   by coarse reach attributes.

--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,9 @@ persistence, diagnostics, and final cartography. The canonical cubed-sphere path
 now reaches connected geological provinces, boundary segments, causal
 pre-erosion elevation/orogenic morphology, monthly orbital forcing, and seasonal
 climate/orographic precipitation. The first depression-aware hydrology pass now
-writes lakes, spill outlets, breaches, conservative drainage basins, monthly
-discharge, and vector river reaches. Explicit geological event history, spherical
+writes fractional lake and wetland coverage, spill outlets, breaches, conservative
+drainage basins, monthly discharge, sparse waterbody membership, and vector river
+reaches. Explicit geological event history, spherical
 erosion and sediment feedback, hydrology pass 2, soils, biomes, and regional
 refinement remain implementation milestones; the current output is a functional
 prototype rather than an atlas-grade world.

--- a/src/map_maker/pipeline/_hydrology_native.py
+++ b/src/map_maker/pipeline/_hydrology_native.py
@@ -10,7 +10,7 @@ from cffi import FFI
 
 from .._native import NativeLibraryAbiError, native_library_info, native_library_path
 
-CUBED_SPHERE_HYDROLOGY_ABI_VERSION = 2
+CUBED_SPHERE_HYDROLOGY_ABI_VERSION = 3
 
 WATER_BODY_CLASSES = {
     1: "wetland",
@@ -39,10 +39,12 @@ BED_MATERIAL_CLASSES = {
 HYDROLOGY_CONTROL_NAMES = {
     "planet_radius_m",
     "minimum_depression_depth_m",
-    "wetland_maximum_depth_m",
+    "wetland_mean_depth_m",
     "endorheic_aridity_threshold",
     "maximum_fill_time_years",
     "lake_seepage_mm_year",
+    "subgrid_relief_scale",
+    "subgrid_connected_basin_fraction",
     "breach_score_threshold",
     "maximum_breach_incision_m",
     "breach_length_cells",
@@ -133,10 +135,12 @@ _CDEF = """
 typedef struct {
     double planet_radius_m;
     float minimum_depression_depth_m;
-    float wetland_maximum_depth_m;
+    float wetland_mean_depth_m;
     float endorheic_aridity_threshold;
     float maximum_fill_time_years;
     float lake_seepage_mm_year;
+    float subgrid_relief_scale;
+    float subgrid_connected_basin_fraction;
     float breach_score_threshold;
     float maximum_breach_incision_m;
     int32_t breach_length_cells;
@@ -259,6 +263,8 @@ int32_t hydrology_run_cubed_sphere(
     int32_t* depression_id_out,
     int32_t* lake_id_out,
     uint8_t* water_class_out,
+    float* lake_fraction_out,
+    float* wetland_fraction_out,
     float* fill_depth_out,
     float* hydrologic_elevation_out,
     float* breach_incision_out,
@@ -512,6 +518,8 @@ def run_cubed_sphere_hydrology(
         "DepressionID": np.dtype(np.int32),
         "LakeID": np.dtype(np.int32),
         "WaterBodyClass": np.dtype(np.uint8),
+        "LakeFraction": np.dtype(np.float32),
+        "WetlandFraction": np.dtype(np.float32),
         "DepressionFillDepthM": np.dtype(np.float32),
         "HydrologicElevationM": np.dtype(np.float32),
         "BreachIncisionM": np.dtype(np.float32),
@@ -585,6 +593,8 @@ def run_cubed_sphere_hydrology(
         _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", output_arrays["DepressionID"])),
         _ffi.cast("int32_t*", _ffi.from_buffer("int32_t[]", output_arrays["LakeID"])),
         _ffi.cast("uint8_t*", _ffi.from_buffer("uint8_t[]", output_arrays["WaterBodyClass"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays["LakeFraction"])),
+        _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays["WetlandFraction"])),
         *[
             _ffi.cast("float*", _ffi.from_buffer("float[]", output_arrays[name]))
             for name in ("DepressionFillDepthM", "HydrologicElevationM", "BreachIncisionM")

--- a/src/map_maker/pipeline/native/hydrology/src/lib.rs
+++ b/src/map_maker/pipeline/native/hydrology/src/lib.rs
@@ -27,10 +27,12 @@ const SINK_STABLE_LAKE: u8 = 4;
 pub struct HydrologyConfig {
     pub planet_radius_m: f64,
     pub minimum_depression_depth_m: f32,
-    pub wetland_maximum_depth_m: f32,
+    pub wetland_mean_depth_m: f32,
     pub endorheic_aridity_threshold: f32,
     pub maximum_fill_time_years: f32,
     pub lake_seepage_mm_year: f32,
+    pub subgrid_relief_scale: f32,
+    pub subgrid_connected_basin_fraction: f32,
     pub breach_score_threshold: f32,
     pub maximum_breach_incision_m: f32,
     pub breach_length_cells: i32,
@@ -202,10 +204,13 @@ struct RiverProperties {
     floodplain: Vec<f32>,
 }
 
+#[derive(Clone)]
 struct Depression {
     id: i32,
     cells: Vec<usize>,
     water_cells: Vec<usize>,
+    water_fractions: Vec<f32>,
+    potential_fractions: Vec<f32>,
     sink_cell: usize,
     outlet_cell: usize,
     outlet_receiver: usize,
@@ -213,6 +218,7 @@ struct Depression {
     maximum_depth_m: f32,
     mean_depth_m: f32,
     area_km2: f64,
+    potential_water_area_km2: f64,
     volume_km3: f64,
     water_area_km2: f64,
     water_volume_km3: f64,
@@ -241,7 +247,7 @@ pub extern "C" fn hydrology_native_abi_version() -> u32 {
 
 #[no_mangle]
 pub extern "C" fn cubed_sphere_hydrology_abi_version() -> u32 {
-    2
+    3
 }
 
 fn priority_flood(elevation: &[f32], ocean: &[u8], neighbors: &[i32]) -> Option<FloodResult> {
@@ -302,17 +308,40 @@ fn edge_distance_m(first: usize, second: usize, xyz: &[f32], radius_m: f64) -> f
     dot.acos().max(1e-9) * radius_m
 }
 
+fn subgrid_inundation(
+    mean_elevation_m: f32,
+    relief_m: f32,
+    water_surface_m: f32,
+    minimum_depth_m: f32,
+    relief_scale: f32,
+    maximum_fraction: f32,
+) -> (f32, f64) {
+    let span_m = (relief_m.max(0.0) * relief_scale.max(0.01)).max(2.0 * minimum_depth_m.max(0.1));
+    let minimum_elevation_m = mean_elevation_m - 0.5 * span_m;
+    let surface_above_minimum_m = water_surface_m - minimum_elevation_m;
+    let raw_fraction = (surface_above_minimum_m / span_m).clamp(0.0, 1.0);
+    let fraction = raw_fraction.min(maximum_fraction.clamp(0.0, 1.0));
+    let equivalent_depth_m = (fraction as f64 * surface_above_minimum_m as f64
+        - 0.5 * span_m as f64 * fraction as f64 * fraction as f64)
+        .max(0.0);
+    (fraction, equivalent_depth_m)
+}
+
 fn find_depressions(
     flood: &FloodResult,
     elevation: &[f32],
+    relief: &[f32],
     ocean: &[u8],
     neighbors: &[i32],
     area_km2: &[f64],
-    minimum_depth_m: f32,
+    config: &HydrologyConfig,
 ) -> (Vec<i32>, Vec<Depression>) {
     let total = elevation.len();
     let candidate: Vec<bool> = (0..total)
-        .map(|cell| ocean[cell] == 0 && flood.filled[cell] - elevation[cell] >= minimum_depth_m)
+        .map(|cell| {
+            ocean[cell] == 0
+                && flood.filled[cell] - elevation[cell] >= config.minimum_depression_depth_m
+        })
         .collect();
     let mut depression_id = vec![-1i32; total];
     let mut depressions = Vec::new();
@@ -368,16 +397,73 @@ fn find_depressions(
         if !spill_elevation_m.is_finite() {
             spill_elevation_m = flood.filled[sink_cell];
         }
-        let maximum_depth_m = (spill_elevation_m - elevation[sink_cell]).max(0.0);
         let area = cells.iter().map(|cell| area_km2[*cell]).sum::<f64>();
-        let volume_km3 = cells
-            .iter()
-            .map(|cell| {
-                (spill_elevation_m - elevation[*cell]).max(0.0) as f64 * area_km2[*cell] / 1_000.0
-            })
-            .sum::<f64>();
-        let mean_depth_m = if area > 0.0 {
-            (volume_km3 * 1_000.0 / area) as f32
+        let mut raw_fractions = Vec::with_capacity(cells.len());
+        let mut raw_water_area_km2 = 0.0f64;
+        for &cell in &cells {
+            let (raw_fraction, _) = subgrid_inundation(
+                elevation[cell],
+                relief[cell],
+                spill_elevation_m,
+                config.minimum_depression_depth_m,
+                config.subgrid_relief_scale,
+                1.0,
+            );
+            raw_fractions.push(raw_fraction);
+            raw_water_area_km2 += raw_fraction as f64 * area_km2[cell];
+        }
+        let mut potential_fractions = vec![0.0f32; cells.len()];
+        let mut ranked: Vec<usize> = (0..cells.len()).collect();
+        ranked.sort_by(|first, second| {
+            let first_cell = cells[*first];
+            let second_cell = cells[*second];
+            let first_span = (relief[first_cell].max(0.0) * config.subgrid_relief_scale.max(0.01))
+                .max(2.0 * config.minimum_depression_depth_m.max(0.1));
+            let second_span = (relief[second_cell].max(0.0)
+                * config.subgrid_relief_scale.max(0.01))
+            .max(2.0 * config.minimum_depression_depth_m.max(0.1));
+            (elevation[first_cell] - 0.5 * first_span)
+                .total_cmp(&(elevation[second_cell] - 0.5 * second_span))
+                .then_with(|| first_cell.cmp(&second_cell))
+        });
+        let target_area_km2 =
+            raw_water_area_km2 * config.subgrid_connected_basin_fraction.clamp(0.0, 1.0) as f64;
+        let mut potential_water_area_km2 = 0.0f64;
+        for index in ranked {
+            let cell = cells[index];
+            let available_area_km2 = raw_fractions[index] as f64 * area_km2[cell];
+            let assigned_area_km2 =
+                available_area_km2.min(target_area_km2 - potential_water_area_km2);
+            if assigned_area_km2 <= 0.0 {
+                break;
+            }
+            let assigned_fraction = (assigned_area_km2 / area_km2[cell]) as f32;
+            potential_fractions[index] = assigned_fraction;
+            potential_water_area_km2 += assigned_area_km2;
+        }
+        let mut maximum_depth_m = 0.0f32;
+        let mut volume_km3 = 0.0f64;
+        for (index, &cell) in cells.iter().enumerate() {
+            let maximum_fraction = potential_fractions[index];
+            if maximum_fraction <= 0.0 {
+                continue;
+            }
+            let span_m = (relief[cell].max(0.0) * config.subgrid_relief_scale.max(0.01))
+                .max(2.0 * config.minimum_depression_depth_m.max(0.1));
+            maximum_depth_m = maximum_depth_m
+                .max((spill_elevation_m - (elevation[cell] - 0.5 * span_m)).max(0.0));
+            let (_, equivalent_depth_m) = subgrid_inundation(
+                elevation[cell],
+                relief[cell],
+                spill_elevation_m,
+                config.minimum_depression_depth_m,
+                config.subgrid_relief_scale,
+                maximum_fraction,
+            );
+            volume_km3 += equivalent_depth_m * area_km2[cell] / 1_000.0;
+        }
+        let mean_depth_m = if potential_water_area_km2 > 0.0 {
+            (volume_km3 * 1_000.0 / potential_water_area_km2) as f32
         } else {
             0.0
         };
@@ -385,6 +471,8 @@ fn find_depressions(
             id,
             cells,
             water_cells: Vec::new(),
+            water_fractions: Vec::new(),
+            potential_fractions,
             sink_cell,
             outlet_cell,
             outlet_receiver,
@@ -392,6 +480,7 @@ fn find_depressions(
             maximum_depth_m,
             mean_depth_m,
             area_km2: area,
+            potential_water_area_km2,
             volume_km3,
             water_area_km2: 0.0,
             water_volume_km3: 0.0,
@@ -456,7 +545,6 @@ fn classify_depressions(
         }
     }
 
-    let mut next_lake_id = 0i32;
     for depression in depressions {
         depression.catchment_area_km2 = catchment_area[depression.id as usize];
         depression.monthly_inflow_m3s = catchment_runoff[depression.id as usize];
@@ -466,22 +554,23 @@ fn classify_depressions(
         let mut aridity_weighted = 0.0f64;
         let mut rock_weighted = 0.0f64;
         let mut accommodation_weighted = 0.0f64;
-        for &cell in &depression.cells {
+        for (&cell, &fraction) in depression.cells.iter().zip(&depression.potential_fractions) {
+            let water_area_km2 = fraction as f64 * area_km2[cell];
             let annual_evaporation_mm = (0..MONTHS)
                 .map(|month| evaporation[month * owner.len() + cell].max(0.0) as f64)
                 .sum::<f64>();
-            evaporation_volume_m3 += annual_evaporation_mm * area_km2[cell] * 1_000.0;
-            aridity_weighted += aridity[cell].max(0.0) as f64 * area_km2[cell];
-            rock_weighted += rock_strength[cell].clamp(0.0, 1.0) as f64 * area_km2[cell];
-            accommodation_weighted += accommodation[cell].clamp(0.0, 1.0) as f64 * area_km2[cell];
+            evaporation_volume_m3 += annual_evaporation_mm * water_area_km2 * 1_000.0;
+            aridity_weighted += aridity[cell].max(0.0) as f64 * water_area_km2;
+            rock_weighted += rock_strength[cell].clamp(0.0, 1.0) as f64 * water_area_km2;
+            accommodation_weighted += accommodation[cell].clamp(0.0, 1.0) as f64 * water_area_km2;
         }
-        let inverse_area = 1.0 / depression.area_km2.max(1e-12);
+        let inverse_area = 1.0 / depression.potential_water_area_km2.max(1e-12);
         depression.mean_aridity = (aridity_weighted * inverse_area) as f32;
         let mean_rock = (rock_weighted * inverse_area) as f32;
         let mean_accommodation = (accommodation_weighted * inverse_area) as f32;
         depression.annual_evaporation_km3 = evaporation_volume_m3 / 1e9;
         depression.annual_seepage_km3 = config.lake_seepage_mm_year.max(0.0) as f64
-            * depression.area_km2
+            * depression.potential_water_area_km2
             * 1_000.0
             * (1.0 - 0.65 * mean_accommodation as f64)
             / 1e9;
@@ -506,7 +595,7 @@ fn classify_depressions(
 
         let overflows = depression.annual_balance_km3 > 0.0
             && depression.fill_time_years <= config.maximum_fill_time_years;
-        depression.class_code = if depression.maximum_depth_m <= config.wetland_maximum_depth_m {
+        depression.class_code = if depression.mean_depth_m <= config.wetland_mean_depth_m {
             WATER_WETLAND
         } else if depression.mean_aridity <= config.endorheic_aridity_threshold
             && depression.annual_balance_km3 <= 0.0
@@ -524,10 +613,6 @@ fn classify_depressions(
             WATER_STABLE_LAKE
         };
         depression.open_outlet = overflows && depression.class_code != WATER_BREACHED;
-        if depression.class_code != WATER_BREACHED {
-            depression.lake_id = next_lake_id;
-            next_lake_id += 1;
-        }
     }
 }
 
@@ -550,7 +635,7 @@ fn refresh_depression_classification(depression: &mut Depression, config: &Hydro
     depression.breach_score = depression.breach_static_score + 0.28 * discharge_score;
     let overflows = depression.annual_balance_km3 > 0.0
         && depression.fill_time_years <= config.maximum_fill_time_years;
-    depression.class_code = if depression.maximum_depth_m <= config.wetland_maximum_depth_m {
+    depression.class_code = if depression.mean_depth_m <= config.wetland_mean_depth_m {
         WATER_WETLAND
     } else if depression.mean_aridity <= config.endorheic_aridity_threshold
         && depression.annual_balance_km3 <= 0.0
@@ -622,79 +707,134 @@ fn propagate_depression_overflow(
             *inflow += routed;
         }
     }
-    let mut next_lake_id = 0i32;
-    for depression in depressions {
-        depression.lake_id = -1;
-        if depression.class_code != WATER_BREACHED {
-            depression.lake_id = next_lake_id;
-            next_lake_id += 1;
-        }
-    }
 }
 
 fn assign_water_extents(
     depressions: &mut [Depression],
     elevation: &[f32],
+    relief: &[f32],
     area_km2: &[f64],
-    minimum_depth_m: f32,
+    config: &HydrologyConfig,
 ) {
     for depression in depressions {
+        depression.water_cells.clear();
+        depression.water_fractions.clear();
         if depression.class_code == WATER_BREACHED {
-            continue;
-        }
-        if depression.open_outlet {
-            depression.water_cells.clone_from(&depression.cells);
-            depression.water_area_km2 = depression.area_km2;
-            depression.water_volume_km3 = depression.volume_km3;
-            depression.water_surface_elevation_m = depression.spill_elevation_m;
             continue;
         }
 
         let full_loss = depression.annual_evaporation_km3 + depression.annual_seepage_km3;
-        let equilibrium_fraction = if full_loss > 1e-12 {
+        let equilibrium_fraction = if depression.open_outlet {
+            1.0
+        } else if full_loss > 1e-12 {
             (depression.annual_inflow_km3 / full_loss).clamp(0.0, 1.0)
         } else {
             1.0
         };
-        let target_area = depression.area_km2 * equilibrium_fraction;
-        let mut ranked = depression.cells.clone();
-        ranked.sort_by(|first, second| {
-            elevation[*first]
-                .total_cmp(&elevation[*second])
-                .then_with(|| first.cmp(second))
-        });
-        let mut water_area = 0.0f64;
-        for cell in ranked {
-            depression.water_cells.push(cell);
-            water_area += area_km2[cell];
-            if water_area >= target_area.max(area_km2[cell]) {
-                break;
-            }
-        }
-        let highest_bed = depression
-            .water_cells
-            .iter()
-            .map(|cell| elevation[*cell])
-            .fold(elevation[depression.sink_cell], f32::max);
-        depression.water_surface_elevation_m =
-            (highest_bed + 0.5 * minimum_depth_m).min(depression.spill_elevation_m);
-        depression.water_area_km2 = water_area;
-        depression.water_volume_km3 = depression
-            .water_cells
+        let target_area = depression.potential_water_area_km2 * equilibrium_fraction;
+        let mut lower_surface = depression
+            .cells
             .iter()
             .map(|cell| {
-                (depression.water_surface_elevation_m - elevation[*cell])
-                    .max(0.25 * minimum_depth_m) as f64
-                    * area_km2[*cell]
-                    / 1_000.0
+                let span = (relief[*cell].max(0.0) * config.subgrid_relief_scale.max(0.01))
+                    .max(2.0 * config.minimum_depression_depth_m.max(0.1));
+                elevation[*cell] - 0.5 * span
             })
-            .sum();
-        let water_fraction = depression.water_area_km2 / depression.area_km2.max(1e-12);
+            .fold(depression.spill_elevation_m, f32::min);
+        let mut upper_surface = depression.spill_elevation_m;
+        if !depression.open_outlet {
+            for _ in 0..36 {
+                let trial_surface = 0.5 * (lower_surface + upper_surface);
+                let trial_area = depression
+                    .cells
+                    .iter()
+                    .enumerate()
+                    .map(|(index, cell)| {
+                        let (fraction, _) = subgrid_inundation(
+                            elevation[*cell],
+                            relief[*cell],
+                            trial_surface,
+                            config.minimum_depression_depth_m,
+                            config.subgrid_relief_scale,
+                            depression.potential_fractions[index],
+                        );
+                        fraction as f64 * area_km2[*cell]
+                    })
+                    .sum::<f64>();
+                if trial_area < target_area {
+                    lower_surface = trial_surface;
+                } else {
+                    upper_surface = trial_surface;
+                }
+            }
+        }
+        let water_surface = if depression.open_outlet {
+            depression.spill_elevation_m
+        } else {
+            0.5 * (lower_surface + upper_surface)
+        };
+        let mut water_area_km2 = 0.0f64;
+        let mut water_volume_km3 = 0.0f64;
+        let mut maximum_depth_m = 0.0f32;
+        for (index, &cell) in depression.cells.iter().enumerate() {
+            let (fraction, equivalent_depth_m) = subgrid_inundation(
+                elevation[cell],
+                relief[cell],
+                water_surface,
+                config.minimum_depression_depth_m,
+                config.subgrid_relief_scale,
+                depression.potential_fractions[index],
+            );
+            if fraction <= 1e-6 {
+                continue;
+            }
+            depression.water_cells.push(cell);
+            depression.water_fractions.push(fraction);
+            water_area_km2 += fraction as f64 * area_km2[cell];
+            water_volume_km3 += equivalent_depth_m * area_km2[cell] / 1_000.0;
+            let span_m = (relief[cell].max(0.0) * config.subgrid_relief_scale.max(0.01))
+                .max(2.0 * config.minimum_depression_depth_m.max(0.1));
+            maximum_depth_m =
+                maximum_depth_m.max((water_surface - (elevation[cell] - 0.5 * span_m)).max(0.0));
+        }
+        depression.water_surface_elevation_m = water_surface;
+        depression.water_area_km2 = water_area_km2;
+        depression.water_volume_km3 = water_volume_km3;
+        depression.maximum_depth_m = maximum_depth_m;
+        depression.mean_depth_m = if water_area_km2 > 0.0 {
+            (water_volume_km3 * 1_000.0 / water_area_km2) as f32
+        } else {
+            0.0
+        };
+        let water_fraction =
+            depression.water_area_km2 / depression.potential_water_area_km2.max(1e-12);
         depression.annual_evaporation_km3 *= water_fraction;
         depression.annual_seepage_km3 *= water_fraction;
         depression.annual_balance_km3 = depression.annual_inflow_km3
             - depression.annual_evaporation_km3
             - depression.annual_seepage_km3;
+        debug_assert!(
+            (depression.water_area_km2 - target_area).abs()
+                <= depression.potential_water_area_km2.max(1.0) * 1e-5
+        );
+    }
+}
+
+fn finalize_waterbody_classes(depressions: &mut [Depression], config: &HydrologyConfig) {
+    for depression in depressions.iter_mut() {
+        if depression.class_code != WATER_BREACHED
+            && depression.mean_depth_m <= config.wetland_mean_depth_m
+        {
+            depression.class_code = WATER_WETLAND;
+        }
+        depression.lake_id = -1;
+    }
+    let mut next_lake_id = 0i32;
+    for depression in depressions {
+        if depression.class_code != WATER_BREACHED && depression.class_code != WATER_WETLAND {
+            depression.lake_id = next_lake_id;
+            next_lake_id += 1;
+        }
     }
 }
 
@@ -915,7 +1055,7 @@ fn flow_geometry(
 fn river_properties(
     receiver: &[i32],
     ocean: &[u8],
-    water_class: &[u8],
+    preserved_waterbody_support: &[bool],
     area_accumulation: &[f64],
     discharge: &[f64],
     slope: &[f32],
@@ -930,7 +1070,7 @@ fn river_properties(
     let mut floodplain = vec![0.0f32; total];
     let log_reference = (config.river_discharge_threshold_m3s.max(1.0) * 100.0).ln_1p();
     for cell in 0..total {
-        if ocean[cell] != 0 || water_class[cell] != WATER_NONE || receiver[cell] < 0 {
+        if ocean[cell] != 0 || preserved_waterbody_support[cell] || receiver[cell] < 0 {
             continue;
         }
         let mean_q = (0..MONTHS)
@@ -1209,6 +1349,8 @@ fn run_hydrology(
     depression_id_out: &mut [i32],
     lake_id_out: &mut [i32],
     water_class_out: &mut [u8],
+    lake_fraction_out: &mut [f32],
+    wetland_fraction_out: &mut [f32],
     fill_depth_out: &mut [f32],
     hydrologic_elevation_out: &mut [f32],
     breach_incision_out: &mut [f32],
@@ -1233,6 +1375,11 @@ fn run_hydrology(
     if total == 0
         || config.planet_radius_m <= 0.0
         || !config.planet_radius_m.is_finite()
+        || config.subgrid_relief_scale <= 0.0
+        || !config.subgrid_relief_scale.is_finite()
+        || !(0.0 < config.subgrid_connected_basin_fraction
+            && config.subgrid_connected_basin_fraction <= 1.0)
+        || !config.subgrid_connected_basin_fraction.is_finite()
         || area_steradians
             .iter()
             .any(|value| !value.is_finite() || *value <= 0.0)
@@ -1280,10 +1427,11 @@ fn run_hydrology(
     let (depression_id, mut depressions) = find_depressions(
         &initial_flood,
         elevation,
+        relief,
         ocean,
         neighbors,
         &area_km2,
-        config.minimum_depression_depth_m,
+        config,
     );
     let owner = depression_catchments(&initial_flood, &depression_id, ocean);
     classify_depressions(
@@ -1298,12 +1446,8 @@ fn run_hydrology(
         config,
     );
     propagate_depression_overflow(&mut depressions, &initial_flood, &depression_id, config);
-    assign_water_extents(
-        &mut depressions,
-        elevation,
-        &area_km2,
-        config.minimum_depression_depth_m,
-    );
+    assign_water_extents(&mut depressions, elevation, relief, &area_km2, config);
+    finalize_waterbody_classes(&mut depressions, config);
     let (hydrologic_elevation, breach_incision, breach_records) = apply_breaches(
         &mut depressions,
         &initial_flood,
@@ -1329,10 +1473,27 @@ fn run_hydrology(
 
     let mut water_class = vec![WATER_NONE; total];
     let mut lake_id = vec![-1i32; total];
+    let mut lake_fraction = vec![0.0f32; total];
+    let mut wetland_fraction = vec![0.0f32; total];
+    let mut preserved_waterbody_support = vec![false; total];
     for depression in &depressions {
-        for &cell in &depression.water_cells {
+        if depression.class_code != WATER_BREACHED {
+            for &cell in &depression.cells {
+                preserved_waterbody_support[cell] = true;
+            }
+        }
+        for (&cell, &fraction) in depression
+            .water_cells
+            .iter()
+            .zip(&depression.water_fractions)
+        {
             water_class[cell] = depression.class_code;
             lake_id[cell] = depression.lake_id;
+            if depression.class_code == WATER_WETLAND {
+                wetland_fraction[cell] = fraction;
+            } else {
+                lake_fraction[cell] = fraction;
+            }
         }
     }
     let (basin_id, sink_type, basin_count) = assign_basins(&order, &receiver, ocean, &water_class);
@@ -1379,7 +1540,7 @@ fn run_hydrology(
     let river_properties = river_properties(
         &receiver,
         ocean,
-        &water_class,
+        &preserved_waterbody_support,
         &contributing_area,
         &discharge,
         &flow_slope,
@@ -1438,6 +1599,8 @@ fn run_hydrology(
     depression_id_out.copy_from_slice(&depression_id);
     lake_id_out.copy_from_slice(&lake_id);
     water_class_out.copy_from_slice(&water_class);
+    lake_fraction_out.copy_from_slice(&lake_fraction);
+    wetland_fraction_out.copy_from_slice(&wetland_fraction);
     for cell in 0..total {
         fill_depth_out[cell] = if ocean[cell] == 0 {
             (initial_flood.filled[cell] - elevation[cell]).max(0.0)
@@ -1479,12 +1642,12 @@ fn run_hydrology(
             / annual_runoff_km3.max(1e-12);
     let lake_count = depressions
         .iter()
-        .filter(|depression| depression.lake_id >= 0)
+        .filter(|depression| depression.lake_id >= 0 && depression.class_code != WATER_WETLAND)
         .count();
     let closed_sink_count = order.iter().filter(|cell| receiver[**cell] < 0).count();
     let lake_volume_km3 = depressions
         .iter()
-        .filter(|depression| depression.lake_id >= 0)
+        .filter(|depression| depression.lake_id >= 0 && depression.class_code != WATER_WETLAND)
         .map(|depression| depression.water_volume_km3)
         .sum();
     let breach_sediment_pulse_km3 = breach_records
@@ -1569,6 +1732,8 @@ pub unsafe extern "C" fn hydrology_run_cubed_sphere(
     depression_id_out: *mut i32,
     lake_id_out: *mut i32,
     water_class_out: *mut u8,
+    lake_fraction_out: *mut f32,
+    wetland_fraction_out: *mut f32,
     fill_depth_out: *mut f32,
     hydrologic_elevation_out: *mut f32,
     breach_incision_out: *mut f32,
@@ -1606,6 +1771,8 @@ pub unsafe extern "C" fn hydrology_run_cubed_sphere(
         || depression_id_out.is_null()
         || lake_id_out.is_null()
         || water_class_out.is_null()
+        || lake_fraction_out.is_null()
+        || wetland_fraction_out.is_null()
         || fill_depth_out.is_null()
         || hydrologic_elevation_out.is_null()
         || breach_incision_out.is_null()
@@ -1647,6 +1814,8 @@ pub unsafe extern "C" fn hydrology_run_cubed_sphere(
         slice::from_raw_parts_mut(depression_id_out, total),
         slice::from_raw_parts_mut(lake_id_out, total),
         slice::from_raw_parts_mut(water_class_out, total),
+        slice::from_raw_parts_mut(lake_fraction_out, total),
+        slice::from_raw_parts_mut(wetland_fraction_out, total),
         slice::from_raw_parts_mut(fill_depth_out, total),
         slice::from_raw_parts_mut(hydrologic_elevation_out, total),
         slice::from_raw_parts_mut(breach_incision_out, total),
@@ -1698,10 +1867,12 @@ mod tests {
         HydrologyConfig {
             planet_radius_m: 6_371_000.0,
             minimum_depression_depth_m: 20.0,
-            wetland_maximum_depth_m: 35.0,
+            wetland_mean_depth_m: 35.0,
             endorheic_aridity_threshold: 0.35,
             maximum_fill_time_years: 50_000.0,
             lake_seepage_mm_year: 30.0,
+            subgrid_relief_scale: 1.0,
+            subgrid_connected_basin_fraction: 0.50,
             breach_score_threshold: 1.0,
             maximum_breach_incision_m: 800.0,
             breach_length_cells: 2,
@@ -1719,6 +1890,24 @@ mod tests {
             result.extend_from_slice(&[before, after, before, after]);
         }
         result
+    }
+
+    #[test]
+    fn subgrid_hypsometry_integrates_fraction_and_volume() {
+        let (half_fraction, equivalent_depth_m) =
+            subgrid_inundation(100.0, 200.0, 100.0, 20.0, 1.0, 1.0);
+        assert!((half_fraction - 0.5).abs() < 1e-6);
+        assert!((equivalent_depth_m - 25.0).abs() < 1e-9);
+
+        let (full_fraction, equivalent_depth_m) =
+            subgrid_inundation(100.0, 200.0, 350.0, 20.0, 1.0, 1.0);
+        assert!((full_fraction - 1.0).abs() < 1e-6);
+        assert!((equivalent_depth_m - 250.0).abs() < 1e-9);
+
+        let (clipped_fraction, equivalent_depth_m) =
+            subgrid_inundation(100.0, 200.0, 100.0, 20.0, 1.0, 0.25);
+        assert!((clipped_fraction - 0.25).abs() < 1e-6);
+        assert!((equivalent_depth_m - 18.75).abs() < 1e-9);
     }
 
     #[test]
@@ -1746,16 +1935,42 @@ mod tests {
         let neighbors = line_neighbors(elevation.len());
         let area_km2 = [100.0; 5];
         let flood = priority_flood(&elevation, &ocean, &neighbors).unwrap();
-        let (depression_id, template) =
-            find_depressions(&flood, &elevation, &ocean, &neighbors, &area_km2, 20.0);
+        let relief = [100.0; 5];
+        let (depression_id, template) = find_depressions(
+            &flood,
+            &elevation,
+            &relief,
+            &ocean,
+            &neighbors,
+            &area_km2,
+            &test_config(),
+        );
         assert_eq!(template.len(), 1);
         let owner = depression_catchments(&flood, &depression_id, &ocean);
         let rock = [0.8; 5];
         let accommodation = [0.5; 5];
 
-        let mut wet = template;
+        assert!(template[0].maximum_depth_m > template[0].mean_depth_m);
+        let mut shallow = template.clone();
+        let mut wetland_config = test_config();
+        wetland_config.wetland_mean_depth_m =
+            0.5 * (template[0].maximum_depth_m + template[0].mean_depth_m);
         let wet_runoff = vec![10.0; MONTHS * elevation.len()];
         let wet_evaporation = vec![5.0; MONTHS * elevation.len()];
+        classify_depressions(
+            &mut shallow,
+            &owner,
+            &area_km2,
+            &wet_runoff,
+            &wet_evaporation,
+            &[1.2; 5],
+            &rock,
+            &accommodation,
+            &wetland_config,
+        );
+        assert_eq!(shallow[0].class_code, WATER_WETLAND);
+
+        let mut wet = template;
         classify_depressions(
             &mut wet,
             &owner,
@@ -1770,8 +1985,15 @@ mod tests {
         assert_eq!(wet[0].class_code, WATER_OVERFLOW_LAKE);
         assert!(wet[0].open_outlet);
 
-        let (depression_id, mut dry) =
-            find_depressions(&flood, &elevation, &ocean, &neighbors, &area_km2, 20.0);
+        let (depression_id, mut dry) = find_depressions(
+            &flood,
+            &elevation,
+            &relief,
+            &ocean,
+            &neighbors,
+            &area_km2,
+            &test_config(),
+        );
         let owner = depression_catchments(&flood, &depression_id, &ocean);
         let dry_runoff = vec![0.001; MONTHS * elevation.len()];
         let dry_evaporation = vec![500.0; MONTHS * elevation.len()];
@@ -1786,14 +2008,26 @@ mod tests {
             &accommodation,
             &test_config(),
         );
-        assign_water_extents(&mut dry, &elevation, &area_km2, 20.0);
+        assign_water_extents(&mut dry, &elevation, &relief, &area_km2, &test_config());
         assert_eq!(dry[0].class_code, WATER_ENDORHEIC);
+        finalize_waterbody_classes(&mut dry, &test_config());
+        assert_eq!(dry[0].class_code, WATER_WETLAND);
+        assert_eq!(dry[0].lake_id, -1);
         assert!(!dry[0].open_outlet);
         assert_eq!(dry[0].water_cells.len(), 1);
+        assert!(dry[0].water_fractions[0] < 1.0);
         assert!(dry[0].water_area_km2 < dry[0].area_km2 + 1e-9);
+        assert!(dry[0].maximum_depth_m >= dry[0].mean_depth_m);
 
-        let (depression_id, mut breached) =
-            find_depressions(&flood, &elevation, &ocean, &neighbors, &area_km2, 20.0);
+        let (depression_id, mut breached) = find_depressions(
+            &flood,
+            &elevation,
+            &relief,
+            &ocean,
+            &neighbors,
+            &area_km2,
+            &test_config(),
+        );
         let owner = depression_catchments(&flood, &depression_id, &ocean);
         let mut breach_config = test_config();
         breach_config.breach_score_threshold = 0.0;
@@ -1829,8 +2063,16 @@ mod tests {
         let neighbors = line_neighbors(elevation.len());
         let area_km2 = [100.0; 6];
         let flood = priority_flood(&elevation, &ocean, &neighbors).unwrap();
-        let (depression_id, mut depressions) =
-            find_depressions(&flood, &elevation, &ocean, &neighbors, &area_km2, 20.0);
+        let relief = [100.0; 6];
+        let (depression_id, mut depressions) = find_depressions(
+            &flood,
+            &elevation,
+            &relief,
+            &ocean,
+            &neighbors,
+            &area_km2,
+            &test_config(),
+        );
         assert_eq!(depressions.len(), 2);
         let owner = depression_catchments(&flood, &depression_id, &ocean);
         let mut runoff = vec![0.001; MONTHS * elevation.len()];

--- a/src/map_maker/pipeline/stages/hydrology.py
+++ b/src/map_maker/pipeline/stages/hydrology.py
@@ -16,15 +16,18 @@ from ..registry import stage
 from ..visualization import VisualizationRequest, VisualizationResult
 
 EARTH_RADIUS_M = 6_371_000.0
+EARTH_LIKE_LAKE_AREA_FRACTION_RANGE = (0.015, 0.040)
 
 
 @dataclass(frozen=True)
 class HydrologyConfig:
     minimum_depression_depth_m: float = 20.0
-    wetland_maximum_depth_m: float = 35.0
+    wetland_mean_depth_m: float = 35.0
     endorheic_aridity_threshold: float = 0.35
     maximum_fill_time_years: float = 50_000.0
     lake_seepage_mm_year: float = 30.0
+    subgrid_relief_scale: float = 1.0
+    subgrid_connected_basin_fraction: float = 0.50
     breach_score_threshold: float = 0.58
     maximum_breach_incision_m: float = 800.0
     breach_length_cells: int = 4
@@ -48,10 +51,12 @@ class HydrologyConfig:
         config = cls(**values)
         bounds = {
             "minimum_depression_depth_m": (0.1, 2_000.0),
-            "wetland_maximum_depth_m": (0.1, 500.0),
+            "wetland_mean_depth_m": (0.1, 500.0),
             "endorheic_aridity_threshold": (0.05, 10.0),
             "maximum_fill_time_years": (1.0, 10_000_000.0),
             "lake_seepage_mm_year": (0.0, 5_000.0),
+            "subgrid_relief_scale": (0.1, 8.0),
+            "subgrid_connected_basin_fraction": (0.05, 1.0),
             "breach_score_threshold": (0.0, 1.0),
             "maximum_breach_incision_m": (1.0, 5_000.0),
             "breach_length_cells": (1, 64),
@@ -63,8 +68,6 @@ class HydrologyConfig:
             value = getattr(config, name)
             if not np.isfinite(value) or not minimum <= value <= maximum:
                 raise ValueError(f"{name} must be finite and in [{minimum}, {maximum}]")
-        if config.wetland_maximum_depth_m < config.minimum_depression_depth_m:
-            raise ValueError("wetland_maximum_depth_m must be at least minimum_depression_depth_m")
         if config.river_minimum_discharge_m3s > config.river_discharge_threshold_m3s:
             raise ValueError(
                 "river_minimum_discharge_m3s must not exceed river_discharge_threshold_m3s"
@@ -211,6 +214,8 @@ def _hydrology_visualizer(
 ) -> list[VisualizationResult] | None:
     elevation = _result_array(result, "HydrologicElevationM")
     water = _result_array(result, "WaterBodyClass")
+    lake_fraction = _result_array(result, "LakeFraction")
+    wetland_fraction = _result_array(result, "WetlandFraction")
     corridor = _result_array(result, "RiverCorridor")
     floodplain = _result_array(result, "FloodplainPotential")
     basin = _result_array(result, "BasinID")
@@ -220,7 +225,17 @@ def _hydrology_visualizer(
     if (
         any(
             value is None
-            for value in (elevation, water, corridor, floodplain, basin, discharge, breach)
+            for value in (
+                elevation,
+                water,
+                lake_fraction,
+                wetland_fraction,
+                corridor,
+                floodplain,
+                basin,
+                discharge,
+                breach,
+            )
         )
         or reach_record is None
         or not isinstance(reach_record.value, pa.Table)
@@ -228,6 +243,8 @@ def _hydrology_visualizer(
         return None
     assert elevation is not None
     assert water is not None
+    assert lake_fraction is not None
+    assert wetland_fraction is not None
     assert corridor is not None
     assert floodplain is not None
     assert basin is not None
@@ -247,8 +264,12 @@ def _hydrology_visualizer(
         ],
         dtype=np.uint8,
     )
-    water_cells = water > 0
-    terrain[water_cells] = water_palette[np.clip(water[water_cells], 0, 5)]
+    water_coverage = np.clip(lake_fraction + wetland_fraction, 0.0, 1.0)[..., None]
+    water_color = water_palette[np.clip(water, 0, 5)]
+    terrain = (
+        terrain.astype(np.float32) * (1.0 - water_coverage)
+        + water_color.astype(np.float32) * water_coverage
+    ).astype(np.uint8)
     floodplain_alpha = (0.12 * np.clip(floodplain, 0.0, 1.0))[..., None]
     floodplain_color = np.array([88, 145, 103], dtype=np.float32)
     terrain = (
@@ -361,6 +382,8 @@ def _drainage_graph(
     sink_type: np.ndarray,
     depression_id: np.ndarray,
     lake_id: np.ndarray,
+    lake_fraction: np.ndarray,
+    wetland_fraction: np.ndarray,
     contributing_area: np.ndarray,
     mean_discharge: np.ndarray,
     ocean: np.ndarray,
@@ -374,6 +397,10 @@ def _drainage_graph(
             "sink_type": pa.array(sink_type.reshape(-1)[land_cells], type=pa.uint8()),
             "depression_id": pa.array(depression_id.reshape(-1)[land_cells], type=pa.int32()),
             "lake_id": pa.array(lake_id.reshape(-1)[land_cells], type=pa.int32()),
+            "lake_fraction": pa.array(lake_fraction.reshape(-1)[land_cells], type=pa.float32()),
+            "wetland_fraction": pa.array(
+                wetland_fraction.reshape(-1)[land_cells], type=pa.float32()
+            ),
             "contributing_area_km2": pa.array(
                 contributing_area.reshape(-1)[land_cells], type=pa.float64()
             ),
@@ -384,10 +411,45 @@ def _drainage_graph(
     )
 
 
+def _waterbody_cell_catalog(
+    depression_id: np.ndarray,
+    lake_id: np.ndarray,
+    water_class: np.ndarray,
+    lake_fraction: np.ndarray,
+    wetland_fraction: np.ndarray,
+    areas_km2: np.ndarray,
+) -> pa.Table:
+    flat_lake_fraction = lake_fraction.reshape(-1)
+    flat_wetland_fraction = wetland_fraction.reshape(-1)
+    coverage = flat_lake_fraction + flat_wetland_fraction
+    cells = np.flatnonzero(coverage > 0.0).astype(np.int32)
+    classes = water_class.reshape(-1)[cells].astype(np.uint8)
+    return pa.table(
+        {
+            "cell_id": pa.array(cells, type=pa.int32()),
+            "waterbody_id": pa.array(depression_id.reshape(-1)[cells], type=pa.int32()),
+            "depression_id": pa.array(depression_id.reshape(-1)[cells], type=pa.int32()),
+            "lake_id": pa.array(lake_id.reshape(-1)[cells], type=pa.int32()),
+            "class_code": pa.array(classes, type=pa.uint8()),
+            "class_name": pa.array(
+                [WATER_BODY_CLASSES.get(int(code), "unknown") for code in classes],
+                type=pa.string(),
+            ),
+            "lake_fraction": pa.array(flat_lake_fraction[cells], type=pa.float32()),
+            "wetland_fraction": pa.array(flat_wetland_fraction[cells], type=pa.float32()),
+            "covered_area_km2": pa.array(
+                areas_km2.reshape(-1)[cells] * coverage[cells], type=pa.float64()
+            ),
+        }
+    )
+
+
 ARRAY_DTYPES = {
     "DepressionID": np.int32,
     "LakeID": np.int32,
     "WaterBodyClass": np.uint8,
+    "LakeFraction": np.float32,
+    "WetlandFraction": np.float32,
     "DepressionFillDepthM": np.float32,
     "HydrologicElevationM": np.float32,
     "BreachIncisionM": np.float32,
@@ -413,13 +475,15 @@ ARRAY_DTYPES = {
         *ARRAY_DTYPES,
         "DepressionCatalog",
         "LakeCatalog",
+        "WetlandCatalog",
         "BreachCatalog",
         "BasinCatalog",
         "DrainageGraph",
+        "WaterBodyCellCatalog",
         "RiverReachCatalog",
         "HydrologyMetadata",
     ),
-    version="v3",
+    version="v5",
     native_libraries=("hydrology_native",),
     visualizer=_hydrology_visualizer,
 )
@@ -485,7 +549,10 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
             f"{metadata['conservation_relative_error']:.3e}"
         )
 
-    lake_catalog = depression_catalog.filter(pc.greater_equal(depression_catalog["lake_id"], 0))
+    registered_lake = pc.greater_equal(depression_catalog["lake_id"], 0)
+    wetland_class = pc.equal(depression_catalog["class_code"], 1)
+    lake_catalog = depression_catalog.filter(registered_lake)
+    wetland_catalog = depression_catalog.filter(wetland_class)
     basin_catalog = _basin_catalog(
         views["BasinID"],
         views["FlowSinkType"],
@@ -500,13 +567,37 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
         views["FlowSinkType"],
         views["DepressionID"],
         views["LakeID"],
+        views["LakeFraction"],
+        views["WetlandFraction"],
         views["ContributingAreaKm2"],
         views["MeanDischargeM3s"],
         ocean.astype(bool),
     )
+    waterbody_cell_catalog = _waterbody_cell_catalog(
+        views["DepressionID"],
+        views["LakeID"],
+        views["WaterBodyClass"],
+        views["LakeFraction"],
+        views["WetlandFraction"],
+        physical_areas_km2,
+    )
     flat_sink = views["FlowSinkType"][land_mask]
     closed_land_fraction = float(np.mean(flat_sink != 1))
-    lake_land_fraction = float(np.mean(views["LakeID"][land_mask] >= 0))
+    waterbody_support_land_cell_fraction = float(
+        np.mean((views["LakeFraction"] + views["WetlandFraction"])[land_mask] > 0.0)
+    )
+    lake_support_land_cell_fraction = float(np.mean(views["LakeFraction"][land_mask] > 0.0))
+    wetland_support_land_cell_fraction = float(np.mean(views["WetlandFraction"][land_mask] > 0.0))
+    land_area_km2 = float(np.sum(physical_areas_km2[land_mask]))
+    lake_land_area_fraction = float(
+        np.sum(physical_areas_km2[land_mask] * views["LakeFraction"][land_mask]) / land_area_km2
+    )
+    wetland_land_area_fraction = float(
+        np.sum(physical_areas_km2[land_mask] * views["WetlandFraction"][land_mask]) / land_area_km2
+    )
+    validation_minimum, validation_maximum = EARTH_LIKE_LAKE_AREA_FRACTION_RANGE
+    lake_area_km2 = float(pc.sum(lake_catalog["water_area_km2"]).as_py() or 0.0)
+    mean_lake_depth_m = float(metadata["lake_volume_km3"] * 1_000.0 / max(lake_area_km2, 1e-12))
     metadata.update(
         {
             **asdict(config),
@@ -515,14 +606,32 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
             "effective_river_contributing_area_threshold_km2": controls[
                 "river_contributing_area_threshold_km2"
             ],
-            "open_lake_count": int(pc.sum(depression_catalog["open_outlet"]).as_py() or 0),
+            "waterbody_count": lake_catalog.num_rows + wetland_catalog.num_rows,
+            "open_lake_count": int(pc.sum(lake_catalog["open_outlet"]).as_py() or 0),
+            "open_wetland_count": int(pc.sum(wetland_catalog["open_outlet"]).as_py() or 0),
+            "mean_lake_depth_m": mean_lake_depth_m,
             "closed_drainage_land_fraction": closed_land_fraction,
-            "lake_land_cell_fraction": lake_land_fraction,
+            "lake_land_cell_fraction": lake_support_land_cell_fraction,
+            "lake_support_land_cell_fraction": lake_support_land_cell_fraction,
+            "wetland_support_land_cell_fraction": wetland_support_land_cell_fraction,
+            "waterbody_support_land_cell_fraction": waterbody_support_land_cell_fraction,
+            "lake_land_area_fraction": lake_land_area_fraction,
+            "wetland_land_area_fraction": wetland_land_area_fraction,
+            "inland_water_and_wetland_land_area_fraction": (
+                lake_land_area_fraction + wetland_land_area_fraction
+            ),
+            "earth_like_lake_area_fraction_range": [
+                validation_minimum,
+                validation_maximum,
+            ],
+            "earth_like_lake_area_validation_pass": int(
+                validation_minimum <= lake_land_area_fraction <= validation_maximum
+            ),
             "water_body_classes": {str(code): name for code, name in WATER_BODY_CLASSES.items()},
             "topology": "cubed_sphere",
-            "model": "priority_flood_fill_spill_breach_hydrology_v1",
+            "model": "fractional_priority_flood_fill_spill_breach_hydrology_v2",
             "runoff_semantics": "monthly_climate_runoff_potential_routed_conservatively",
-            "lake_semantics": "explicit_open_or_closed_water_balance_depressions",
+            "lake_semantics": "subgrid_fractional_open_or_closed_water_balance_depressions",
             "river_semantics": "vector_reach_graph_with_support_rasters",
             "breach_semantics": "selective_sustained_overflow_outlet_incision",
         }
@@ -532,9 +641,11 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
         **handles,
         "DepressionCatalog": depression_catalog,
         "LakeCatalog": lake_catalog,
+        "WetlandCatalog": wetland_catalog,
         "BreachCatalog": breach_catalog,
         "BasinCatalog": basin_catalog,
         "DrainageGraph": drainage_graph,
+        "WaterBodyCellCatalog": waterbody_cell_catalog,
         "RiverReachCatalog": reach_catalog,
         "HydrologyMetadata": metadata,
     }

--- a/tests/test_hydrology.py
+++ b/tests/test_hydrology.py
@@ -97,6 +97,8 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
         "DepressionID": np.int32,
         "LakeID": np.int32,
         "WaterBodyClass": np.uint8,
+        "LakeFraction": np.float32,
+        "WetlandFraction": np.float32,
         "DepressionFillDepthM": np.float32,
         "HydrologicElevationM": np.float32,
         "BreachIncisionM": np.float32,
@@ -140,11 +142,15 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
 
     contributing_area = arrays["ContributingAreaKm2"].reshape(-1)
     monthly_discharge = arrays["MonthlyDischargeM3s"].reshape(12, -1)
+    depression_catalog = hydrology.artifact_records["DepressionCatalog"].value
+    open_outlet_cells = set(
+        depression_catalog.filter(depression_catalog["open_outlet"])["outlet_cell"].to_pylist()
+    )
     for cell in np.flatnonzero(land.reshape(-1)):
         target = int(flat_receiver[cell])
         if target >= 0 and not flat_ocean[target]:
             assert contributing_area[target] + 1e-8 >= contributing_area[cell]
-            if arrays["LakeID"].reshape(-1)[target] < 0:
+            if target not in open_outlet_cells:
                 assert np.all(monthly_discharge[:, target] + 1e-3 >= monthly_discharge[:, cell])
 
     routed = land & (receiver >= 0)
@@ -156,27 +162,52 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
     assert np.all(arrays["MeanDischargeM3s"] >= 0.0)
     assert np.all(arrays["MeanFlowVelocityMps"] >= 0.0)
     assert np.all(arrays["StreamPowerW"] >= 0.0)
-    assert np.all(arrays["RiverCorridor"][arrays["LakeID"] >= 0] == 0.0)
+    water_fraction = arrays["LakeFraction"] + arrays["WetlandFraction"]
+    assert np.all((arrays["LakeFraction"] >= 0.0) & (arrays["LakeFraction"] <= 1.0))
+    assert np.all((arrays["WetlandFraction"] >= 0.0) & (arrays["WetlandFraction"] <= 1.0))
+    assert np.all(water_fraction <= 1.0 + 1e-6)
+    assert np.all(arrays["LakeFraction"][arrays["WaterBodyClass"] == 1] == 0.0)
+    assert np.all(arrays["WetlandFraction"][arrays["WaterBodyClass"] != 1] == 0.0)
+    assert np.all(arrays["LakeID"][arrays["WetlandFraction"] > 0.0] == -1)
+    assert np.any((water_fraction > 0.0) & (water_fraction < 1.0))
+    assert np.all(arrays["RiverCorridor"][water_fraction >= 0.5] == 0.0)
 
-    depression_catalog = hydrology.artifact_records["DepressionCatalog"].value
     lake_catalog = hydrology.artifact_records["LakeCatalog"].value
+    wetland_catalog = hydrology.artifact_records["WetlandCatalog"].value
     breach_catalog = hydrology.artifact_records["BreachCatalog"].value
     basin_catalog = hydrology.artifact_records["BasinCatalog"].value
     drainage_graph = hydrology.artifact_records["DrainageGraph"].value
+    waterbody_cells = hydrology.artifact_records["WaterBodyCellCatalog"].value
     reaches = hydrology.artifact_records["RiverReachCatalog"].value
     for table in (
         depression_catalog,
         lake_catalog,
+        wetland_catalog,
         breach_catalog,
         basin_catalog,
         drainage_graph,
+        waterbody_cells,
         reaches,
     ):
         assert isinstance(table, pa.Table)
     assert depression_catalog.num_rows > 0
     assert lake_catalog.num_rows > 0
+    assert set(lake_catalog["class_code"].to_pylist()).isdisjoint({1})
+    assert set(wetland_catalog["class_code"].to_pylist()) <= {1}
+    np.testing.assert_array_equal(
+        np.sort(np.asarray(lake_catalog["lake_id"])),
+        np.arange(lake_catalog.num_rows, dtype=np.int32),
+    )
+    assert set(wetland_catalog["lake_id"].to_pylist()) <= {-1}
+    depression_classes = np.asarray(depression_catalog["class_code"])
+    preserved_depression_ids = np.asarray(depression_catalog["depression_id"])[
+        depression_classes != 5
+    ]
+    preserved_support = np.isin(arrays["DepressionID"], preserved_depression_ids)
+    assert np.all(arrays["RiverCorridor"][preserved_support] == 0.0)
     assert basin_catalog.num_rows > 0
     assert drainage_graph.num_rows == int(np.count_nonzero(land))
+    assert waterbody_cells.num_rows == int(np.count_nonzero(water_fraction > 0.0))
     assert reaches.num_rows > 0
     assert {
         "cell_id",
@@ -185,9 +216,38 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
         "sink_type",
         "depression_id",
         "lake_id",
+        "lake_fraction",
+        "wetland_fraction",
         "contributing_area_km2",
         "mean_discharge_m3s",
     } == set(drainage_graph.column_names)
+    assert {
+        "cell_id",
+        "waterbody_id",
+        "depression_id",
+        "lake_id",
+        "class_code",
+        "class_name",
+        "lake_fraction",
+        "wetland_fraction",
+        "covered_area_km2",
+    } == set(waterbody_cells.column_names)
+    np.testing.assert_array_equal(
+        np.asarray(waterbody_cells["waterbody_id"]),
+        np.asarray(waterbody_cells["depression_id"]),
+    )
+    assert np.all(np.asarray(waterbody_cells["covered_area_km2"]) > 0.0)
+    catalog_covered_area = float(np.sum(np.asarray(waterbody_cells["covered_area_km2"])))
+    radius_km = 6_371.0
+    physical_area_km2 = grid.cell_areas * radius_km * radius_km
+    raster_covered_area = float(np.sum(physical_area_km2 * water_fraction))
+    assert catalog_covered_area == pytest.approx(raster_covered_area, rel=1e-6)
+    assert float(np.sum(np.asarray(lake_catalog["water_area_km2"]))) == pytest.approx(
+        float(np.sum(physical_area_km2 * arrays["LakeFraction"])), rel=1e-6
+    )
+    assert float(np.sum(np.asarray(wetland_catalog["water_area_km2"]))) == pytest.approx(
+        float(np.sum(physical_area_km2 * arrays["WetlandFraction"])), rel=1e-6
+    )
     assert {"open_outlet", "outlet_cell", "annual_balance_km3"} <= set(
         depression_catalog.column_names
     )
@@ -248,10 +308,14 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
     assert metadata["annual_open_water_loss_km3"] >= 0.0
     assert metadata["depression_count"] == depression_catalog.num_rows
     assert metadata["lake_count"] == lake_catalog.num_rows
+    assert metadata["wetland_count"] == wetland_catalog.num_rows
+    assert metadata["waterbody_count"] == lake_catalog.num_rows + wetland_catalog.num_rows
     assert metadata["basin_count"] == basin_catalog.num_rows
     assert metadata["reach_count"] == reaches.num_rows
     assert metadata["open_lake_count"] > 0
     assert 0.0 < metadata["lake_land_cell_fraction"] < 0.25
+    assert 0.0 < metadata["lake_land_area_fraction"] < metadata["lake_land_cell_fraction"]
+    assert 0.0 <= metadata["wetland_land_area_fraction"] < 0.25
     assert 0.0 <= metadata["closed_drainage_land_fraction"] < 1.0
 
     visual_dir = engine.context.config.run_visual_dir() / "hydrology"
@@ -271,6 +335,8 @@ def test_hydrology_is_deterministic_and_cacheable(tmp_path: Path):
         "DepressionID",
         "LakeID",
         "WaterBodyClass",
+        "LakeFraction",
+        "WetlandFraction",
         "HydrologicElevationM",
         "FlowReceiverID",
         "ContributingAreaKm2",
@@ -282,9 +348,11 @@ def test_hydrology_is_deterministic_and_cacheable(tmp_path: Path):
     for name in (
         "DepressionCatalog",
         "LakeCatalog",
+        "WetlandCatalog",
         "BreachCatalog",
         "BasinCatalog",
         "DrainageGraph",
+        "WaterBodyCellCatalog",
         "RiverReachCatalog",
     ):
         assert first.artifact_records[name].value.equals(second.artifact_records[name].value)
@@ -294,13 +362,15 @@ def test_hydrology_is_deterministic_and_cacheable(tmp_path: Path):
 def test_hydrology_config_and_cli_reject_invalid_controls():
     with pytest.raises(ValueError, match="Unknown hydrology controls"):
         HydrologyConfig.from_mapping({"draw_rivers": True})
-    with pytest.raises(ValueError, match="wetland_maximum_depth_m"):
-        HydrologyConfig.from_mapping(
-            {"minimum_depression_depth_m": 50.0, "wetland_maximum_depth_m": 20.0}
-        )
+    with pytest.raises(ValueError, match="wetland_mean_depth_m"):
+        HydrologyConfig.from_mapping({"wetland_mean_depth_m": 0.0})
     with pytest.raises(ValueError, match="river_minimum_discharge_m3s"):
         HydrologyConfig.from_mapping(
             {"river_minimum_discharge_m3s": 500.0, "river_discharge_threshold_m3s": 100.0}
         )
+    with pytest.raises(ValueError, match="subgrid_relief_scale"):
+        HydrologyConfig.from_mapping({"subgrid_relief_scale": 0.0})
+    with pytest.raises(ValueError, match="subgrid_connected_basin_fraction"):
+        HydrologyConfig.from_mapping({"subgrid_connected_basin_fraction": 1.1})
     with pytest.raises(SystemExit):
         pipeline_tools_main(["--stage", "hydrology"])


### PR DESCRIPTION
## Summary
- model lake and wetland coverage as fractional coarse-cell quantities using subgrid hypsometry
- conserve fractional area and volume through equilibrium lake filling, and keep permanent lakes separate from wetlands
- add sparse waterbody membership, validation metrics, deterministic tests, and the accepted modeling decision
- stop synthetic river geometry at preserved coarse lake support pending fine-scale channel refinement

## Validation
- `.venv/bin/pytest -q` (97 passed)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `.venv/bin/ruff check src tests`
- changed-file `black --check`
- release native build and `map-maker doctor`

Repository-wide Black still reports two pre-existing untouched legacy files: `src/map_maker/legacy/io/geo.py` and `src/map_maker/legacy/generate.py`.

## Current limits
- canonical face-128 permanent lake area is 2.70%, but modeled lake volume remains high
- hydrology statistics remain resolution-sensitive until coarse drainage connectivity constrains refinement
- the coarse pass does not resolve multiple independent minor lakes within one cell
- ecological wetlands still require hydroperiod, soils, water table, and vegetation modeling