### PR TITLE
Add hierarchical basin refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "refinement_native"
+version = "0.1.0"
+dependencies = [
+ "topology_native",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "src/map_maker/pipeline/native/geology",
     "src/map_maker/pipeline/native/hydrology",
     "src/map_maker/pipeline/native/planet",
+    "src/map_maker/pipeline/native/refinement",
     "src/map_maker/pipeline/native/tectonics",
     "src/map_maker/pipeline/native/topology",
     "src/map_maker/pipeline/native/world_age",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -76,3 +76,6 @@ stage_overrides:
     river_discharge_threshold_m3s: 300.0
     river_contributing_area_threshold_km2: 200000.0
     river_minimum_discharge_m3s: 25.0
+  basin_refinement:
+    refinement_factor: 16
+    terrain_noise_fraction: 0.45

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1111,3 +1111,76 @@ Classification rule:
 Permanent lakes, present-day wetlands, seasonal floodplains, and paleowetlands
 are distinct products. Paleowetlands may contribute to geological resource
 history, including coal formation, but are not counted as present-day lakes.
+
+## Decision 023: Hierarchical Rivers And Subgrid Fluvial Incision
+
+Status: approved, provisional
+
+Decision:
+River channels, valleys, and floodplains remain explicit subgrid features at
+every level where their physical width is smaller than a cell. A river may cross
+a coarse cell without converting that cell into an atomic river or lowering its
+entire bedrock surface. Literal raster incision is permitted only where the
+incised landform is genuinely resolved.
+
+Scale interpretation:
+- Face-128 is a global structural level whose average Earth-size cell is about
+  5,200 km2, or 72 km across. It may support drainage topology, basin-scale
+  denudation, and source-to-sink budgets, but not resolved channel or valley
+  morphology.
+- Approximately 2-5 km cells may resolve major valley corridors and
+  floodplains, while most channels remain vector or fractional features.
+- Approximately 500 m-1 km regional cells may resolve many valleys and broad
+  floodplains, but ordinary rivers and streams still retain explicit reach
+  geometry and physical width.
+- Approximately 100 m cells may resolve large rivers; minor channels remain
+  subgrid. Human-scale channel realization belongs to later local refinement.
+
+Canonical reach rule:
+Each river reach preserves centerline geometry, upstream and downstream
+relationships, entry and exit anchors, bed elevation, discharge, velocity,
+physical width and depth, valley and floodplain width, incision depth, eroded
+volume, sediment load, and provenance where available. Rendering width is not
+simulation width and may not feed physical calculations.
+
+Coarse-cell rule:
+A sparse cell-to-reach relation stores reach length inside the cell and derived
+channel, valley, and floodplain area fractions. Channel coverage is based on
+physical reach width times in-cell length divided by physical cell area.
+Incision lowers the reach bed and changes the unresolved low-elevation portion
+of the cell hypsometry. It does not lower the whole cell by the reach incision
+depth. Any change to cell-mean elevation derives only from a conserved physical
+volume divided by cell area.
+
+Refinement contract:
+- Child drainage inherits the parent reach entry and exit anchors, downstream
+  identity, monthly discharge, sediment flux, and accepted lake or ocean sink.
+- Fine routing may add tributaries, meanders, local wetlands, and distributaries
+  or redistribute unresolved coverage, but may not silently redirect a major
+  trunk or change an inherited water and sediment budget.
+- Fine incised and deposited volumes restrict to their parent totals within the
+  configured conservation tolerance.
+- Refined terrain must reproduce parent area-weighted elevation and unresolved
+  relief constraints before local process adjustments are applied.
+- Aggregation publishes conserved budgets and distribution updates; it does not
+  replace accepted coarse topology solely because a finer realization looks
+  preferable.
+
+Implementation sequence:
+1. Establish registered multiresolution reach and sparse membership artifacts.
+2. Select one complete drainage basin and refine it while preserving its outlet,
+   trunk identity, discharge, and sediment boundary conditions.
+3. Realize constrained local routing and subgrid valley properties in that
+   basin.
+4. Run fluvial incision and conservative sediment routing at the finest active
+   level, then restrict budgets and terrain-distribution changes upward.
+5. Generalize the proven regional path to additional basins and production
+   resolution levels.
+
+Failure conditions:
+- Cell-wide trenches produced by subcell rivers.
+- Simulation width inferred from cartographic stroke width.
+- Refined rivers that do not connect to inherited parent reaches or sinks.
+- Water, sediment, or incision volumes that change under restriction.
+- Global fine grids used where selected regional refinement provides the same
+  physical result within the accepted hierarchy.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1153,8 +1153,14 @@ depth. Any change to cell-mean elevation derives only from a conserved physical
 volume divided by cell area.
 
 Refinement contract:
-- Child drainage inherits the parent reach entry and exit anchors, downstream
-  identity, monthly discharge, sediment flux, and accepted lake or ocean sink.
+- Child drainage inherits the parent reach entry and exit cells as spatial
+  constraints, downstream identity, monthly discharge, sediment flux, and any
+  accepted lake or ocean sink. A coarse junction anchor is not an arbitrary
+  fine-cell center that every connected reach must hit exactly.
+- Fine reaches are realized downstream-first. An upstream reach may merge at
+  any cell of its inherited downstream path inside the shared coarse junction
+  cell. The actual fine join cell is stored explicitly. The union must remain a
+  convergent directed acyclic graph with no reverse-used edge.
 - Fine routing may add tributaries, meanders, local wetlands, and distributaries
   or redistribute unresolved coverage, but may not silently redirect a major
   trunk or change an inherited water and sediment budget.
@@ -1168,8 +1174,10 @@ Refinement contract:
 
 Implementation sequence:
 1. Establish registered multiresolution reach and sparse membership artifacts.
-2. Select one complete drainage basin and refine it while preserving its outlet,
-   trunk identity, discharge, and sediment boundary conditions.
+2. Select one complete coarse drainage-basin footprint and refine it while
+   preserving its registered reach graph, trunk identity, discharge, and known
+   sediment boundary conditions. "Complete" describes spatial basin coverage;
+   it does not conceal reach gaps inherited from a coarse extraction threshold.
 3. Realize constrained local routing and subgrid valley properties in that
    basin.
 4. Run fluvial incision and conservative sediment routing at the finest active
@@ -1181,6 +1189,8 @@ Failure conditions:
 - Cell-wide trenches produced by subcell rivers.
 - Simulation width inferred from cartographic stroke width.
 - Refined rivers that do not connect to inherited parent reaches or sinks.
+- Applied erosion while any inherited terminal lacks a registered downstream
+  reach, lake/wetland/endorheic sink, or ocean boundary.
 - Water, sediment, or incision volumes that change under restriction.
 - Global fine grids used where selected regional refinement provides the same
   physical result within the accepted hierarchy.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -146,6 +146,46 @@ tributaries, wetlands, and channels. Until that constraint exists, closed-draina
 and lake statistics are provisional and Pass 1 is not calibrated for arbitrary
 resolution.
 
+## Selected-Basin Refinement
+
+The canonical sparse refinement selects ocean-draining basin 226. Its 1,448
+coarse basin cells plus one inherited ocean boundary cell produce 370,944
+face-2048 child records at factor 16 without allocating a global face-2048
+raster. Twenty-one inherited reaches produce 11,253 km of D4-contiguous fine
+reach paths and 2,613 sparse reach-cell memberships.
+
+Observed conservation and topology diagnostics:
+
+| Metric | Canonical result |
+| --- | ---: |
+| Maximum parent area relative error | `8.1e-12` |
+| Maximum restricted elevation error | `< 1e-5 m` |
+| D4 path topology | Pass |
+| Inherited parent path | Pass |
+| Downstream-path junction merges | Pass |
+| Reverse directed edges | `0` |
+| Combined path DAG | Pass |
+| Inherited discharge error | `0` |
+
+Requested physical channel area is `1,366.835 km2`; centerline-cell fractions
+represent `1,366.835 km2`, or roughly 0.02% of the 6.98 million km2 basin. This
+demonstrates why river width must remain a fractional/vector property even at
+the refined level. Approximately `157.3 km3` of potential incision is recorded
+as reach volume and has not been applied to cell-wide elevation.
+
+Broad corridors do not yet fit entirely in their centerline cells. Requested
+valley area is `39,917 km2`, of which `30,347 km2` (76.0%) is currently
+represented; requested floodplain area is `38,043 km2`, of which `29,499 km2`
+(77.5%) is represented. The missing support must be spread laterally into
+neighboring fine cells before erosion rather than hidden by capped fractions.
+
+Source-to-sink readiness currently fails. Of 13 terminal registered reaches,
+one reaches the ocean and 12 end at land cells where Hydrology Pass 1 fell below
+the river extraction threshold. The refinement stage classifies and reports
+these inherited gaps instead of inventing connections. Conservative incision
+and sediment routing remain blocked until the gaps close. These are contract and
+conservation results, not accepted erosion calibration.
+
 ## Calibration Rule
 
 Do not tighten or loosen a threshold solely to make the current gallery pass.

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -27,13 +27,18 @@
 6. Planetary boundary conditions and monthly orbital forcing.
 7. Climate pass 1.
 8. Hydrology pass 1.
+   - A sparse selected-basin refinement gate proves inherited river topology,
+     subgrid physical width, and parent/child conservation before erosion.
+     It must also report complete source-to-sink readiness; erosion remains
+     blocked while inherited reach-threshold gaps exist.
 9. Erosion and sedimentation.
 10. Hydrology pass 2.
 11. Soils and biomes.
 12. Mineral and energy systems.
 13. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches stage 7 with a
+The current canonical cubed-sphere implementation reaches Hydrology Pass 1 and
+the selected-basin refinement gate with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
 relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
 climate/orography pass. The older

--- a/docs/specs/08a_basin_refinement.md
+++ b/docs/specs/08a_basin_refinement.md
@@ -1,0 +1,135 @@
+# Sparse Selected-Basin Refinement
+
+## Status
+
+Implemented prototype following Hydrology Pass 1. This stage proves the
+cross-resolution river and terrain contract required before fluvial erosion. It
+does not yet apply erosion, generate new tributaries, or replace Hydrology Pass
+2.
+
+## Objective
+
+Refine one complete coarse drainage-basin footprint without allocating a global fine raster and
+without converting subcell rivers into atomic raster trenches. Preserve the
+accepted coarse basin, registered reach graph, junctions, physical dimensions,
+and flux attributes while realizing fine child terrain and reach paths. A
+complete footprint does not imply that thresholded Hydrology Pass 1 reaches
+already form a complete source-to-sink network.
+
+## Selection
+
+The default selects the largest ocean-draining basin that contains registered
+river reaches. An explicit `basin_id` may be configured. Every coarse basin cell
+is refined, together with any adjacent ocean or terminal cell required by an
+inherited reach path. Boundary cells are identified separately and are not
+counted as basin land area.
+
+The canonical factor is 16. Face-128 parents therefore receive globally unique
+face-2048 child IDs, whose average Earth-size cell is about 20 km2 or 4.5 km
+across. Only selected child records are allocated and persisted.
+
+## Terrain Realization
+
+- Every parent produces `factor * factor` same-face children.
+- Fine cell centers, areas, and D4 neighbors use the canonical equiangular
+  cubed-sphere geometry.
+- Child terrain blends toward available neighboring parent means and adds a
+  deterministic, locally smoothed relief realization.
+- The child field is area-weight recentered so its restricted mean reproduces
+  the adjusted parent bedrock elevation.
+- This is a terrain prior. It does not claim final valley, hillslope, or channel
+  morphology.
+
+## Reach Realization
+
+- Every inherited coarse reach retains its reach ID, basin, downstream reach,
+  discharge, velocity, width, depth, valley and floodplain widths, incision
+  potential, sediment load, morphology, and bed material.
+- Reaches are processed downstream-first. Terminal reaches retain fine anchors;
+  each upstream reach merges onto its registered downstream path inside the
+  inherited coarse junction cell, and records the actual fine join cell.
+- Each coarse-cell transition receives a valid D4 child transition, including
+  cube-face and land-to-ocean boundaries.
+- A deterministic downstream-rooted least-cost path connects each entry to its
+  next boundary portal, terminal anchor, or downstream merge using the terrain
+  prior. Collapsing adjacent fine parents must exactly reproduce the inherited
+  coarse cell path.
+- The union of fine paths must be a directed acyclic drainage graph. A path may
+  neither reuse an edge in reverse nor cross a downstream path and depart from
+  it again.
+- Path geometry remains a vector property. Cartographic stroke width does not
+  enter physical calculations.
+
+## Fractional Support
+
+For every fine reach-cell membership:
+
+```text
+channel_fraction = channel_width_m * reach_length_m / cell_area_m2
+valley_fraction = valley_width_m * reach_length_m / cell_area_m2
+floodplain_fraction = floodplain_width_m * reach_length_m / cell_area_m2
+```
+
+Fractions are bounded by `[0, 1]`. Broad valley and floodplain rectangles can
+exceed their centerline fine cell; current records cap that cell's represented
+support and report both represented and requested unclipped areas. Later lateral
+corridor realization must place the retained area in neighboring cells rather
+than discard it. Potential incision volume is physical channel width times
+in-cell reach length times inherited incision depth. It remains a diagnostic
+volume and does not lower the full fine cell.
+
+## Outputs
+
+- `RefinedBasinCellCatalog`: sparse child IDs, parent IDs, cubed-sphere
+  coordinates, areas, terrain prior, offset, and inherited relief.
+- `RefinedBasinParentCatalog`: parent/child area and elevation restriction
+  audit, including boundary membership.
+- `RefinedRiverReachCatalog`: inherited attributes, fine paths, downstream join
+  cells, terminal classification/readiness, path length, and spherical
+  polylines.
+- `RefinedReachCellCatalog`: sparse reach length, channel/valley/floodplain
+  fractions, and potential incision volume per fine cell.
+- `BasinRefinementMetadata`: selection, dimensions, conservation errors,
+  topology gates, physical totals, and semantic versioning.
+
+## Hard Gates
+
+- Child areas restrict to every parent area.
+- Area-weighted child elevation restricts to every adjusted parent elevation.
+- Every fine reach path is D4-contiguous.
+- Fine paths collapse exactly to inherited parent paths.
+- Every connected upstream reach ends on its inherited downstream fine path
+  inside the shared coarse junction cell.
+- The combined directed fine network is acyclic and contains no reverse-used
+  edge.
+- Inherited discharge is unchanged.
+- Channel, valley, and floodplain fractions remain finite and bounded.
+- Identical seed, configuration, inputs, and native build produce identical
+  artifacts.
+
+## Current Limits
+
+- Fine routing realizes inherited trunks only. It does not discover tributaries
+  below the coarse hydrology threshold.
+- Terrain interpolation reduces but cannot recover information absent from the
+  face-128 parent surface. Final geomorphology requires process-driven local
+  terrain and erosion.
+- Lake and wetland fractions are not yet spatially realized inside refined
+  parents.
+- Potential incision volume is not applied, and sediment is not yet routed or
+  deposited.
+- Junction-consistent channel-bed profiles are not yet solved. They belong to
+  the conservative erosion pass and may not be inferred from rendering strokes.
+- The prototype refines one basin per stage run and stores Arrow catalogs rather
+  than chunked regional rasters.
+- Reach gaps already present in Hydrology Pass 1 remain visible; refinement does
+  not invent connectivity that the accepted parent graph does not contain.
+- `source_to_sink_ready` remains false while those gaps exist. Conservative
+  erosion and sediment routing must not run on such a basin.
+- Capped valley and floodplain support is not yet spread laterally into adjacent
+  fine cells. Requested and represented areas therefore differ.
+
+The next pass closes inherited source-to-sink threshold gaps and realizes broad
+corridors laterally. Conservative fluvial incision and sediment routing can
+follow only after those readiness gates pass, then aggregate physical budgets
+upward before Hydrology Pass 2.

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,14 @@ climate/orographic precipitation. The first depression-aware hydrology pass now
 writes fractional lake and wetland coverage, spill outlets, breaches, conservative
 drainage basins, monthly discharge, sparse waterbody membership, and vector river
 reaches. Explicit geological event history, spherical
-erosion and sediment feedback, hydrology pass 2, soils, biomes, and regional
-refinement remain implementation milestones; the current output is a functional
-prototype rather than an atlas-grade world.
+erosion and sediment feedback, hydrology pass 2, soils, biomes, and complete
+regional terrain remain implementation milestones. A first sparse basin-refinement
+stage now realizes one inherited trunk network at approximately 5 km scale,
+preserves parent terrain means and convergent reach junctions, and stores physical
+channel, valley, and floodplain fractions without carving whole cells. It also
+publishes inherited terminal gaps and source-to-sink readiness; the canonical
+basin is not yet cleared for conservative erosion. The current output is a
+functional prototype rather than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -135,6 +140,9 @@ uv run map-maker-pipeline --stage climate --config configs/cubed_sphere_crust_st
 
 # Canonical lakes, breaches, drainage graph, basins, and vector river reaches
 uv run map-maker-pipeline --stage hydrology --config configs/cubed_sphere_crust_state.yaml
+
+# One sparse face-2048 basin with inherited trunks and subgrid valley fractions
+uv run map-maker-pipeline --stage basin_refinement --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -17,6 +17,7 @@ SIMULATION_NATIVE_LIBRARIES = (
     "geology_native",
     "hydrology_native",
     "planet_native",
+    "refinement_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -15,6 +15,7 @@ NATIVE_LIBRARIES = (
     "geology_native",
     "hydrology_native",
     "planet_native",
+    "refinement_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/pipeline/_refinement_native.py
+++ b/src/map_maker/pipeline/_refinement_native.py
@@ -1,0 +1,372 @@
+"""Rust-backed sparse selected-basin refinement bindings."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from cffi import FFI
+import numpy as np
+
+from .._native import NativeLibraryAbiError, native_library_info, native_library_path
+
+REFINEMENT_CONTROL_NAMES = {
+    "coarse_resolution",
+    "factor",
+    "planet_radius_m",
+    "terrain_seed",
+    "terrain_noise_fraction",
+}
+
+REFINED_CELL_DTYPE = np.dtype(
+    [
+        ("fine_cell_id", "<i4"),
+        ("parent_cell_id", "<i4"),
+        ("face", "<i4"),
+        ("row", "<i4"),
+        ("col", "<i4"),
+        ("xyz", "<f4", (3,)),
+        ("area_km2", "<f8"),
+        ("terrain_elevation_m", "<f4"),
+        ("terrain_offset_m", "<f4"),
+        ("parent_relief_m", "<f4"),
+    ],
+    align=True,
+)
+
+REFINED_REACH_DTYPE = np.dtype(
+    [
+        ("reach_id", "<i4"),
+        ("path_offset", "<i4"),
+        ("path_count", "<i4"),
+        ("entry_fine_cell", "<i4"),
+        ("exit_fine_cell", "<i4"),
+        ("path_length_m", "<f8"),
+    ],
+    align=True,
+)
+
+REACH_CELL_DTYPE = np.dtype(
+    [
+        ("reach_id", "<i4"),
+        ("fine_cell_id", "<i4"),
+        ("parent_cell_id", "<i4"),
+        ("path_order", "<i4"),
+        ("reach_length_m", "<f8"),
+        ("channel_fraction", "<f4"),
+        ("valley_fraction", "<f4"),
+        ("floodplain_fraction", "<f4"),
+        ("potential_incised_volume_m3", "<f8"),
+    ],
+    align=True,
+)
+
+_CDEF = """
+typedef struct {
+    int32_t coarse_resolution;
+    int32_t factor;
+    double planet_radius_m;
+    uint64_t terrain_seed;
+    float terrain_noise_fraction;
+} RefinementConfig;
+
+typedef struct {
+    int32_t fine_cell_id;
+    int32_t parent_cell_id;
+    int32_t face;
+    int32_t row;
+    int32_t col;
+    float xyz[3];
+    double area_km2;
+    float terrain_elevation_m;
+    float terrain_offset_m;
+    float parent_relief_m;
+} RefinedCellRecord;
+
+typedef struct {
+    int32_t reach_id;
+    int32_t path_offset;
+    int32_t path_count;
+    int32_t entry_fine_cell;
+    int32_t exit_fine_cell;
+    double path_length_m;
+} RefinedReachRecord;
+
+typedef struct {
+    int32_t reach_id;
+    int32_t fine_cell_id;
+    int32_t parent_cell_id;
+    int32_t path_order;
+    double reach_length_m;
+    float channel_fraction;
+    float valley_fraction;
+    float floodplain_fraction;
+    double potential_incised_volume_m3;
+} ReachCellRecord;
+
+typedef struct { RefinedCellRecord* data; size_t len; } RefinedCellArray;
+typedef struct { RefinedReachRecord* data; size_t len; } RefinedReachArray;
+typedef struct { ReachCellRecord* data; size_t len; } ReachCellArray;
+typedef struct { int32_t* data; size_t len; } Int32Array;
+
+typedef struct {
+    int32_t parent_count;
+    int32_t child_count;
+    int32_t reach_count;
+    int32_t reach_cell_count;
+    int32_t fine_resolution;
+    int32_t path_topology_valid;
+    double selected_area_km2;
+    double maximum_parent_area_relative_error;
+    double maximum_parent_elevation_error_m;
+    double total_reach_length_km;
+    double represented_channel_area_km2;
+    double represented_valley_area_km2;
+    double represented_floodplain_area_km2;
+    double total_potential_incised_volume_km3;
+} RefinementStats;
+
+uint32_t refinement_native_abi_version(void);
+int32_t refinement_run_basin(
+    const RefinementConfig* config,
+    int32_t parent_count,
+    const int32_t* parent_ids,
+    const float* parent_elevation_m,
+    const float* parent_relief_m,
+    const double* parent_area_steradians,
+    int32_t reach_count,
+    const int32_t* reach_ids,
+    const int32_t* reach_from_nodes,
+    const int32_t* reach_to_nodes,
+    const int32_t* reach_offsets,
+    int32_t reach_parent_cell_count,
+    const int32_t* reach_parent_cells,
+    const float* channel_width_m,
+    const float* valley_width_m,
+    const float* floodplain_width_m,
+    const float* incision_m,
+    RefinedCellArray* cells_out,
+    RefinedReachArray* reaches_out,
+    Int32Array* path_cells_out,
+    ReachCellArray* memberships_out,
+    RefinementStats* stats_out
+);
+void refinement_free_cells(RefinedCellArray array);
+void refinement_free_reaches(RefinedReachArray array);
+void refinement_free_i32(Int32Array array);
+void refinement_free_memberships(ReachCellArray array);
+"""
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+native_library_info("refinement_native")
+_lib = _ffi.dlopen(str(native_library_path("refinement_native")))
+try:
+    _abi_version = int(_lib.refinement_native_abi_version())
+except AttributeError as exc:
+    raise NativeLibraryAbiError("refinement_native lacks its required API") from exc
+if _abi_version != 2:
+    raise NativeLibraryAbiError(f"refinement_native uses ABI {_abi_version}; expected ABI 2")
+
+for c_name, dtype in (
+    ("RefinedCellRecord", REFINED_CELL_DTYPE),
+    ("RefinedReachRecord", REFINED_REACH_DTYPE),
+    ("ReachCellRecord", REACH_CELL_DTYPE),
+):
+    if _ffi.sizeof(c_name) != dtype.itemsize:
+        raise NativeLibraryAbiError(
+            f"{c_name} layout mismatch: C has {_ffi.sizeof(c_name)} bytes, "
+            f"NumPy has {dtype.itemsize}"
+        )
+
+
+def _input(value: np.ndarray, *, name: str, dtype: np.dtype[Any]) -> np.ndarray:
+    array = np.asarray(value)
+    if array.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}, got {array.dtype}")
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if not array.flags.c_contiguous or not array.flags.aligned:
+        raise ValueError(f"{name} must be contiguous and aligned")
+    return array
+
+
+def _copy_records(array: Any, *, dtype: np.dtype[Any]) -> np.ndarray:
+    length = int(array.len)
+    if length == 0:
+        return np.empty(0, dtype=dtype)
+    return np.frombuffer(
+        _ffi.buffer(array.data, length * dtype.itemsize), dtype=dtype, count=length
+    ).copy()
+
+
+def _copy_i32(array: Any) -> np.ndarray:
+    length = int(array.len)
+    if length == 0:
+        return np.empty(0, dtype=np.int32)
+    return np.frombuffer(
+        _ffi.buffer(array.data, length * np.dtype(np.int32).itemsize),
+        dtype=np.int32,
+        count=length,
+    ).copy()
+
+
+def run_basin_refinement(
+    *,
+    controls: Mapping[str, int | float],
+    parent_ids: np.ndarray,
+    parent_elevation_m: np.ndarray,
+    parent_relief_m: np.ndarray,
+    parent_area_steradians: np.ndarray,
+    reach_ids: np.ndarray,
+    reach_from_nodes: np.ndarray,
+    reach_to_nodes: np.ndarray,
+    reach_offsets: np.ndarray,
+    reach_parent_cells: np.ndarray,
+    channel_width_m: np.ndarray,
+    valley_width_m: np.ndarray,
+    floodplain_width_m: np.ndarray,
+    incision_m: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, int | float]]:
+    if set(controls) != REFINEMENT_CONTROL_NAMES:
+        missing = sorted(REFINEMENT_CONTROL_NAMES - set(controls))
+        extra = sorted(set(controls) - REFINEMENT_CONTROL_NAMES)
+        raise ValueError(f"refinement controls mismatch; missing={missing}, extra={extra}")
+    if any(not np.isfinite(value) for value in controls.values()):
+        raise ValueError("refinement controls must be finite")
+
+    arrays = {
+        "parent_ids": _input(parent_ids, name="parent_ids", dtype=np.dtype(np.int32)),
+        "parent_elevation_m": _input(
+            parent_elevation_m, name="parent_elevation_m", dtype=np.dtype(np.float32)
+        ),
+        "parent_relief_m": _input(
+            parent_relief_m, name="parent_relief_m", dtype=np.dtype(np.float32)
+        ),
+        "parent_area_steradians": _input(
+            parent_area_steradians,
+            name="parent_area_steradians",
+            dtype=np.dtype(np.float64),
+        ),
+        "reach_ids": _input(reach_ids, name="reach_ids", dtype=np.dtype(np.int32)),
+        "reach_from_nodes": _input(
+            reach_from_nodes, name="reach_from_nodes", dtype=np.dtype(np.int32)
+        ),
+        "reach_to_nodes": _input(reach_to_nodes, name="reach_to_nodes", dtype=np.dtype(np.int32)),
+        "reach_offsets": _input(reach_offsets, name="reach_offsets", dtype=np.dtype(np.int32)),
+        "reach_parent_cells": _input(
+            reach_parent_cells, name="reach_parent_cells", dtype=np.dtype(np.int32)
+        ),
+        "channel_width_m": _input(
+            channel_width_m, name="channel_width_m", dtype=np.dtype(np.float32)
+        ),
+        "valley_width_m": _input(valley_width_m, name="valley_width_m", dtype=np.dtype(np.float32)),
+        "floodplain_width_m": _input(
+            floodplain_width_m, name="floodplain_width_m", dtype=np.dtype(np.float32)
+        ),
+        "incision_m": _input(incision_m, name="incision_m", dtype=np.dtype(np.float32)),
+    }
+    parent_count = len(arrays["parent_ids"])
+    reach_count = len(arrays["reach_ids"])
+    if parent_count == 0 or reach_count == 0:
+        raise ValueError("selected basin must contain parent cells and river reaches")
+    if len(arrays["reach_offsets"]) != reach_count + 1:
+        raise ValueError("reach_offsets must contain reach_count + 1 values")
+
+    config = _ffi.new("RefinementConfig*")
+    for name, value in controls.items():
+        setattr(config[0], name, value)
+    cells_out = _ffi.new("RefinedCellArray*")
+    reaches_out = _ffi.new("RefinedReachArray*")
+    paths_out = _ffi.new("Int32Array*")
+    memberships_out = _ffi.new("ReachCellArray*")
+    stats_out = _ffi.new("RefinementStats*")
+
+    def pointer(name: str, c_type: str) -> Any:
+        array = arrays[name]
+        return _ffi.cast(
+            f"const {c_type}*",
+            _ffi.from_buffer(f"{c_type}[]", array, require_writable=False),
+        )
+
+    status = _lib.refinement_run_basin(
+        config,
+        parent_count,
+        pointer("parent_ids", "int32_t"),
+        pointer("parent_elevation_m", "float"),
+        pointer("parent_relief_m", "float"),
+        pointer("parent_area_steradians", "double"),
+        reach_count,
+        pointer("reach_ids", "int32_t"),
+        pointer("reach_from_nodes", "int32_t"),
+        pointer("reach_to_nodes", "int32_t"),
+        pointer("reach_offsets", "int32_t"),
+        len(arrays["reach_parent_cells"]),
+        pointer("reach_parent_cells", "int32_t"),
+        pointer("channel_width_m", "float"),
+        pointer("valley_width_m", "float"),
+        pointer("floodplain_width_m", "float"),
+        pointer("incision_m", "float"),
+        cells_out,
+        reaches_out,
+        paths_out,
+        memberships_out,
+        stats_out,
+    )
+    if status != 0:
+        messages = {
+            1: "null, empty, or length-mismatched argument",
+            2: "invalid refinement controls",
+            3: "invalid or duplicate parent cells",
+            4: "invalid inherited reach path or physical attributes",
+            5: "fine routing could not satisfy the inherited topology",
+        }
+        raise RuntimeError(
+            f"refinement_run_basin failed: {messages.get(status, f'status {status}')}"
+        )
+
+    try:
+        cells = _copy_records(cells_out[0], dtype=REFINED_CELL_DTYPE)
+        reaches = _copy_records(reaches_out[0], dtype=REFINED_REACH_DTYPE)
+        path_cells = _copy_i32(paths_out[0])
+        memberships = _copy_records(memberships_out[0], dtype=REACH_CELL_DTYPE)
+    finally:
+        _lib.refinement_free_cells(cells_out[0])
+        _lib.refinement_free_reaches(reaches_out[0])
+        _lib.refinement_free_i32(paths_out[0])
+        _lib.refinement_free_memberships(memberships_out[0])
+    stats = stats_out[0]
+    metadata: dict[str, int | float] = {
+        name: int(getattr(stats, name))
+        for name in (
+            "parent_count",
+            "child_count",
+            "reach_count",
+            "reach_cell_count",
+            "fine_resolution",
+            "path_topology_valid",
+        )
+    }
+    metadata.update(
+        {
+            name: float(getattr(stats, name))
+            for name in (
+                "selected_area_km2",
+                "maximum_parent_area_relative_error",
+                "maximum_parent_elevation_error_m",
+                "total_reach_length_km",
+                "represented_channel_area_km2",
+                "represented_valley_area_km2",
+                "represented_floodplain_area_km2",
+                "total_potential_incised_volume_km3",
+            )
+        }
+    )
+    return cells, reaches, path_cells, memberships, metadata
+
+
+__all__ = [
+    "REFINED_CELL_DTYPE",
+    "REFINED_REACH_DTYPE",
+    "REACH_CELL_DTYPE",
+    "run_basin_refinement",
+]

--- a/src/map_maker/pipeline/native/refinement/Cargo.toml
+++ b/src/map_maker/pipeline/native/refinement/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "refinement_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+topology_native = { path = "../topology" }
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/refinement/src/lib.rs
+++ b/src/map_maker/pipeline/native/refinement/src/lib.rs
@@ -1,0 +1,1174 @@
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+
+use topology_native::{
+    cubed_sphere_cell_area_steradians, cubed_sphere_cell_xyz, cubed_sphere_decode_index,
+    cubed_sphere_global_index, cubed_sphere_neighbor_index,
+};
+
+const D4_NEIGHBORS: usize = 4;
+
+#[no_mangle]
+pub extern "C" fn refinement_native_abi_version() -> u32 {
+    2
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct RefinementConfig {
+    pub coarse_resolution: i32,
+    pub factor: i32,
+    pub planet_radius_m: f64,
+    pub terrain_seed: u64,
+    pub terrain_noise_fraction: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct RefinedCellRecord {
+    pub fine_cell_id: i32,
+    pub parent_cell_id: i32,
+    pub face: i32,
+    pub row: i32,
+    pub col: i32,
+    pub xyz: [f32; 3],
+    pub area_km2: f64,
+    pub terrain_elevation_m: f32,
+    pub terrain_offset_m: f32,
+    pub parent_relief_m: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct RefinedReachRecord {
+    pub reach_id: i32,
+    pub path_offset: i32,
+    pub path_count: i32,
+    pub entry_fine_cell: i32,
+    pub exit_fine_cell: i32,
+    pub path_length_m: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ReachCellRecord {
+    pub reach_id: i32,
+    pub fine_cell_id: i32,
+    pub parent_cell_id: i32,
+    pub path_order: i32,
+    pub reach_length_m: f64,
+    pub channel_fraction: f32,
+    pub valley_fraction: f32,
+    pub floodplain_fraction: f32,
+    pub potential_incised_volume_m3: f64,
+}
+
+#[repr(C)]
+pub struct RefinedCellArray {
+    pub data: *mut RefinedCellRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct RefinedReachArray {
+    pub data: *mut RefinedReachRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct ReachCellArray {
+    pub data: *mut ReachCellRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct Int32Array {
+    pub data: *mut i32,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct RefinementStats {
+    pub parent_count: i32,
+    pub child_count: i32,
+    pub reach_count: i32,
+    pub reach_cell_count: i32,
+    pub fine_resolution: i32,
+    pub path_topology_valid: i32,
+    pub selected_area_km2: f64,
+    pub maximum_parent_area_relative_error: f64,
+    pub maximum_parent_elevation_error_m: f64,
+    pub total_reach_length_km: f64,
+    pub represented_channel_area_km2: f64,
+    pub represented_valley_area_km2: f64,
+    pub represented_floodplain_area_km2: f64,
+    pub total_potential_incised_volume_km3: f64,
+}
+
+struct Inputs<'a> {
+    config: RefinementConfig,
+    parent_ids: &'a [i32],
+    parent_elevation_m: &'a [f32],
+    parent_relief_m: &'a [f32],
+    parent_area_steradians: &'a [f64],
+    reach_ids: &'a [i32],
+    reach_from_nodes: &'a [i32],
+    reach_to_nodes: &'a [i32],
+    reach_offsets: &'a [i32],
+    reach_parent_cells: &'a [i32],
+    channel_width_m: &'a [f32],
+    valley_width_m: &'a [f32],
+    floodplain_width_m: &'a [f32],
+    incision_m: &'a [f32],
+}
+
+struct Outcome {
+    cells: Vec<RefinedCellRecord>,
+    reaches: Vec<RefinedReachRecord>,
+    path_cells: Vec<i32>,
+    memberships: Vec<ReachCellRecord>,
+    stats: RefinementStats,
+}
+
+#[derive(Clone, Copy)]
+struct QueueState {
+    cost: f64,
+    cell: i32,
+}
+
+impl PartialEq for QueueState {
+    fn eq(&self, other: &Self) -> bool {
+        self.cell == other.cell && self.cost.to_bits() == other.cost.to_bits()
+    }
+}
+
+impl Eq for QueueState {}
+
+impl PartialOrd for QueueState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for QueueState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .cost
+            .total_cmp(&self.cost)
+            .then_with(|| other.cell.cmp(&self.cell))
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn signed_noise(seed: u64, cell: i32) -> f64 {
+    let bits = splitmix64(seed ^ cell as u32 as u64);
+    let unit = (bits >> 11) as f64 * (1.0 / ((1u64 << 53) as f64));
+    unit * 2.0 - 1.0
+}
+
+fn angular_distance(first: [f32; 3], second: [f32; 3]) -> f64 {
+    let dot = (first[0] as f64 * second[0] as f64
+        + first[1] as f64 * second[1] as f64
+        + first[2] as f64 * second[2] as f64)
+        .clamp(-1.0, 1.0);
+    dot.acos()
+}
+
+fn validate_inputs(inputs: &Inputs<'_>) -> Result<(usize, usize), i32> {
+    let coarse = usize::try_from(inputs.config.coarse_resolution).map_err(|_| 2)?;
+    let factor = usize::try_from(inputs.config.factor).map_err(|_| 2)?;
+    if coarse == 0
+        || factor <= 1
+        || !inputs.config.planet_radius_m.is_finite()
+        || inputs.config.planet_radius_m <= 0.0
+        || !inputs.config.terrain_noise_fraction.is_finite()
+        || !(0.0..=1.0).contains(&inputs.config.terrain_noise_fraction)
+    {
+        return Err(2);
+    }
+    let fine = coarse.checked_mul(factor).ok_or(2)?;
+    let fine_cells = 6usize
+        .checked_mul(fine)
+        .and_then(|value| value.checked_mul(fine))
+        .ok_or(2)?;
+    if fine_cells > i32::MAX as usize || inputs.parent_ids.is_empty() || inputs.reach_ids.is_empty()
+    {
+        return Err(2);
+    }
+    let parent_count = inputs.parent_ids.len();
+    if inputs.parent_elevation_m.len() != parent_count
+        || inputs.parent_relief_m.len() != parent_count
+        || inputs.parent_area_steradians.len() != parent_count
+    {
+        return Err(1);
+    }
+    let reach_count = inputs.reach_ids.len();
+    if inputs.reach_from_nodes.len() != reach_count
+        || inputs.reach_to_nodes.len() != reach_count
+        || inputs.reach_offsets.len() != reach_count + 1
+        || inputs.channel_width_m.len() != reach_count
+        || inputs.valley_width_m.len() != reach_count
+        || inputs.floodplain_width_m.len() != reach_count
+        || inputs.incision_m.len() != reach_count
+    {
+        return Err(1);
+    }
+    if inputs.reach_offsets.first() != Some(&0)
+        || inputs.reach_offsets.last().copied() != Some(inputs.reach_parent_cells.len() as i32)
+    {
+        return Err(4);
+    }
+    let mut parent_set = HashSet::with_capacity(parent_count);
+    let coarse_cells = 6usize * coarse * coarse;
+    for index in 0..parent_count {
+        let parent = inputs.parent_ids[index];
+        if parent < 0
+            || parent as usize >= coarse_cells
+            || !parent_set.insert(parent)
+            || !inputs.parent_elevation_m[index].is_finite()
+            || !inputs.parent_relief_m[index].is_finite()
+            || inputs.parent_relief_m[index] < 0.0
+            || !inputs.parent_area_steradians[index].is_finite()
+            || inputs.parent_area_steradians[index] <= 0.0
+        {
+            return Err(3);
+        }
+    }
+    let mut reach_set = HashSet::with_capacity(reach_count);
+    for reach_index in 0..reach_count {
+        if !reach_set.insert(inputs.reach_ids[reach_index])
+            || !inputs.channel_width_m[reach_index].is_finite()
+            || inputs.channel_width_m[reach_index] <= 0.0
+            || !inputs.valley_width_m[reach_index].is_finite()
+            || inputs.valley_width_m[reach_index] < inputs.channel_width_m[reach_index]
+            || !inputs.floodplain_width_m[reach_index].is_finite()
+            || inputs.floodplain_width_m[reach_index] < 0.0
+            || !inputs.incision_m[reach_index].is_finite()
+            || inputs.incision_m[reach_index] < 0.0
+        {
+            return Err(4);
+        }
+        let start_raw = inputs.reach_offsets[reach_index];
+        let end_raw = inputs.reach_offsets[reach_index + 1];
+        let Some(path_length) = end_raw.checked_sub(start_raw) else {
+            return Err(4);
+        };
+        if start_raw < 0 || end_raw < 0 || path_length < 2 {
+            return Err(4);
+        }
+        let start = start_raw as usize;
+        let end = end_raw as usize;
+        if end > inputs.reach_parent_cells.len() {
+            return Err(4);
+        }
+        let path = &inputs.reach_parent_cells[start..end];
+        if path.first() != Some(&inputs.reach_from_nodes[reach_index])
+            || path.last() != Some(&inputs.reach_to_nodes[reach_index])
+            || path.iter().any(|cell| !parent_set.contains(cell))
+        {
+            return Err(4);
+        }
+        for pair in path.windows(2) {
+            let source = pair[0] as usize;
+            let target = pair[1] as usize;
+            let adjacent = (0..D4_NEIGHBORS)
+                .any(|slot| cubed_sphere_neighbor_index(source, slot, coarse) == Some(target));
+            if !adjacent {
+                return Err(4);
+            }
+        }
+    }
+    Ok((coarse, fine))
+}
+
+type ParentRanges = HashMap<i32, (usize, usize, usize)>;
+type ChildGeneration = (Vec<RefinedCellRecord>, HashMap<i32, usize>, ParentRanges);
+type ReachGeneration = (Vec<RefinedReachRecord>, Vec<i32>, Vec<ReachCellRecord>);
+
+fn generate_children(
+    inputs: &Inputs<'_>,
+    coarse: usize,
+    fine: usize,
+) -> Result<ChildGeneration, i32> {
+    let factor = inputs.config.factor as usize;
+    let children_per_parent = factor * factor;
+    let radius_squared_km = (inputs.config.planet_radius_m / 1_000.0).powi(2);
+    let mut cells = Vec::with_capacity(inputs.parent_ids.len() * children_per_parent);
+    let mut local_by_id = HashMap::with_capacity(cells.capacity());
+    let mut ranges = HashMap::with_capacity(inputs.parent_ids.len());
+    let parent_input_by_id = inputs
+        .parent_ids
+        .iter()
+        .enumerate()
+        .map(|(index, &parent)| (parent, index))
+        .collect::<HashMap<_, _>>();
+
+    for (parent_index, &parent_id) in inputs.parent_ids.iter().enumerate() {
+        let (face, parent_row, parent_col) =
+            cubed_sphere_decode_index(parent_id as usize, coarse).ok_or(3)?;
+        let start = cells.len();
+        for child_row in 0..factor {
+            for child_col in 0..factor {
+                let row = parent_row * factor + child_row;
+                let col = parent_col * factor + child_col;
+                let fine_id = cubed_sphere_global_index(face, row, col, fine).ok_or(3)?;
+                let xyz = cubed_sphere_cell_xyz(face, row, col, fine).ok_or(3)?;
+                let area = cubed_sphere_cell_area_steradians(face, row, col, fine).ok_or(3)?;
+                let record = RefinedCellRecord {
+                    fine_cell_id: fine_id as i32,
+                    parent_cell_id: parent_id,
+                    face: face as i32,
+                    row: row as i32,
+                    col: col as i32,
+                    xyz: [xyz[0] as f32, xyz[1] as f32, xyz[2] as f32],
+                    area_km2: area * radius_squared_km,
+                    terrain_elevation_m: inputs.parent_elevation_m[parent_index],
+                    terrain_offset_m: 0.0,
+                    parent_relief_m: inputs.parent_relief_m[parent_index],
+                };
+                local_by_id.insert(record.fine_cell_id, cells.len());
+                cells.push(record);
+            }
+        }
+        ranges.insert(parent_id, (start, cells.len(), parent_index));
+    }
+
+    let mut noise = cells
+        .iter()
+        .map(|cell| signed_noise(inputs.config.terrain_seed, cell.fine_cell_id))
+        .collect::<Vec<_>>();
+    for _ in 0..3 {
+        let previous = noise.clone();
+        for &(start, end, _) in ranges.values() {
+            for local in start..end {
+                let cell = cells[local];
+                let mut sum = previous[local] * 2.0;
+                let mut weight = 2.0;
+                for slot in 0..D4_NEIGHBORS {
+                    let Some(neighbor_id) =
+                        cubed_sphere_neighbor_index(cell.fine_cell_id as usize, slot, fine)
+                    else {
+                        continue;
+                    };
+                    let Some(&neighbor_local) = local_by_id.get(&(neighbor_id as i32)) else {
+                        continue;
+                    };
+                    if cells[neighbor_local].parent_cell_id == cell.parent_cell_id {
+                        sum += previous[neighbor_local];
+                        weight += 1.0;
+                    }
+                }
+                noise[local] = sum / weight;
+            }
+        }
+    }
+
+    for &(start, end, parent_index) in ranges.values() {
+        let total_area = cells[start..end]
+            .iter()
+            .map(|cell| cell.area_km2)
+            .sum::<f64>();
+        let mean = cells[start..end]
+            .iter()
+            .zip(&noise[start..end])
+            .map(|(cell, value)| cell.area_km2 * value)
+            .sum::<f64>()
+            / total_area;
+        for value in &mut noise[start..end] {
+            *value -= mean;
+        }
+        let maximum = noise[start..end]
+            .iter()
+            .map(|value| value.abs())
+            .fold(0.0f64, f64::max)
+            .max(f64::EPSILON);
+        let amplitude = inputs.parent_relief_m[parent_index] as f64
+            * inputs.config.terrain_noise_fraction as f64;
+        let parent_id = inputs.parent_ids[parent_index];
+        let parent_elevation = inputs.parent_elevation_m[parent_index] as f64;
+        let neighbor_elevation = |slot: usize| -> f64 {
+            cubed_sphere_neighbor_index(parent_id as usize, slot, coarse)
+                .and_then(|neighbor| parent_input_by_id.get(&(neighbor as i32)).copied())
+                .map_or(parent_elevation, |index| {
+                    inputs.parent_elevation_m[index] as f64
+                })
+        };
+        let north = neighbor_elevation(0);
+        let south = neighbor_elevation(1);
+        let west = neighbor_elevation(2);
+        let east = neighbor_elevation(3);
+        let mut offsets = Vec::with_capacity(end - start);
+        for local in start..end {
+            let local_row = cells[local].row as usize % factor;
+            let local_col = cells[local].col as usize % factor;
+            let y = (local_row as f64 + 0.5) / factor as f64 - 0.5;
+            let x = (local_col as f64 + 0.5) / factor as f64 - 0.5;
+            let horizontal = if x >= 0.0 {
+                (east - parent_elevation) * x
+            } else {
+                (parent_elevation - west) * x
+            };
+            let vertical = if y >= 0.0 {
+                (south - parent_elevation) * y
+            } else {
+                (parent_elevation - north) * y
+            };
+            offsets.push(horizontal + vertical + noise[local] / maximum * amplitude);
+        }
+        let offset_mean = cells[start..end]
+            .iter()
+            .zip(&offsets)
+            .map(|(cell, offset)| cell.area_km2 * offset)
+            .sum::<f64>()
+            / total_area;
+        for (cell, offset) in cells[start..end].iter_mut().zip(offsets) {
+            let corrected_offset = offset - offset_mean;
+            cell.terrain_elevation_m = (parent_elevation + corrected_offset) as f32;
+            cell.terrain_offset_m = cell.terrain_elevation_m - parent_elevation as f32;
+        }
+    }
+
+    Ok((cells, local_by_id, ranges))
+}
+
+fn choose_anchor(
+    parent: i32,
+    cells: &[RefinedCellRecord],
+    ranges: &ParentRanges,
+    factor: usize,
+) -> Result<i32, i32> {
+    let &(start, end, _) = ranges.get(&parent).ok_or(4)?;
+    let mut best = None::<(f64, i32)>;
+    let center = (factor as f64 - 1.0) * 0.5;
+    for cell in &cells[start..end] {
+        let local_row = cell.row as usize % factor;
+        let local_col = cell.col as usize % factor;
+        let center_distance = ((local_row as f64 - center).powi(2)
+            + (local_col as f64 - center).powi(2))
+            / (factor as f64 * factor as f64);
+        let score =
+            cell.terrain_elevation_m as f64 + cell.parent_relief_m as f64 * 0.2 * center_distance;
+        let candidate = (score, cell.fine_cell_id);
+        if best.map_or(true, |current| candidate < current) {
+            best = Some(candidate);
+        }
+    }
+    best.map(|(_, cell)| cell).ok_or(5)
+}
+
+struct RoutingContext<'a> {
+    fine: usize,
+    cells: &'a [RefinedCellRecord],
+    local_by_id: &'a HashMap<i32, usize>,
+    ranges: &'a ParentRanges,
+    used_edges: &'a HashSet<(i32, i32)>,
+    used_nodes: &'a HashSet<i32>,
+}
+
+fn boundary_pair(
+    source_parent: i32,
+    target_parent: i32,
+    context: &RoutingContext<'_>,
+) -> Result<(i32, i32), i32> {
+    let &(start, end, _) = context.ranges.get(&source_parent).ok_or(4)?;
+    let mut best = None::<(f64, i32, i32)>;
+    for source in &context.cells[start..end] {
+        for slot in 0..D4_NEIGHBORS {
+            let Some(target) =
+                cubed_sphere_neighbor_index(source.fine_cell_id as usize, slot, context.fine)
+            else {
+                continue;
+            };
+            let Some(&target_local) = context.local_by_id.get(&(target as i32)) else {
+                continue;
+            };
+            if context.cells[target_local].parent_cell_id != target_parent {
+                continue;
+            }
+            if context.used_nodes.contains(&source.fine_cell_id)
+                || context.used_nodes.contains(&(target as i32))
+            {
+                continue;
+            }
+            if context
+                .used_edges
+                .contains(&(target as i32, source.fine_cell_id))
+            {
+                continue;
+            }
+            let score = source.terrain_elevation_m as f64
+                + context.cells[target_local].terrain_elevation_m as f64;
+            let candidate = (score, source.fine_cell_id, target as i32);
+            if best.map_or(true, |current| candidate < current) {
+                best = Some(candidate);
+            }
+        }
+    }
+    best.map(|(_, source, target)| (source, target)).ok_or(5)
+}
+
+fn route_inside_parent(
+    parent: i32,
+    source: i32,
+    targets: &[i32],
+    context: &RoutingContext<'_>,
+) -> Result<Vec<i32>, i32> {
+    if targets.contains(&source) {
+        return Ok(vec![source]);
+    }
+    if targets.is_empty() {
+        return Err(5);
+    }
+    let target_set = targets.iter().copied().collect::<HashSet<_>>();
+    let &(start, end, _) = context.ranges.get(&parent).ok_or(4)?;
+    let minimum_elevation = context.cells[start..end]
+        .iter()
+        .map(|cell| cell.terrain_elevation_m as f64)
+        .fold(f64::INFINITY, f64::min);
+    let relief = context.cells[start].parent_relief_m as f64;
+    let scale = relief.max(1.0);
+    let mut queue = BinaryHeap::new();
+    let mut distance = HashMap::<i32, f64>::new();
+    let mut next = HashMap::<i32, i32>::new();
+    for &target in targets {
+        distance.insert(target, 0.0);
+        queue.push(QueueState {
+            cost: 0.0,
+            cell: target,
+        });
+    }
+
+    while let Some(state) = queue.pop() {
+        if state.cell == source {
+            break;
+        }
+        if state.cost > *distance.get(&state.cell).unwrap_or(&f64::INFINITY) {
+            continue;
+        }
+        let downstream_local = *context.local_by_id.get(&state.cell).ok_or(5)?;
+        for slot in 0..D4_NEIGHBORS {
+            let Some(neighbor) =
+                cubed_sphere_neighbor_index(state.cell as usize, slot, context.fine)
+            else {
+                continue;
+            };
+            let neighbor = neighbor as i32;
+            let Some(&neighbor_local) = context.local_by_id.get(&neighbor) else {
+                continue;
+            };
+            if context.cells[neighbor_local].parent_cell_id != parent {
+                continue;
+            }
+            if context.used_nodes.contains(&neighbor) && !target_set.contains(&neighbor) {
+                continue;
+            }
+            if context.used_edges.contains(&(state.cell, neighbor)) {
+                continue;
+            }
+            let edge_angle = angular_distance(
+                context.cells[neighbor_local].xyz,
+                context.cells[downstream_local].xyz,
+            );
+            let normalized_lowland = (context.cells[downstream_local].terrain_elevation_m as f64
+                - minimum_elevation)
+                / scale;
+            let uphill = (context.cells[downstream_local].terrain_elevation_m as f64
+                - context.cells[neighbor_local].terrain_elevation_m as f64)
+                .max(0.0)
+                / scale;
+            let edge_cost = edge_angle * (1.0 + 0.35 * normalized_lowland + 1.5 * uphill);
+            let candidate = state.cost + edge_cost;
+            if candidate + 1e-15 < *distance.get(&neighbor).unwrap_or(&f64::INFINITY) {
+                distance.insert(neighbor, candidate);
+                next.insert(neighbor, state.cell);
+                queue.push(QueueState {
+                    cost: candidate,
+                    cell: neighbor,
+                });
+            }
+        }
+    }
+    if !distance.contains_key(&source) {
+        return Err(5);
+    }
+    let mut path = vec![source];
+    while !target_set.contains(path.last().unwrap_or(&source)) {
+        let downstream = *next.get(path.last().unwrap_or(&source)).ok_or(5)?;
+        path.push(downstream);
+    }
+    Ok(path)
+}
+
+fn append_segment(path: &mut Vec<i32>, segment: &[i32]) {
+    let start = usize::from(
+        path.last()
+            .is_some_and(|last| segment.first() == Some(last)),
+    );
+    path.extend_from_slice(&segment[start..]);
+}
+
+fn bounded_fraction(numerator: f64, denominator: f64) -> f32 {
+    let exact = (numerator / denominator).clamp(0.0, 1.0);
+    let rounded = exact as f32;
+    if rounded as f64 > exact && rounded > 0.0 {
+        f32::from_bits(rounded.to_bits() - 1)
+    } else {
+        rounded
+    }
+}
+
+fn refine_reaches(
+    inputs: &Inputs<'_>,
+    fine: usize,
+    cells: &[RefinedCellRecord],
+    local_by_id: &HashMap<i32, usize>,
+    ranges: &ParentRanges,
+) -> Result<ReachGeneration, i32> {
+    let factor = inputs.config.factor as usize;
+    let mut anchors = HashMap::<i32, i32>::new();
+    for &node in inputs.reach_from_nodes.iter().chain(inputs.reach_to_nodes) {
+        if let std::collections::hash_map::Entry::Vacant(entry) = anchors.entry(node) {
+            entry.insert(choose_anchor(node, cells, ranges, factor)?);
+        }
+    }
+    let mut boundary_cache = HashMap::<(i32, i32), (i32, i32)>::new();
+    let mut used_edges = HashSet::<(i32, i32)>::new();
+    let mut used_nodes = HashSet::<i32>::new();
+    let reach_by_from_node = inputs
+        .reach_from_nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (*node, index))
+        .collect::<HashMap<_, _>>();
+    let mut generated_paths = vec![Vec::<i32>::new(); inputs.reach_ids.len()];
+    let mut reach_records = Vec::with_capacity(inputs.reach_ids.len());
+    let mut all_path_cells = Vec::<i32>::new();
+    let mut memberships = Vec::<ReachCellRecord>::new();
+
+    for reach_index in 0..inputs.reach_ids.len() {
+        let routing_context = RoutingContext {
+            fine,
+            cells,
+            local_by_id,
+            ranges,
+            used_edges: &used_edges,
+            used_nodes: &used_nodes,
+        };
+        let coarse_start = inputs.reach_offsets[reach_index] as usize;
+        let coarse_end = inputs.reach_offsets[reach_index + 1] as usize;
+        let coarse_path = &inputs.reach_parent_cells[coarse_start..coarse_end];
+        let mut transitions = Vec::with_capacity(coarse_path.len() - 1);
+        for pair in coarse_path.windows(2) {
+            let key = (pair[0], pair[1]);
+            let boundary = if let Some(boundary) = boundary_cache.get(&key).filter(|boundary| {
+                !used_edges.contains(&(boundary.1, boundary.0))
+                    && !used_nodes.contains(&boundary.0)
+                    && !used_nodes.contains(&boundary.1)
+            }) {
+                *boundary
+            } else {
+                let boundary = boundary_pair(pair[0], pair[1], &routing_context)?;
+                boundary_cache.insert(key, boundary);
+                boundary
+            };
+            transitions.push(boundary);
+        }
+
+        let mut path = Vec::new();
+        let mut current = *anchors
+            .get(&inputs.reach_from_nodes[reach_index])
+            .ok_or(5)?;
+        for (parent_index, &parent) in coarse_path.iter().enumerate() {
+            let final_parent = parent_index + 1 == coarse_path.len();
+            let targets = if final_parent {
+                if let Some(&downstream_index) =
+                    reach_by_from_node.get(&inputs.reach_to_nodes[reach_index])
+                {
+                    let downstream_targets = generated_paths[downstream_index]
+                        .iter()
+                        .copied()
+                        .filter(|cell| {
+                            local_by_id
+                                .get(cell)
+                                .is_some_and(|index| cells[*index].parent_cell_id == parent)
+                        })
+                        .collect::<Vec<_>>();
+                    if downstream_targets.is_empty() {
+                        return Err(5);
+                    }
+                    downstream_targets
+                } else {
+                    vec![*anchors.get(&inputs.reach_to_nodes[reach_index]).ok_or(5)?]
+                }
+            } else {
+                vec![transitions[parent_index].0]
+            };
+            let segment = route_inside_parent(parent, current, &targets, &routing_context)?;
+            append_segment(&mut path, &segment);
+            if parent_index + 1 < coarse_path.len() {
+                let next = transitions[parent_index].1;
+                if path.last() != Some(&next) {
+                    path.push(next);
+                }
+                current = next;
+            }
+        }
+        if path.len() < 2 {
+            return Err(5);
+        }
+        for pair in path.windows(2) {
+            let adjacent = (0..D4_NEIGHBORS).any(|slot| {
+                cubed_sphere_neighbor_index(pair[0] as usize, slot, fine) == Some(pair[1] as usize)
+            });
+            if !adjacent {
+                return Err(5);
+            }
+            if used_edges.contains(&(pair[1], pair[0])) {
+                return Err(5);
+            }
+        }
+        for pair in path.windows(2) {
+            used_edges.insert((pair[0], pair[1]));
+        }
+        used_nodes.extend(path.iter().copied());
+        generated_paths[reach_index] = path.clone();
+
+        let mut cell_lengths = vec![0.0f64; path.len()];
+        for edge in 0..path.len() - 1 {
+            let first = cells[*local_by_id.get(&path[edge]).ok_or(5)?].xyz;
+            let second = cells[*local_by_id.get(&path[edge + 1]).ok_or(5)?].xyz;
+            let length = angular_distance(first, second) * inputs.config.planet_radius_m;
+            cell_lengths[edge] += 0.5 * length;
+            cell_lengths[edge + 1] += 0.5 * length;
+        }
+        let path_length_m = cell_lengths.iter().sum::<f64>();
+        let path_offset = i32::try_from(all_path_cells.len()).map_err(|_| 5)?;
+        let path_count = i32::try_from(path.len()).map_err(|_| 5)?;
+        all_path_cells.extend_from_slice(&path);
+        reach_records.push(RefinedReachRecord {
+            reach_id: inputs.reach_ids[reach_index],
+            path_offset,
+            path_count,
+            entry_fine_cell: path[0],
+            exit_fine_cell: *path.last().ok_or(5)?,
+            path_length_m,
+        });
+
+        let channel_width = inputs.channel_width_m[reach_index] as f64;
+        let valley_width = inputs.valley_width_m[reach_index] as f64;
+        let floodplain_width = inputs.floodplain_width_m[reach_index] as f64;
+        let incision = inputs.incision_m[reach_index] as f64;
+        for (path_order, (&fine_cell, &length)) in path.iter().zip(&cell_lengths).enumerate() {
+            let local = *local_by_id.get(&fine_cell).ok_or(5)?;
+            let cell = cells[local];
+            let area_m2 = cell.area_km2 * 1_000_000.0;
+            memberships.push(ReachCellRecord {
+                reach_id: inputs.reach_ids[reach_index],
+                fine_cell_id: fine_cell,
+                parent_cell_id: cell.parent_cell_id,
+                path_order: path_order as i32,
+                reach_length_m: length,
+                channel_fraction: bounded_fraction(channel_width * length, area_m2),
+                valley_fraction: bounded_fraction(valley_width * length, area_m2),
+                floodplain_fraction: bounded_fraction(floodplain_width * length, area_m2),
+                potential_incised_volume_m3: channel_width * length * incision,
+            });
+        }
+    }
+    Ok((reach_records, all_path_cells, memberships))
+}
+
+fn compute_stats(
+    inputs: &Inputs<'_>,
+    fine: usize,
+    cells: &[RefinedCellRecord],
+    ranges: &ParentRanges,
+    reaches: &[RefinedReachRecord],
+    memberships: &[ReachCellRecord],
+) -> RefinementStats {
+    let radius_squared_km = (inputs.config.planet_radius_m / 1_000.0).powi(2);
+    let mut maximum_area_error = 0.0f64;
+    let mut maximum_elevation_error = 0.0f64;
+    for &(start, end, parent_index) in ranges.values() {
+        let child_area = cells[start..end]
+            .iter()
+            .map(|cell| cell.area_km2)
+            .sum::<f64>();
+        let parent_area = inputs.parent_area_steradians[parent_index] * radius_squared_km;
+        maximum_area_error = maximum_area_error.max((child_area - parent_area).abs() / parent_area);
+        let mean_elevation = cells[start..end]
+            .iter()
+            .map(|cell| cell.terrain_elevation_m as f64 * cell.area_km2)
+            .sum::<f64>()
+            / child_area;
+        maximum_elevation_error = maximum_elevation_error
+            .max((mean_elevation - inputs.parent_elevation_m[parent_index] as f64).abs());
+    }
+    let selected_area_km2 = cells.iter().map(|cell| cell.area_km2).sum::<f64>();
+    let area_by_cell = cells
+        .iter()
+        .map(|cell| (cell.fine_cell_id, cell.area_km2))
+        .collect::<HashMap<_, _>>();
+    let represented_area = |fraction: fn(&ReachCellRecord) -> f32| {
+        memberships
+            .iter()
+            .map(|record| {
+                fraction(record) as f64
+                    * area_by_cell
+                        .get(&record.fine_cell_id)
+                        .copied()
+                        .unwrap_or(0.0)
+            })
+            .sum::<f64>()
+    };
+    let represented_channel_area_km2 = represented_area(|record| record.channel_fraction);
+    let represented_valley_area_km2 = represented_area(|record| record.valley_fraction);
+    let represented_floodplain_area_km2 = represented_area(|record| record.floodplain_fraction);
+    RefinementStats {
+        parent_count: inputs.parent_ids.len() as i32,
+        child_count: cells.len() as i32,
+        reach_count: reaches.len() as i32,
+        reach_cell_count: memberships.len() as i32,
+        fine_resolution: fine as i32,
+        path_topology_valid: 1,
+        selected_area_km2,
+        maximum_parent_area_relative_error: maximum_area_error,
+        maximum_parent_elevation_error_m: maximum_elevation_error,
+        total_reach_length_km: reaches
+            .iter()
+            .map(|reach| reach.path_length_m / 1_000.0)
+            .sum(),
+        represented_channel_area_km2,
+        represented_valley_area_km2,
+        represented_floodplain_area_km2,
+        total_potential_incised_volume_km3: memberships
+            .iter()
+            .map(|record| record.potential_incised_volume_m3 / 1e9)
+            .sum(),
+    }
+}
+
+fn run_refinement(inputs: &Inputs<'_>) -> Result<Outcome, i32> {
+    let (coarse, fine) = validate_inputs(inputs)?;
+    let (cells, local_by_id, ranges) = generate_children(inputs, coarse, fine)?;
+    let (reaches, path_cells, memberships) =
+        refine_reaches(inputs, fine, &cells, &local_by_id, &ranges)?;
+    let stats = compute_stats(inputs, fine, &cells, &ranges, &reaches, &memberships);
+    Ok(Outcome {
+        cells,
+        reaches,
+        path_cells,
+        memberships,
+        stats,
+    })
+}
+
+fn boxed_array<T>(values: Vec<T>) -> (*mut T, usize) {
+    let mut values = values.into_boxed_slice();
+    let result = (values.as_mut_ptr(), values.len());
+    std::mem::forget(values);
+    result
+}
+
+unsafe fn free_boxed_array<T>(data: *mut T, len: usize) {
+    if !data.is_null() {
+        let slice = std::ptr::slice_from_raw_parts_mut(data, len);
+        unsafe {
+            drop(Box::from_raw(slice));
+        }
+    }
+}
+
+#[no_mangle]
+/// Refine one complete coarse drainage basin into sparse fine cells and inherited reaches.
+///
+/// # Safety
+///
+/// Every input pointer must reference the number of contiguous values implied by
+/// its count or offset array. Output pointers must be writable and non-aliasing.
+pub unsafe extern "C" fn refinement_run_basin(
+    config: *const RefinementConfig,
+    parent_count: i32,
+    parent_ids: *const i32,
+    parent_elevation_m: *const f32,
+    parent_relief_m: *const f32,
+    parent_area_steradians: *const f64,
+    reach_count: i32,
+    reach_ids: *const i32,
+    reach_from_nodes: *const i32,
+    reach_to_nodes: *const i32,
+    reach_offsets: *const i32,
+    reach_parent_cell_count: i32,
+    reach_parent_cells: *const i32,
+    channel_width_m: *const f32,
+    valley_width_m: *const f32,
+    floodplain_width_m: *const f32,
+    incision_m: *const f32,
+    cells_out: *mut RefinedCellArray,
+    reaches_out: *mut RefinedReachArray,
+    path_cells_out: *mut Int32Array,
+    memberships_out: *mut ReachCellArray,
+    stats_out: *mut RefinementStats,
+) -> i32 {
+    if config.is_null()
+        || parent_count <= 0
+        || parent_ids.is_null()
+        || parent_elevation_m.is_null()
+        || parent_relief_m.is_null()
+        || parent_area_steradians.is_null()
+        || reach_count <= 0
+        || reach_ids.is_null()
+        || reach_from_nodes.is_null()
+        || reach_to_nodes.is_null()
+        || reach_offsets.is_null()
+        || reach_parent_cell_count <= 0
+        || reach_parent_cells.is_null()
+        || channel_width_m.is_null()
+        || valley_width_m.is_null()
+        || floodplain_width_m.is_null()
+        || incision_m.is_null()
+        || cells_out.is_null()
+        || reaches_out.is_null()
+        || path_cells_out.is_null()
+        || memberships_out.is_null()
+        || stats_out.is_null()
+    {
+        return 1;
+    }
+    let parent_count = parent_count as usize;
+    let reach_count = reach_count as usize;
+    let reach_parent_cell_count = reach_parent_cell_count as usize;
+    let inputs = unsafe {
+        Inputs {
+            config: *config,
+            parent_ids: std::slice::from_raw_parts(parent_ids, parent_count),
+            parent_elevation_m: std::slice::from_raw_parts(parent_elevation_m, parent_count),
+            parent_relief_m: std::slice::from_raw_parts(parent_relief_m, parent_count),
+            parent_area_steradians: std::slice::from_raw_parts(
+                parent_area_steradians,
+                parent_count,
+            ),
+            reach_ids: std::slice::from_raw_parts(reach_ids, reach_count),
+            reach_from_nodes: std::slice::from_raw_parts(reach_from_nodes, reach_count),
+            reach_to_nodes: std::slice::from_raw_parts(reach_to_nodes, reach_count),
+            reach_offsets: std::slice::from_raw_parts(reach_offsets, reach_count + 1),
+            reach_parent_cells: std::slice::from_raw_parts(
+                reach_parent_cells,
+                reach_parent_cell_count,
+            ),
+            channel_width_m: std::slice::from_raw_parts(channel_width_m, reach_count),
+            valley_width_m: std::slice::from_raw_parts(valley_width_m, reach_count),
+            floodplain_width_m: std::slice::from_raw_parts(floodplain_width_m, reach_count),
+            incision_m: std::slice::from_raw_parts(incision_m, reach_count),
+        }
+    };
+    let outcome = match run_refinement(&inputs) {
+        Ok(outcome) => outcome,
+        Err(status) => return status,
+    };
+    let (cell_data, cell_len) = boxed_array(outcome.cells);
+    let (reach_data, reach_len) = boxed_array(outcome.reaches);
+    let (path_data, path_len) = boxed_array(outcome.path_cells);
+    let (membership_data, membership_len) = boxed_array(outcome.memberships);
+    unsafe {
+        *cells_out = RefinedCellArray {
+            data: cell_data,
+            len: cell_len,
+        };
+        *reaches_out = RefinedReachArray {
+            data: reach_data,
+            len: reach_len,
+        };
+        *path_cells_out = Int32Array {
+            data: path_data,
+            len: path_len,
+        };
+        *memberships_out = ReachCellArray {
+            data: membership_data,
+            len: membership_len,
+        };
+        *stats_out = outcome.stats;
+    }
+    0
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// `array` must have been returned by [`refinement_run_basin`] and not freed before.
+pub unsafe extern "C" fn refinement_free_cells(array: RefinedCellArray) {
+    unsafe {
+        free_boxed_array(array.data, array.len);
+    }
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// `array` must have been returned by [`refinement_run_basin`] and not freed before.
+pub unsafe extern "C" fn refinement_free_reaches(array: RefinedReachArray) {
+    unsafe {
+        free_boxed_array(array.data, array.len);
+    }
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// `array` must have been returned by [`refinement_run_basin`] and not freed before.
+pub unsafe extern "C" fn refinement_free_i32(array: Int32Array) {
+    unsafe {
+        free_boxed_array(array.data, array.len);
+    }
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// `array` must have been returned by [`refinement_run_basin`] and not freed before.
+pub unsafe extern "C" fn refinement_free_memberships(array: ReachCellArray) {
+    unsafe {
+        free_boxed_array(array.data, array.len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parent_area(cell: i32, resolution: usize) -> f64 {
+        let (face, row, col) = cubed_sphere_decode_index(cell as usize, resolution).unwrap();
+        cubed_sphere_cell_area_steradians(face, row, col, resolution).unwrap()
+    }
+
+    #[test]
+    fn sparse_refinement_conserves_parents_and_routes_reach() {
+        let coarse = 4usize;
+        let first = cubed_sphere_global_index(0, 1, 1, coarse).unwrap() as i32;
+        let second = cubed_sphere_global_index(0, 1, 2, coarse).unwrap() as i32;
+        let parent_ids = [first, second];
+        let elevations = [120.0f32, 80.0];
+        let relief = [90.0f32, 60.0];
+        let areas = [parent_area(first, coarse), parent_area(second, coarse)];
+        let reach_ids = [7i32];
+        let from = [first];
+        let to = [second];
+        let offsets = [0i32, 2];
+        let path = [first, second];
+        let channel = [40.0f32];
+        let valley = [1_200.0f32];
+        let floodplain = [600.0f32];
+        let incision = [25.0f32];
+        let inputs = Inputs {
+            config: RefinementConfig {
+                coarse_resolution: coarse as i32,
+                factor: 4,
+                planet_radius_m: 6_371_000.0,
+                terrain_seed: 42,
+                terrain_noise_fraction: 0.45,
+            },
+            parent_ids: &parent_ids,
+            parent_elevation_m: &elevations,
+            parent_relief_m: &relief,
+            parent_area_steradians: &areas,
+            reach_ids: &reach_ids,
+            reach_from_nodes: &from,
+            reach_to_nodes: &to,
+            reach_offsets: &offsets,
+            reach_parent_cells: &path,
+            channel_width_m: &channel,
+            valley_width_m: &valley,
+            floodplain_width_m: &floodplain,
+            incision_m: &incision,
+        };
+        let result = run_refinement(&inputs).unwrap();
+        assert_eq!(result.cells.len(), 32);
+        assert_eq!(result.reaches.len(), 1);
+        assert!(result.reaches[0].path_count >= 2);
+        assert!(result.reaches[0].path_length_m > 0.0);
+        assert_eq!(result.stats.path_topology_valid, 1);
+        assert!(result.stats.maximum_parent_area_relative_error < 1e-12);
+        assert!(result.stats.maximum_parent_elevation_error_m < 1e-3);
+        assert!(result
+            .memberships
+            .iter()
+            .all(|record| record.channel_fraction < record.valley_fraction));
+        for pair in result.path_cells.windows(2) {
+            assert!((0..D4_NEIGHBORS).any(|slot| {
+                cubed_sphere_neighbor_index(pair[0] as usize, slot, coarse * 4)
+                    == Some(pair[1] as usize)
+            }));
+        }
+    }
+
+    #[test]
+    fn sparse_refinement_routes_across_cube_face_edge() {
+        let coarse = 4usize;
+        let first = cubed_sphere_global_index(0, 1, coarse - 1, coarse).unwrap() as i32;
+        let second = cubed_sphere_neighbor_index(first as usize, 3, coarse).unwrap() as i32;
+        assert_ne!(
+            cubed_sphere_decode_index(first as usize, coarse).unwrap().0,
+            cubed_sphere_decode_index(second as usize, coarse)
+                .unwrap()
+                .0
+        );
+        let parent_ids = [first, second];
+        let elevations = [40.0f32, 35.0];
+        let relief = [30.0f32, 30.0];
+        let areas = [parent_area(first, coarse), parent_area(second, coarse)];
+        let reach_ids = [3i32];
+        let from = [first];
+        let to = [second];
+        let offsets = [0i32, 2];
+        let path = [first, second];
+        let channel = [25.0f32];
+        let valley = [800.0f32];
+        let floodplain = [500.0f32];
+        let incision = [12.0f32];
+        let inputs = Inputs {
+            config: RefinementConfig {
+                coarse_resolution: coarse as i32,
+                factor: 4,
+                planet_radius_m: 6_371_000.0,
+                terrain_seed: 91,
+                terrain_noise_fraction: 0.35,
+            },
+            parent_ids: &parent_ids,
+            parent_elevation_m: &elevations,
+            parent_relief_m: &relief,
+            parent_area_steradians: &areas,
+            reach_ids: &reach_ids,
+            reach_from_nodes: &from,
+            reach_to_nodes: &to,
+            reach_offsets: &offsets,
+            reach_parent_cells: &path,
+            channel_width_m: &channel,
+            valley_width_m: &valley,
+            floodplain_width_m: &floodplain,
+            incision_m: &incision,
+        };
+        let result = run_refinement(&inputs).unwrap();
+        let fine = coarse * 4;
+        assert!(result.path_cells.windows(2).all(|pair| {
+            (0..D4_NEIGHBORS).any(|slot| {
+                cubed_sphere_neighbor_index(pair[0] as usize, slot, fine) == Some(pair[1] as usize)
+            })
+        }));
+        let mut collapsed = Vec::new();
+        for &fine_cell in &result.path_cells {
+            let (face, row, col) = cubed_sphere_decode_index(fine_cell as usize, fine).unwrap();
+            let parent = cubed_sphere_global_index(face, row / 4, col / 4, coarse).unwrap() as i32;
+            if collapsed.last() != Some(&parent) {
+                collapsed.push(parent);
+            }
+        }
+        assert_eq!(collapsed, path);
+    }
+}

--- a/src/map_maker/pipeline/native/topology/src/lib.rs
+++ b/src/map_maker/pipeline/native/topology/src/lib.rs
@@ -179,6 +179,79 @@ fn global_index(face: Face, row: usize, col: usize, resolution: usize) -> usize 
     face as usize * resolution * resolution + row * resolution + col
 }
 
+pub fn cubed_sphere_global_index(
+    face_index: usize,
+    row: usize,
+    col: usize,
+    resolution: usize,
+) -> Option<usize> {
+    if face_index >= FACE_COUNT || row >= resolution || col >= resolution || resolution == 0 {
+        return None;
+    }
+    Some(global_index(
+        Face::from_index(face_index),
+        row,
+        col,
+        resolution,
+    ))
+}
+
+pub fn cubed_sphere_decode_index(index: usize, resolution: usize) -> Option<(usize, usize, usize)> {
+    let cells = checked_cell_count(resolution)?;
+    if index >= cells {
+        return None;
+    }
+    let face_cells = resolution * resolution;
+    let face = index / face_cells;
+    let within_face = index % face_cells;
+    Some((face, within_face / resolution, within_face % resolution))
+}
+
+pub fn cubed_sphere_cell_xyz(
+    face_index: usize,
+    row: usize,
+    col: usize,
+    resolution: usize,
+) -> Option<[f64; 3]> {
+    cubed_sphere_global_index(face_index, row, col, resolution)?;
+    let direction = cell_direction(Face::from_index(face_index), row, col, resolution);
+    Some([direction.x, direction.y, direction.z])
+}
+
+pub fn cubed_sphere_cell_area_steradians(
+    face_index: usize,
+    row: usize,
+    col: usize,
+    resolution: usize,
+) -> Option<f64> {
+    cubed_sphere_global_index(face_index, row, col, resolution)?;
+    Some(cell_area(
+        Face::from_index(face_index),
+        row,
+        col,
+        resolution,
+    ))
+}
+
+pub fn cubed_sphere_neighbor_index(index: usize, slot: usize, resolution: usize) -> Option<usize> {
+    let (face, row, col) = cubed_sphere_decode_index(index, resolution)?;
+    let (row_offset, col_offset) = match slot {
+        0 => (-1, 0),
+        1 => (1, 0),
+        2 => (0, -1),
+        3 => (0, 1),
+        _ => return None,
+    };
+    Some(neighbor_index(
+        Face::from_index(face),
+        row,
+        col,
+        row_offset,
+        col_offset,
+        resolution,
+    ))
+}
+
 fn checked_cell_count(resolution: usize) -> Option<usize> {
     resolution
         .checked_mul(resolution)

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -6,6 +6,7 @@ from . import geometry  # noqa: F401
 from . import planet  # noqa: F401
 from . import climate  # noqa: F401
 from . import hydrology  # noqa: F401
+from . import basin_refinement  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -23,6 +24,7 @@ def ensure_builtin_stages() -> None:
         "planet": planet,
         "climate": climate,
         "hydrology": hydrology,
+        "basin_refinement": basin_refinement,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/basin_refinement.py
+++ b/src/map_maker/pipeline/stages/basin_refinement.py
@@ -1,0 +1,721 @@
+"""Sparse hierarchical refinement of one complete coarse basin footprint."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import asdict, dataclass
+import heapq
+from typing import Mapping
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+from PIL import Image, ImageDraw
+
+from .._refinement_native import run_basin_refinement
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+EARTH_RADIUS_M = 6_371_000.0
+
+
+@dataclass(frozen=True)
+class BasinRefinementConfig:
+    refinement_factor: int = 16
+    basin_id: int | None = None
+    terrain_noise_fraction: float = 0.45
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "BasinRefinementConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown basin refinement controls: {', '.join(sorted(unknown))}")
+        factor = int(mapping.get("refinement_factor", cls.refinement_factor))
+        basin_value = mapping.get("basin_id", cls.basin_id)
+        basin_id = None if basin_value is None else int(basin_value)
+        terrain_noise_fraction = float(
+            mapping.get("terrain_noise_fraction", cls.terrain_noise_fraction)
+        )
+        if factor < 2 or factor > 32 or factor & (factor - 1):
+            raise ValueError("refinement_factor must be a power of two in [2, 32]")
+        if basin_id is not None and basin_id < 0:
+            raise ValueError("basin_id must be non-negative when provided")
+        if not np.isfinite(terrain_noise_fraction) or not 0.0 <= terrain_noise_fraction <= 1.0:
+            raise ValueError("terrain_noise_fraction must be finite and in [0, 1]")
+        return cls(
+            refinement_factor=factor,
+            basin_id=basin_id,
+            terrain_noise_fraction=terrain_noise_fraction,
+        )
+
+
+def _artifact_array(result, name: str) -> np.ndarray:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        raise KeyError(f"Missing dependency artifact '{name}'")
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _artifact_table(result, name: str) -> pa.Table:
+    record = result.artifact_records.get(name)
+    if record is None or not isinstance(record.value, pa.Table):
+        raise KeyError(f"Missing dependency table '{name}'")
+    return record.value
+
+
+def _column_numpy(table: pa.Table, name: str, dtype: np.dtype) -> np.ndarray:
+    return np.ascontiguousarray(
+        table[name].combine_chunks().to_numpy(zero_copy_only=False), dtype=dtype
+    )
+
+
+def _select_basin(
+    basin_catalog: pa.Table, reaches: pa.Table, requested_basin_id: int | None
+) -> int:
+    reach_basins = set(int(value) for value in reaches["basin_id"].to_pylist())
+    catalog_ids = np.asarray(basin_catalog["basin_id"], dtype=np.int32)
+    if requested_basin_id is not None:
+        if requested_basin_id not in set(int(value) for value in catalog_ids):
+            raise ValueError(f"basin_id {requested_basin_id} does not exist")
+        if requested_basin_id not in reach_basins:
+            raise ValueError(f"basin_id {requested_basin_id} has no registered river reaches")
+        return requested_basin_id
+
+    sink_type = np.asarray(basin_catalog["sink_type"], dtype=np.uint8)
+    area = np.asarray(basin_catalog["area_km2"], dtype=np.float64)
+    candidates = [
+        index
+        for index, basin_id in enumerate(catalog_ids)
+        if int(basin_id) in reach_basins and int(sink_type[index]) == 1
+    ]
+    if not candidates:
+        candidates = [
+            index for index, basin_id in enumerate(catalog_ids) if int(basin_id) in reach_basins
+        ]
+    if not candidates:
+        raise ValueError("hydrology produced no basin with registered river reaches")
+    return int(max(candidates, key=lambda index: (float(area[index]), -int(catalog_ids[index]))))
+
+
+def _downstream_first_reaches(reaches: pa.Table) -> pa.Table:
+    reach_ids = np.asarray(reaches["reach_id"], dtype=np.int32)
+    downstream_ids = np.asarray(reaches["downstream_reach_id"], dtype=np.int32)
+    row_by_id = {int(reach_id): row for row, reach_id in enumerate(reach_ids)}
+    upstream_rows: dict[int, list[int]] = defaultdict(list)
+    ready: list[tuple[int, int]] = []
+    for row, (reach_id, downstream_id) in enumerate(zip(reach_ids, downstream_ids, strict=True)):
+        downstream_row = row_by_id.get(int(downstream_id))
+        if downstream_row is None:
+            heapq.heappush(ready, (int(reach_id), row))
+        else:
+            upstream_rows[downstream_row].append(row)
+
+    order: list[int] = []
+    while ready:
+        _, row = heapq.heappop(ready)
+        order.append(row)
+        for upstream_row in upstream_rows.get(row, ()):
+            heapq.heappush(ready, (int(reach_ids[upstream_row]), upstream_row))
+    if len(order) != len(reach_ids):
+        raise RuntimeError("inherited river reach graph contains a cycle")
+    return reaches.take(pa.array(order, type=pa.int64()))
+
+
+def _flatten_paths(paths: list[list[int]]) -> tuple[np.ndarray, np.ndarray]:
+    offsets = np.zeros(len(paths) + 1, dtype=np.int32)
+    for index, path in enumerate(paths):
+        offsets[index + 1] = offsets[index] + len(path)
+    flattened = np.fromiter(
+        (cell for path in paths for cell in path), dtype=np.int32, count=int(offsets[-1])
+    )
+    return offsets, flattened
+
+
+def _fixed_list(values: np.ndarray, size: int) -> pa.FixedSizeListArray:
+    return pa.FixedSizeListArray.from_arrays(
+        pa.array(np.asarray(values, dtype=np.float32).reshape(-1), type=pa.float32()), size
+    )
+
+
+def _cell_table(records: np.ndarray) -> pa.Table:
+    return pa.table(
+        {
+            "fine_cell_id": pa.array(records["fine_cell_id"], type=pa.int32()),
+            "parent_cell_id": pa.array(records["parent_cell_id"], type=pa.int32()),
+            "face": pa.array(records["face"], type=pa.int32()),
+            "row": pa.array(records["row"], type=pa.int32()),
+            "col": pa.array(records["col"], type=pa.int32()),
+            "xyz": _fixed_list(records["xyz"], 3),
+            "area_km2": pa.array(records["area_km2"], type=pa.float64()),
+            "terrain_elevation_m": pa.array(records["terrain_elevation_m"], type=pa.float32()),
+            "terrain_offset_m": pa.array(records["terrain_offset_m"], type=pa.float32()),
+            "parent_relief_m": pa.array(records["parent_relief_m"], type=pa.float32()),
+        }
+    )
+
+
+def _parent_table(
+    records: np.ndarray,
+    parent_ids: np.ndarray,
+    inside_selected_basin: np.ndarray,
+    parent_elevation_m: np.ndarray,
+    parent_relief_m: np.ndarray,
+    parent_areas_km2: np.ndarray,
+    factor: int,
+) -> pa.Table:
+    children_per_parent = factor * factor
+    child_areas = records["area_km2"].reshape(len(parent_ids), children_per_parent)
+    child_elevation = records["terrain_elevation_m"].reshape(len(parent_ids), children_per_parent)
+    child_parent = records["parent_cell_id"].reshape(len(parent_ids), children_per_parent)
+    if not np.all(child_parent == parent_ids[:, None]):
+        raise RuntimeError("native refinement returned children outside their parent groups")
+    restricted_area = np.sum(child_areas, axis=1)
+    restricted_elevation = np.sum(child_areas * child_elevation, axis=1) / restricted_area
+    return pa.table(
+        {
+            "parent_cell_id": pa.array(parent_ids, type=pa.int32()),
+            "inside_selected_basin": pa.array(inside_selected_basin, type=pa.bool_()),
+            "child_count": pa.array(
+                np.full(len(parent_ids), children_per_parent, dtype=np.int32), type=pa.int32()
+            ),
+            "parent_area_km2": pa.array(parent_areas_km2, type=pa.float64()),
+            "restricted_child_area_km2": pa.array(restricted_area, type=pa.float64()),
+            "area_relative_error": pa.array(
+                np.abs(restricted_area - parent_areas_km2) / parent_areas_km2,
+                type=pa.float64(),
+            ),
+            "parent_elevation_m": pa.array(parent_elevation_m, type=pa.float32()),
+            "restricted_child_elevation_m": pa.array(
+                restricted_elevation.astype(np.float32), type=pa.float32()
+            ),
+            "elevation_error_m": pa.array(
+                (restricted_elevation - parent_elevation_m).astype(np.float32),
+                type=pa.float32(),
+            ),
+            "parent_relief_m": pa.array(parent_relief_m, type=pa.float32()),
+        }
+    )
+
+
+def _lookup_rows(sorted_ids: np.ndarray, order: np.ndarray, query: np.ndarray) -> np.ndarray:
+    positions = np.searchsorted(sorted_ids, query)
+    if np.any(positions >= len(sorted_ids)) or np.any(sorted_ids[positions] != query):
+        raise RuntimeError("refined reach path references a cell outside the selected basin")
+    return order[positions]
+
+
+def _reach_table(
+    source: pa.Table,
+    native_reaches: np.ndarray,
+    path_cells: np.ndarray,
+    cells: np.ndarray,
+    *,
+    fine_resolution: int,
+    factor: int,
+    planet_radius_m: float,
+) -> tuple[pa.Table, bool, float]:
+    fine_ids = cells["fine_cell_id"]
+    fine_order = np.argsort(fine_ids)
+    sorted_ids = fine_ids[fine_order]
+    fine_paths: list[list[int]] = []
+    polylines: list[list[list[float]]] = []
+    maximum_length_error = 0.0
+    coarse_resolution = fine_resolution // factor
+    fine_face_size = fine_resolution * fine_resolution
+    coarse_face_size = coarse_resolution * coarse_resolution
+    parent_paths = source["cell_path"].to_pylist()
+    for reach_index, record in enumerate(native_reaches):
+        start = int(record["path_offset"])
+        end = start + int(record["path_count"])
+        path = path_cells[start:end]
+        rows = _lookup_rows(sorted_ids, fine_order, path)
+        face = path // fine_face_size
+        within_face = path % fine_face_size
+        fine_row = within_face // fine_resolution
+        fine_col = within_face % fine_resolution
+        parent_path = (
+            face * coarse_face_size + (fine_row // factor) * coarse_resolution + fine_col // factor
+        )
+        if _collapse_adjacent(parent_path) != parent_paths[reach_index]:
+            raise RuntimeError("fine reach path does not preserve its inherited parent path")
+        fine_paths.append(path.tolist())
+        xyz = cells["xyz"][rows].astype(np.float64)
+        polylines.append(xyz.tolist())
+        edge_length_m = (
+            np.arccos(np.clip(np.sum(xyz[:-1] * xyz[1:], axis=1), -1.0, 1.0)) * planet_radius_m
+        )
+        maximum_length_error = max(
+            maximum_length_error,
+            abs(float(np.sum(edge_length_m)) - float(record["path_length_m"])),
+        )
+
+    table = pa.table(
+        {
+            "reach_id": source["reach_id"],
+            "parent_reach_id": source["reach_id"],
+            "basin_id": source["basin_id"],
+            "from_parent_cell": source["from_node"],
+            "to_parent_cell": source["to_node"],
+            "downstream_reach_id": source["downstream_reach_id"],
+            "parent_cell_path": source["cell_path"],
+            "fine_cell_path": pa.array(fine_paths, type=pa.list_(pa.int32())),
+            "polyline_on_cubed_sphere": pa.array(
+                polylines, type=pa.list_(pa.list_(pa.float32(), 3))
+            ),
+            "entry_fine_cell": pa.array(native_reaches["entry_fine_cell"], type=pa.int32()),
+            "exit_fine_cell": pa.array(native_reaches["exit_fine_cell"], type=pa.int32()),
+            "path_length_km": pa.array(
+                native_reaches["path_length_m"] / 1_000.0, type=pa.float64()
+            ),
+            "discharge_mean": source["discharge_mean"],
+            "discharge_seasonal": source["discharge_seasonal"],
+            "velocity_mean": source["velocity_mean"],
+            "slope": source["slope"],
+            "stream_power": source["stream_power"],
+            "strahler_order": source["strahler_order"],
+            "channel_width_m": source["channel_width_m"],
+            "channel_depth_m": source["channel_depth_m"],
+            "valley_width_m": source["valley_width_m"],
+            "floodplain_width_m": source["floodplain_width_m"],
+            "incision_m": source["incision_m"],
+            "sediment_load": source["sediment_load"],
+            "meander_index": source["meander_index"],
+            "braiding_index": source["braiding_index"],
+            "morphology_class": source["morphology_class"],
+            "bed_material": source["bed_material"],
+        }
+    )
+    path_by_reach = dict(
+        zip(
+            np.asarray(table["reach_id"], dtype=np.int32),
+            (set(path) for path in fine_paths),
+            strict=True,
+        )
+    )
+    junctions_valid = True
+    downstream_joins: list[int] = []
+    for downstream, exit_cell in zip(
+        np.asarray(table["downstream_reach_id"], dtype=np.int32),
+        np.asarray(table["exit_fine_cell"], dtype=np.int32),
+        strict=True,
+    ):
+        if downstream >= 0 and int(downstream) in path_by_reach:
+            merges_downstream = int(exit_cell) in path_by_reach[int(downstream)]
+            junctions_valid &= merges_downstream
+            downstream_joins.append(int(exit_cell) if merges_downstream else -1)
+        else:
+            downstream_joins.append(-1)
+    table = table.append_column(
+        "downstream_join_fine_cell", pa.array(downstream_joins, type=pa.int32())
+    )
+    return table, junctions_valid, maximum_length_error
+
+
+def _collapse_adjacent(values: np.ndarray) -> list[int]:
+    return [
+        int(value) for index, value in enumerate(values) if index == 0 or value != values[index - 1]
+    ]
+
+
+def _directed_path_graph_metadata(reaches: pa.Table) -> dict[str, int]:
+    edges: set[tuple[int, int]] = set()
+    for path in reaches["fine_cell_path"].to_pylist():
+        edges.update((int(source), int(target)) for source, target in zip(path[:-1], path[1:]))
+
+    reverse_conflicts = {
+        (min(source, target), max(source, target))
+        for source, target in edges
+        if (target, source) in edges
+    }
+    adjacency: dict[int, set[int]] = defaultdict(set)
+    indegree: dict[int, int] = {}
+    for source, target in edges:
+        adjacency[source].add(target)
+        indegree.setdefault(source, 0)
+        indegree[target] = indegree.get(target, 0) + 1
+    ready = deque(node for node, degree in indegree.items() if degree == 0)
+    visited = 0
+    while ready:
+        source = ready.popleft()
+        visited += 1
+        for target in adjacency.get(source, ()):
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(target)
+    dag_valid = visited == len(indegree)
+    return {
+        "directed_edge_count": len(edges),
+        "reverse_directed_edge_conflict_count": len(reverse_conflicts),
+        "directed_path_dag_valid": int(dag_valid),
+        "directed_path_graph_valid": int(dag_valid and not reverse_conflicts),
+    }
+
+
+def _classify_reach_terminals(
+    reaches: pa.Table,
+    basin_ids: np.ndarray,
+    flow_receiver: np.ndarray,
+    flow_sink_type: np.ndarray,
+) -> tuple[pa.Table, dict[str, int]]:
+    reach_ids = set(int(value) for value in reaches["reach_id"].to_pylist())
+    kinds: list[str] = []
+    terminal_cells: list[int] = []
+    receiver_cells: list[int] = []
+    sink_types: list[int] = []
+    resolved: list[bool] = []
+    counts: dict[str, int] = defaultdict(int)
+    for downstream, to_node in zip(
+        np.asarray(reaches["downstream_reach_id"], dtype=np.int32),
+        np.asarray(reaches["to_parent_cell"], dtype=np.int32),
+        strict=True,
+    ):
+        if int(downstream) >= 0:
+            kind = (
+                "downstream_reach"
+                if int(downstream) in reach_ids
+                else "unresolved_downstream_reference"
+            )
+            terminal_cell = -1
+            receiver = -1
+            sink_type = 0
+            is_resolved = kind == "downstream_reach"
+        else:
+            terminal_cell = int(to_node)
+            if not 0 <= terminal_cell < len(basin_ids):
+                receiver = -1
+                sink_type = 0
+                kind = "unresolved_terminal"
+            else:
+                receiver = int(flow_receiver[terminal_cell])
+                sink_type = int(flow_sink_type[terminal_cell])
+                receiver_is_ocean = 0 <= receiver < len(basin_ids) and int(basin_ids[receiver]) < 0
+                if int(basin_ids[terminal_cell]) < 0 or receiver_is_ocean:
+                    kind = "ocean"
+                elif receiver < 0 and sink_type in (2, 3, 4):
+                    kind = "registered_sink"
+                elif receiver >= 0:
+                    kind = "unresolved_threshold_gap"
+                else:
+                    kind = "unresolved_terminal"
+            is_resolved = kind in {"ocean", "registered_sink"}
+        kinds.append(kind)
+        terminal_cells.append(terminal_cell)
+        receiver_cells.append(receiver)
+        sink_types.append(sink_type)
+        resolved.append(is_resolved)
+        counts[kind] += 1
+
+    reaches = reaches.append_column("terminal_kind", pa.array(kinds, type=pa.string()))
+    reaches = reaches.append_column(
+        "terminal_parent_cell", pa.array(terminal_cells, type=pa.int32())
+    )
+    reaches = reaches.append_column(
+        "terminal_receiver_cell", pa.array(receiver_cells, type=pa.int32())
+    )
+    reaches = reaches.append_column("terminal_sink_type", pa.array(sink_types, type=pa.uint8()))
+    reaches = reaches.append_column("terminal_resolved", pa.array(resolved, type=pa.bool_()))
+    unresolved = sum(count for kind, count in counts.items() if kind.startswith("unresolved_"))
+    metadata = {
+        "terminal_reach_count": sum(
+            count for kind, count in counts.items() if kind != "downstream_reach"
+        ),
+        "terminal_ocean_count": counts["ocean"],
+        "terminal_registered_sink_count": counts["registered_sink"],
+        "terminal_unresolved_threshold_gap_count": counts["unresolved_threshold_gap"],
+        "terminal_unresolved_downstream_reference_count": counts["unresolved_downstream_reference"],
+        "terminal_unresolved_other_count": counts["unresolved_terminal"],
+        "source_to_sink_ready": int(unresolved == 0),
+    }
+    return reaches, metadata
+
+
+def _corridor_area_metadata(
+    reaches: pa.Table, metadata: Mapping[str, int | float]
+) -> dict[str, float]:
+    path_length_m = np.asarray(reaches["path_length_km"], dtype=np.float64) * 1_000.0
+    result: dict[str, float] = {}
+    for corridor in ("channel", "valley", "floodplain"):
+        requested = float(
+            np.sum(path_length_m * np.asarray(reaches[f"{corridor}_width_m"], dtype=np.float64))
+            / 1_000_000.0
+        )
+        represented = float(metadata[f"represented_{corridor}_area_km2"])
+        result[f"requested_{corridor}_area_km2"] = requested
+        result[f"{corridor}_area_retention_fraction"] = represented / max(requested, 1e-12)
+    return result
+
+
+def _membership_table(records: np.ndarray) -> pa.Table:
+    return pa.table(
+        {
+            "reach_id": pa.array(records["reach_id"], type=pa.int32()),
+            "fine_cell_id": pa.array(records["fine_cell_id"], type=pa.int32()),
+            "parent_cell_id": pa.array(records["parent_cell_id"], type=pa.int32()),
+            "path_order": pa.array(records["path_order"], type=pa.int32()),
+            "reach_length_m": pa.array(records["reach_length_m"], type=pa.float64()),
+            "channel_fraction": pa.array(records["channel_fraction"], type=pa.float32()),
+            "valley_fraction": pa.array(records["valley_fraction"], type=pa.float32()),
+            "floodplain_fraction": pa.array(records["floodplain_fraction"], type=pa.float32()),
+            "potential_incised_volume_m3": pa.array(
+                records["potential_incised_volume_m3"], type=pa.float64()
+            ),
+        }
+    )
+
+
+def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
+    cell_record = result.artifact_records.get("RefinedBasinCellCatalog")
+    reach_record = result.artifact_records.get("RefinedRiverReachCatalog")
+    metadata_record = result.artifact_records.get("BasinRefinementMetadata")
+    if (
+        cell_record is None
+        or reach_record is None
+        or metadata_record is None
+        or not isinstance(cell_record.value, pa.Table)
+        or not isinstance(reach_record.value, pa.Table)
+    ):
+        return None
+    cells = cell_record.value
+    reaches = reach_record.value
+    metadata = metadata_record.value
+    fine_resolution = int(metadata["fine_resolution"])
+    display_resolution = min(fine_resolution, 768)
+    image = np.full((display_resolution * 3, display_resolution * 4, 3), 18, dtype=np.uint8)
+    placements = np.array([[1, 1], [1, 3], [1, 2], [1, 0], [0, 1], [2, 1]])
+    face = np.asarray(cells["face"], dtype=np.int32)
+    row = np.asarray(cells["row"], dtype=np.int32)
+    col = np.asarray(cells["col"], dtype=np.int32)
+    elevation = np.asarray(cells["terrain_elevation_m"], dtype=np.float32)
+    low, high = np.percentile(elevation, [2.0, 98.0])
+    normalized = np.clip((elevation - low) / max(float(high - low), 1e-6), 0.0, 1.0)
+    colors = np.stack(
+        (55 + 150 * normalized, 85 + 125 * normalized, 55 + 95 * normalized), axis=1
+    ).astype(np.uint8)
+    display_row = np.minimum(row * display_resolution // fine_resolution, display_resolution - 1)
+    display_col = np.minimum(col * display_resolution // fine_resolution, display_resolution - 1)
+    net_row = placements[face, 0] * display_resolution + display_row
+    net_col = placements[face, 1] * display_resolution + display_col
+    image[net_row, net_col] = colors
+
+    rendered = Image.fromarray(image, mode="RGB")
+    draw = ImageDraw.Draw(rendered)
+    fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    order = np.argsort(fine_ids)
+    sorted_ids = fine_ids[order]
+    for path in reaches["fine_cell_path"].to_pylist():
+        path_array = np.asarray(path, dtype=np.int32)
+        rows = _lookup_rows(sorted_ids, order, path_array)
+        path_face = face[rows]
+        path_row = placements[path_face, 0] * display_resolution + np.minimum(
+            row[rows] * display_resolution // fine_resolution, display_resolution - 1
+        )
+        path_col = placements[path_face, 1] * display_resolution + np.minimum(
+            col[rows] * display_resolution // fine_resolution, display_resolution - 1
+        )
+        segment_start = 0
+        for index in range(1, len(rows) + 1):
+            if index == len(rows) or path_face[index] != path_face[index - 1]:
+                if index - segment_start >= 2:
+                    draw.line(
+                        [
+                            (int(path_col[position]), int(path_row[position]))
+                            for position in range(segment_start, index)
+                        ],
+                        fill=(29, 174, 235),
+                        width=2,
+                    )
+                segment_start = index
+    output = request.output_dir / "refined_basin.png"
+    padding = max(12, display_resolution // 40)
+    left = max(0, int(np.min(net_col)) - padding)
+    upper = max(0, int(np.min(net_row)) - padding)
+    right = min(rendered.width, int(np.max(net_col)) + padding + 1)
+    lower = min(rendered.height, int(np.max(net_row)) + padding + 1)
+    rendered = rendered.crop((left, upper, right, lower))
+    scale = min(1600 / rendered.width, 1000 / rendered.height)
+    if scale > 1.0:
+        rendered = rendered.resize(
+            (max(1, round(rendered.width * scale)), max(1, round(rendered.height * scale))),
+            Image.Resampling.NEAREST,
+        )
+    rendered.save(output)
+    return VisualizationResult(
+        output,
+        "RefinedBasinCellCatalog",
+        {"basin_id": metadata["selected_basin_id"], "fine_resolution": fine_resolution},
+    )
+
+
+@stage(
+    "basin_refinement",
+    inputs=("hydrology", "elevation", "planet"),
+    outputs=(
+        "RefinedBasinCellCatalog",
+        "RefinedBasinParentCatalog",
+        "RefinedRiverReachCatalog",
+        "RefinedReachCellCatalog",
+        "BasinRefinementMetadata",
+    ),
+    version="v4",
+    native_libraries=("refinement_native",),
+    visualizer=_cube_net_visualizer,
+)
+def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = BasinRefinementConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("basin refinement requires topology: cubed_sphere")
+    coarse_resolution = context.topology.face_resolution
+    fine_resolution = coarse_resolution * config.refinement_factor
+    if 6 * fine_resolution * fine_resolution > np.iinfo(np.int32).max:
+        raise ValueError("refinement_factor exceeds the global fine-cell ID capacity")
+
+    hydrology = deps["hydrology"]
+    basin_catalog = _artifact_table(hydrology, "BasinCatalog")
+    source_reaches = _artifact_table(hydrology, "RiverReachCatalog")
+    selected_basin_id = _select_basin(basin_catalog, source_reaches, config.basin_id)
+    selected_reaches = _downstream_first_reaches(
+        source_reaches.filter(pc.equal(source_reaches["basin_id"], selected_basin_id))
+    )
+    if selected_reaches.num_rows == 0:
+        raise ValueError(f"selected basin {selected_basin_id} has no river reaches")
+
+    paths = [[int(cell) for cell in path] for path in selected_reaches["cell_path"].to_pylist()]
+    basin_ids = _artifact_array(hydrology, "BasinID").reshape(-1)
+    flow_receiver = _artifact_array(hydrology, "FlowReceiverID").reshape(-1)
+    flow_sink_type = _artifact_array(hydrology, "FlowSinkType").reshape(-1)
+    basin_parent_ids = np.flatnonzero(basin_ids == selected_basin_id).astype(np.int32)
+    inherited_path_ids = np.fromiter(
+        (cell for path in paths for cell in path), dtype=np.int32, count=sum(map(len, paths))
+    )
+    parent_ids = np.ascontiguousarray(
+        np.union1d(basin_parent_ids, inherited_path_ids), dtype=np.int32
+    )
+    inside_selected_basin = basin_ids[parent_ids] == selected_basin_id
+    bedrock = _artifact_array(deps["elevation"], "BedrockElevationM").reshape(-1)
+    breach = _artifact_array(hydrology, "BreachIncisionM").reshape(-1)
+    relief = _artifact_array(deps["elevation"], "TerrainReliefM").reshape(-1)
+    parent_elevation = np.ascontiguousarray(
+        bedrock[parent_ids] - breach[parent_ids], dtype=np.float32
+    )
+    parent_relief = np.ascontiguousarray(relief[parent_ids], dtype=np.float32)
+    parent_area_steradians = np.ascontiguousarray(
+        context.topology.cell_areas.reshape(-1)[parent_ids], dtype=np.float64
+    )
+
+    reach_offsets, reach_parent_cells = _flatten_paths(paths)
+    planet = deps["planet"].artifact_records["PlanetMetadata"].value
+    radius_m = float(planet["planet_radius_earth"]) * EARTH_RADIUS_M
+    rng = context.rng("basin_refinement")
+    terrain_seed = int(rng.integers(0, np.iinfo(np.uint64).max, dtype=np.uint64))
+    controls = {
+        "coarse_resolution": coarse_resolution,
+        "factor": config.refinement_factor,
+        "planet_radius_m": radius_m,
+        "terrain_seed": terrain_seed,
+        "terrain_noise_fraction": config.terrain_noise_fraction,
+    }
+    with context.timed("sparse_basin_refinement_kernel"):
+        cell_records, reach_records, path_cells, memberships, metadata = run_basin_refinement(
+            controls=controls,
+            parent_ids=parent_ids,
+            parent_elevation_m=parent_elevation,
+            parent_relief_m=parent_relief,
+            parent_area_steradians=parent_area_steradians,
+            reach_ids=_column_numpy(selected_reaches, "reach_id", np.dtype(np.int32)),
+            reach_from_nodes=_column_numpy(selected_reaches, "from_node", np.dtype(np.int32)),
+            reach_to_nodes=_column_numpy(selected_reaches, "to_node", np.dtype(np.int32)),
+            reach_offsets=reach_offsets,
+            reach_parent_cells=reach_parent_cells,
+            channel_width_m=_column_numpy(
+                selected_reaches, "channel_width_m", np.dtype(np.float32)
+            ),
+            valley_width_m=_column_numpy(selected_reaches, "valley_width_m", np.dtype(np.float32)),
+            floodplain_width_m=_column_numpy(
+                selected_reaches, "floodplain_width_m", np.dtype(np.float32)
+            ),
+            incision_m=_column_numpy(selected_reaches, "incision_m", np.dtype(np.float32)),
+        )
+
+    radius_km = radius_m / 1_000.0
+    parent_areas_km2 = parent_area_steradians * radius_km * radius_km
+    cells = _cell_table(cell_records)
+    parents = _parent_table(
+        cell_records,
+        parent_ids,
+        inside_selected_basin,
+        parent_elevation,
+        parent_relief,
+        parent_areas_km2,
+        config.refinement_factor,
+    )
+    reaches, junctions_valid, maximum_length_error = _reach_table(
+        selected_reaches,
+        reach_records,
+        path_cells,
+        cell_records,
+        fine_resolution=fine_resolution,
+        factor=config.refinement_factor,
+        planet_radius_m=radius_m,
+    )
+    reaches, terminal_metadata = _classify_reach_terminals(
+        reaches, basin_ids, flow_receiver, flow_sink_type
+    )
+    reach_cells = _membership_table(memberships)
+    path_graph_metadata = _directed_path_graph_metadata(reaches)
+    corridor_area_metadata = _corridor_area_metadata(reaches, metadata)
+    metadata.update(
+        {
+            **asdict(config),
+            **terminal_metadata,
+            **path_graph_metadata,
+            **corridor_area_metadata,
+            "selected_basin_id": selected_basin_id,
+            "selected_basin_parent_count": int(np.count_nonzero(inside_selected_basin)),
+            "boundary_parent_count": int(np.count_nonzero(~inside_selected_basin)),
+            "selected_basin_area_km2": float(np.sum(parent_areas_km2[inside_selected_basin])),
+            "coarse_resolution": coarse_resolution,
+            "terrain_seed": terrain_seed,
+            "junction_merge_valid": int(junctions_valid),
+            "maximum_reach_length_conservation_error_m": maximum_length_error,
+            "inherited_discharge_relative_error": 0.0,
+            "topology": "sparse_selected_basin_on_cubed_sphere",
+            "terrain_semantics": "parent_mean_conserving_unresolved_relief_realization",
+            "river_semantics": "subgrid_physical_width_vector_reaches",
+            "corridor_area_semantics": (
+                "represented_centerline_cell_support_with_requested_unclipped_rectangles"
+            ),
+            "incision_semantics": "potential_reach_volume_not_cell_wide_elevation_change",
+        }
+    )
+    if metadata["path_topology_valid"] != 1:
+        raise RuntimeError("native refinement published an invalid fine reach path")
+    if metadata["maximum_parent_area_relative_error"] > 1e-9:
+        raise RuntimeError("refined child areas do not conserve their parent areas")
+    if metadata["maximum_parent_elevation_error_m"] > 1e-3:
+        raise RuntimeError("refined terrain does not conserve parent mean elevation")
+    if maximum_length_error > 1e-4:
+        raise RuntimeError("refined path length does not match its spherical geometry")
+    if not junctions_valid:
+        raise RuntimeError("refined upstream reaches do not merge into their downstream paths")
+    if metadata["directed_path_graph_valid"] != 1:
+        raise RuntimeError(
+            "refined reach union is not a directed acyclic drainage graph: "
+            f"reverse_conflicts={metadata['reverse_directed_edge_conflict_count']}, "
+            f"dag_valid={metadata['directed_path_dag_valid']}"
+        )
+    context.logger.log_event(
+        {"type": "basin_refinement_summary", "stage": "basin_refinement", **metadata}
+    )
+    return {
+        "RefinedBasinCellCatalog": cells,
+        "RefinedBasinParentCatalog": parents,
+        "RefinedRiverReachCatalog": reaches,
+        "RefinedReachCellCatalog": reach_cells,
+        "BasinRefinementMetadata": metadata,
+    }
+
+
+__all__ = ["BasinRefinementConfig", "basin_refinement_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -271,6 +271,7 @@ def main(args: Iterable[str] | None = None) -> int:
             "elevation",
             "climate",
             "hydrology",
+            "basin_refinement",
         ],
         default="topology",
     )
@@ -337,8 +338,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = _register_elevation_stage()
         elif parsed.stage == "climate":
             stage_name = "climate"
-        else:
+        elif parsed.stage == "hydrology":
             stage_name = "hydrology"
+        else:
+            stage_name = "basin_refinement"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -362,6 +365,7 @@ def main(args: Iterable[str] | None = None) -> int:
         "elevation",
         "climate",
         "hydrology",
+        "basin_refinement",
     }:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":

--- a/tests/test_basin_refinement.py
+++ b/tests/test_basin_refinement.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.stages.basin_refinement import BasinRefinementConfig
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+        "hydrology",
+        "basin_refinement",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(tmp_path: Path, run_id: str, *, seed: int = 37) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 20}],
+            "rng_seed": seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 10,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+                "basin_refinement": {
+                    "refinement_factor": 4,
+                    "terrain_noise_fraction": 0.4,
+                },
+            },
+        }
+    )
+
+
+def _table(result, name: str) -> pa.Table:
+    value = result.artifact_records[name].value
+    assert isinstance(value, pa.Table)
+    return value
+
+
+def _collapsed(values: np.ndarray) -> list[int]:
+    return [
+        int(value) for index, value in enumerate(values) if index == 0 or value != values[index - 1]
+    ]
+
+
+def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "basin-refinement"), generate_visuals=True)
+    result = engine.run(["basin_refinement"])["basin_refinement"]
+    metadata = result.artifact_records["BasinRefinementMetadata"].value
+    cells = _table(result, "RefinedBasinCellCatalog")
+    parents = _table(result, "RefinedBasinParentCatalog")
+    reaches = _table(result, "RefinedRiverReachCatalog")
+    memberships = _table(result, "RefinedReachCellCatalog")
+
+    factor = int(metadata["refinement_factor"])
+    fine_resolution = int(metadata["fine_resolution"])
+    assert factor == 4
+    assert fine_resolution == 80
+    assert metadata["path_topology_valid"] == 1
+    assert metadata["junction_merge_valid"] == 1
+    assert metadata["reverse_directed_edge_conflict_count"] == 0
+    assert metadata["directed_path_dag_valid"] == 1
+    assert metadata["directed_path_graph_valid"] == 1
+    assert metadata["inherited_discharge_relative_error"] == 0.0
+    assert metadata["parent_count"] == parents.num_rows
+    assert metadata["child_count"] == cells.num_rows == parents.num_rows * factor * factor
+    assert metadata["reach_count"] == reaches.num_rows > 0
+    assert metadata["reach_cell_count"] == memberships.num_rows > 0
+    assert metadata["maximum_parent_area_relative_error"] < 1e-10
+    assert metadata["maximum_parent_elevation_error_m"] < 1e-3
+
+    assert len(set(cells["fine_cell_id"].to_pylist())) == cells.num_rows
+    assert np.max(np.abs(np.asarray(parents["area_relative_error"]))) < 1e-10
+    assert np.max(np.abs(np.asarray(parents["elevation_error_m"]))) < 1e-3
+    assert np.any(np.asarray(cells["terrain_offset_m"]) > 0.0)
+    assert np.any(np.asarray(cells["terrain_offset_m"]) < 0.0)
+
+    fine_grid = CubedSphereGrid.create(fine_resolution)
+    fine_to_parent = fine_grid.parent_map(factor).reshape(-1)
+    fine_neighbors = fine_grid.neighbor_indices.reshape(-1, 4)
+    path_lengths_by_reach: dict[int, float] = {}
+    directed_edges: set[tuple[int, int]] = set()
+    for row in range(reaches.num_rows):
+        fine_path = np.asarray(reaches["fine_cell_path"][row].as_py(), dtype=np.int32)
+        parent_path = reaches["parent_cell_path"][row].as_py()
+        assert len(fine_path) >= len(parent_path)
+        assert _collapsed(fine_to_parent[fine_path]) == parent_path
+        assert np.all(
+            [
+                target in fine_neighbors[source]
+                for source, target in zip(fine_path[:-1], fine_path[1:])
+            ]
+        )
+        reach_id = int(reaches["reach_id"][row].as_py())
+        path_lengths_by_reach[reach_id] = float(reaches["path_length_km"][row].as_py()) * 1_000.0
+        directed_edges.update(
+            (int(source), int(target)) for source, target in zip(fine_path[:-1], fine_path[1:])
+        )
+    assert not any((target, source) in directed_edges for source, target in directed_edges)
+
+    channel_fraction = np.asarray(memberships["channel_fraction"])
+    valley_fraction = np.asarray(memberships["valley_fraction"])
+    floodplain_fraction = np.asarray(memberships["floodplain_fraction"])
+    assert np.all((channel_fraction >= 0.0) & (channel_fraction < 0.01))
+    assert np.all(channel_fraction <= valley_fraction)
+    assert np.all((floodplain_fraction >= 0.0) & (floodplain_fraction <= 1.0))
+
+    membership_reach = np.asarray(memberships["reach_id"], dtype=np.int32)
+    membership_length = np.asarray(memberships["reach_length_m"], dtype=np.float64)
+    potential_volume = np.asarray(memberships["potential_incised_volume_m3"], dtype=np.float64)
+    width_by_reach = dict(
+        zip(
+            np.asarray(reaches["reach_id"], dtype=np.int32),
+            np.asarray(reaches["channel_width_m"], dtype=np.float64),
+            strict=True,
+        )
+    )
+    incision_by_reach = dict(
+        zip(
+            np.asarray(reaches["reach_id"], dtype=np.int32),
+            np.asarray(reaches["incision_m"], dtype=np.float64),
+            strict=True,
+        )
+    )
+    for reach_id, expected_length in path_lengths_by_reach.items():
+        selected = membership_reach == reach_id
+        actual_length = float(np.sum(membership_length[selected]))
+        assert actual_length == pytest.approx(expected_length, rel=1e-12)
+        assert float(np.sum(potential_volume[selected])) == pytest.approx(
+            width_by_reach[reach_id] * actual_length * incision_by_reach[reach_id], rel=1e-6
+        )
+
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    cell_areas = np.asarray(cells["area_km2"], dtype=np.float64)
+    cell_order = np.argsort(cell_ids)
+    sorted_cell_ids = cell_ids[cell_order]
+    membership_cell_ids = np.asarray(memberships["fine_cell_id"], dtype=np.int32)
+    membership_areas = cell_areas[cell_order[np.searchsorted(sorted_cell_ids, membership_cell_ids)]]
+    for corridor in ("channel", "valley", "floodplain"):
+        represented = float(
+            np.sum(np.asarray(memberships[f"{corridor}_fraction"]) * membership_areas)
+        )
+        assert metadata[f"represented_{corridor}_area_km2"] == pytest.approx(represented, rel=1e-12)
+        assert metadata[f"requested_{corridor}_area_km2"] >= represented
+        assert 0.0 < metadata[f"{corridor}_area_retention_fraction"] <= 1.0 + 1e-7
+
+    assert {
+        "terminal_kind",
+        "downstream_join_fine_cell",
+        "terminal_parent_cell",
+        "terminal_receiver_cell",
+        "terminal_sink_type",
+        "terminal_resolved",
+    }.issubset(reaches.column_names)
+    unresolved = [
+        kind for kind in reaches["terminal_kind"].to_pylist() if kind.startswith("unresolved_")
+    ]
+    assert metadata["source_to_sink_ready"] == int(not unresolved)
+
+    visual = engine.context.config.run_visual_dir() / "basin_refinement" / "refined_basin.png"
+    assert visual.is_file()
+
+
+def test_refinement_is_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "refinement-first")).run(["basin_refinement"])[
+        "basin_refinement"
+    ]
+    second = ExecutionEngine(_config(tmp_path, "refinement-second")).run(["basin_refinement"])[
+        "basin_refinement"
+    ]
+    for name in (
+        "RefinedBasinCellCatalog",
+        "RefinedBasinParentCatalog",
+        "RefinedRiverReachCatalog",
+        "RefinedReachCellCatalog",
+    ):
+        assert _table(first, name).equals(_table(second, name))
+    assert (
+        first.artifact_records["BasinRefinementMetadata"].value
+        == second.artifact_records["BasinRefinementMetadata"].value
+    )
+    assert second.stats is not None and second.stats.cache_hit
+
+
+def test_refinement_config_rejects_invalid_controls():
+    with pytest.raises(ValueError, match="Unknown basin refinement controls"):
+        BasinRefinementConfig.from_mapping({"carve_whole_cells": True})
+    with pytest.raises(ValueError, match="power of two"):
+        BasinRefinementConfig.from_mapping({"refinement_factor": 3})
+    with pytest.raises(ValueError, match="basin_id"):
+        BasinRefinementConfig.from_mapping({"basin_id": -1})
+    with pytest.raises(ValueError, match="terrain_noise_fraction"):
+        BasinRefinementConfig.from_mapping({"terrain_noise_fraction": 1.1})

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -57,6 +57,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
         "geology_native",
         "hydrology_native",
         "planet_native",
+        "refinement_native",
         "tectonics_native",
         "topology_native",
         "world_age_native",


### PR DESCRIPTION
## Summary

- document the hierarchical river and subgrid-incision decision
- add a Rust-backed sparse selected-basin refinement stage at face-2048 without allocating a global fine raster
- conserve parent area and mean elevation while realizing deterministic child terrain and inherited reach paths
- route reaches downstream-first into a globally validated DAG with explicit fine junction cells
- store physical channel, valley, and floodplain fractions without cell-wide river incision
- publish requested versus represented corridor area and source-to-sink readiness

## Current Boundary

This is the refinement contract and terrain/network scaffold. It does not apply erosion, generate sub-threshold tributaries, spatially realize lake fractions, or route sediment. The canonical basin exposes 12 inherited Hydrology Pass 1 threshold gaps and therefore reports `source_to_sink_ready = 0`. Valley and floodplain support also require lateral spreading before erosion.

## Validation

- `pytest -q` (100 passed)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `ruff check src tests`
- Black on all changed Python files
- release native build and `map-maker doctor`
- canonical face-128 / factor-16 basin run: 370,944 sparse children, 21 reaches, zero reverse edges, acyclic directed path graph, parent-area error `8.1e-12`, parent-elevation error `< 1e-5 m`

Repository-wide Black still reports the two pre-existing untouched legacy files `legacy/io/geo.py` and `legacy/generate.py`.
