### PR TITLE
Make refined basins erosion-ready

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1194,3 +1194,72 @@ Failure conditions:
 - Water, sediment, or incision volumes that change under restriction.
 - Global fine grids used where selected regional refinement provides the same
   physical result within the accepted hierarchy.
+
+## Decision 024: Hydrologic Connectors And Conservative Corridor Support
+
+Status: implemented, provisional
+
+Decision:
+The canonical reach graph distinguishes physical river channels from
+zero-width hydrologic connectors. A connector preserves source-to-sink topology
+where routed discharge crosses preserved coarse depression or waterbody support
+in which Hydrology Pass 1 cannot justify open-channel geometry. Ordinary
+below-threshold land gaps may not become connectors. A connector is not a
+hidden river and cannot contribute channel, valley, floodplain, or incision
+area.
+
+Connector contract:
+- Connectors retain reach identity, ordered cell paths, upstream/downstream
+  relationships, discharge, sediment flux, and sink topology needed by later
+  stages.
+- They publish `reach_kind = connector`, zero physical width and depth, zero
+  valley and floodplain width, zero local velocity and stream power, zero
+  incision, `hydrologic_connector` morphology, and a not-applicable bed
+  material.
+- A terminal reach is valid only at an ocean boundary or registered
+  lake/wetland/endorheic sink. Any other terminal blocks refinement and erosion.
+- Regional refinement may replace a connector with resolved inlet, waterbody,
+  outlet, or local channel geometry, but may not infer erosion from the coarse
+  connector itself.
+- Topological path length and physical channel length remain separate. Shared
+  connector endpoints preserve graph continuity but do not add physical channel
+  length or support.
+
+Corridor support contract:
+- Requested channel, floodplain, and valley area derives from physical reach
+  width times in-cell reach length. Rendering width never enters the budget.
+- Physical channel support is reserved first. Valley support is distributed
+  from the centerline into nearby sparse fine cells, and floodplain support is
+  constrained to the allocated valley footprint.
+- Per membership and in aggregate per fine cell, channel support must be no
+  greater than floodplain support, which must be no greater than valley
+  support. The summed support of each type cannot exceed the cell's physical
+  area even where multiple reaches share it.
+- Lateral support records carry zero reach length and zero incision volume.
+  They describe occupied area, not additional channel centerline.
+- Preserved depression parents are process-excluded: topological paths may cross
+  them, but channel, valley, floodplain, and incision memberships may not enter
+  them until resolved local geometry replaces the connector.
+- Requested and represented areas must agree within the configured conservation
+  tolerance. Allocation failure is fatal rather than silently clipping area.
+- Competing valley demands are ordered by spatial scarcity with deterministic
+  fallback orders. Floodplain area is allocated per reach from that reach's
+  already-conserved valley footprint, guaranteeing nested support when the
+  input widths are nested.
+
+Current approximation:
+Lateral allocation is deterministic and prefers nearby lower terrain, but it
+does not yet solve cross-valley flow direction, flood recurrence, or
+process-driven valley morphology. Those refinements may redistribute support
+while preserving the registered reach graph and physical area budgets.
+
+Failure conditions:
+- A connector with nonzero physical channel dimensions or incision.
+- A connector created across ordinary non-waterbody land merely to satisfy the
+  readiness gate.
+- An unresolved land terminal in the canonical reach graph.
+- Physical process support in a connector-owned or preserved-depression parent.
+- Corridor support clipped because it does not fit in a centerline cell.
+- Per-cell support greater than physical cell area or non-nested channel,
+  floodplain, and valley footprints.
+- Lateral support counted as extra reach length or erodible channel area.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -120,6 +120,14 @@ nonglaciated land when much smaller lakes are included in the
 [high-resolution inventory](https://doi.org/10.1002/2014GL060641). It is a
 validation diagnostic, not a global-area clamp.
 
+The canonical face-128 reach graph contains 1,259 physical channel reaches and
+220 zero-width hydrologic connectors. All 369 terminal reaches resolve to 351
+ocean outlets or 18 registered inland sinks; unresolved terminals are zero.
+Connector paths cover 885 coarse reach cells while publishing zero channel
+width, depth, local velocity, stream power, valley/floodplain support, and
+incision. They preserve routed flux and graph continuity without inventing a
+physical river through unresolved waterbody support.
+
 The previous whole-cell lake statistic is retired as an area estimate. Coarse
 support cells now carry `LakeFraction` and `WetlandFraction`; area diagnostics
 weight those fractions by physical cubed-sphere cell area. These ranges remain
@@ -140,19 +148,20 @@ Resolution stability still fails. Fractional area removes whole-cell inflation,
 but face-128 worlds retain materially more lakes and closed drainage than the
 face-64 sweep. Finer elevation exposes additional local depressions that can
 capture drainage which the coarse pass sent onward. Do not tune this away with a
-resolution-specific lake count. The required fix is hierarchical hydrology:
-preserve accepted coarse trunk connectivity and flux while refining local basins,
-tributaries, wetlands, and channels. Until that constraint exists, closed-drainage
-and lake statistics are provisional and Pass 1 is not calibrated for arbitrary
-resolution.
+resolution-specific lake count. The selected-basin prototype now preserves
+accepted coarse trunk connectivity and flux, but the contract is not yet
+generalized to local basins, tributaries, wetlands, and channels at arbitrary
+resolution. Closed-drainage and lake statistics therefore remain provisional.
 
 ## Selected-Basin Refinement
 
 The canonical sparse refinement selects ocean-draining basin 226. Its 1,448
 coarse basin cells plus one inherited ocean boundary cell produce 370,944
 face-2048 child records at factor 16 without allocating a global face-2048
-raster. Twenty-one inherited reaches produce 11,253 km of D4-contiguous fine
-reach paths and 2,613 sparse reach-cell memberships.
+raster. Twenty-one physical channel reaches and 16 zero-width hydrologic
+connectors produce 14,068 km of D4-contiguous topological paths, of which
+10,530 km is physical channel. The physical support catalog contains 3,152
+sparse memberships: 2,442 centerline records and 710 lateral corridor records.
 
 Observed conservation and topology diagnostics:
 
@@ -165,26 +174,35 @@ Observed conservation and topology diagnostics:
 | Downstream-path junction merges | Pass |
 | Reverse directed edges | `0` |
 | Combined path DAG | Pass |
+| Source-to-sink readiness | Pass |
+| Unresolved reach terminals | `0` |
 | Inherited discharge error | `0` |
+| Per-cell corridor capacity | Pass |
+| Nested channel/floodplain/valley support | Pass |
+| Preserved-depression process exclusion | Pass (`127` parents) |
 
-Requested physical channel area is `1,366.835 km2`; centerline-cell fractions
-represent `1,366.835 km2`, or roughly 0.02% of the 6.98 million km2 basin. This
+Requested physical channel area is `1,297.241 km2`; centerline-cell fractions
+represent `1,297.241 km2`, or roughly 0.02% of the 6.98 million km2 basin. This
 demonstrates why river width must remain a fractional/vector property even at
-the refined level. Approximately `157.3 km3` of potential incision is recorded
+the refined level. Approximately `150.20 km3` of potential incision is recorded
 as reach volume and has not been applied to cell-wide elevation.
 
-Broad corridors do not yet fit entirely in their centerline cells. Requested
-valley area is `39,917 km2`, of which `30,347 km2` (76.0%) is currently
-represented; requested floodplain area is `38,043 km2`, of which `29,499 km2`
-(77.5%) is represented. The missing support must be spread laterally into
-neighboring fine cells before erosion rather than hidden by capped fractions.
+Requested valley area is `38,010.699 km2` and represented area is
+`38,010.698 km2`. Requested floodplain area is `36,230.158 km2` and represented
+area is `36,230.157 km2`. The remaining differences are floating-point
+allocation error below `2e-8` relative. Per-cell summed support never exceeds
+one for channel, valley, or floodplain, including cells shared by multiple
+reaches, and every membership preserves channel <= floodplain <= valley.
 
-Source-to-sink readiness currently fails. Of 13 terminal registered reaches,
-one reaches the ocean and 12 end at land cells where Hydrology Pass 1 fell below
-the river extraction threshold. The refinement stage classifies and reports
-these inherited gaps instead of inventing connections. Conservative incision
-and sediment routing remain blocked until the gaps close. These are contract and
-conservation results, not accepted erosion calibration.
+The basin has one terminal reach, which reaches the ocean. Sixteen zero-width
+connectors preserve the accepted drainage path through coarse depression
+support without pretending those cells contain physical channels. They carry no
+physical memberships. Physical channel reaches also stop their process support
+at shared connector endpoints, so no channel, valley, floodplain, or incision
+area enters a connector-owned or preserved-depression parent. The basin
+therefore passes the topology and corridor input gates for conservative
+incision and sediment routing. These are contract and conservation results, not
+accepted erosion calibration.
 
 ## Calibration Rule
 

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -28,9 +28,9 @@
 7. Climate pass 1.
 8. Hydrology pass 1.
    - A sparse selected-basin refinement gate proves inherited river topology,
-     subgrid physical width, and parent/child conservation before erosion.
-     It must also report complete source-to-sink readiness; erosion remains
-     blocked while inherited reach-threshold gaps exist.
+     subgrid physical width, lateral corridor capacity, and parent/child
+     conservation before erosion. It reports complete source-to-sink readiness
+     through physical channels and zero-width hydrologic connectors.
 9. Erosion and sedimentation.
 10. Hydrology pass 2.
 11. Soils and biomes.
@@ -38,7 +38,7 @@
 13. Selected-region refinement and map export.
 
 The current canonical cubed-sphere implementation reaches Hydrology Pass 1 and
-the selected-basin refinement gate with a
+passes the selected-basin refinement readiness gate with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
 relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
 climate/orography pass. The older

--- a/docs/specs/08_climate_hydrology.md
+++ b/docs/specs/08_climate_hydrology.md
@@ -177,6 +177,12 @@ contract for inspection and surrogate training.
 - Junction-to-junction reaches form the canonical river graph. Exact cubed-sphere
   cell paths are retained for refinement and a two-pass spherical corner-cutting
   generalization writes smooth unit-XYZ polylines for rendering.
+- Zero-width hydrologic connector reaches carry routed topology and flux across
+  preserved depression or waterbody support cells where the coarse pass cannot
+  justify open-channel geometry. They have no physical channel dimensions,
+  corridor support, or incision and must be replaced by resolved local geometry
+  before any channel process is applied there. Ordinary below-threshold land
+  paths remain unresolved and fail the source-to-sink readiness gate.
 - Reach attributes include monthly discharge and velocity, slope, stream power,
   Strahler order, estimated width/depth, valley and floodplain width, meandering,
   braiding, incision, sediment load, bed material, and morphology class.
@@ -206,6 +212,10 @@ conservation error, and artifact semantics.
   losses within floating-point tolerance.
 - Flow vectors are tangent unit vectors on routed cells.
 - Reach IDs and downstream references are valid and the reach graph is acyclic.
+- Every terminal reach ends at ocean or a registered lake, wetland, or
+  endorheic sink; unresolved terminals block downstream processing.
+- Hydrologic connectors have zero channel width, depth, local velocity, stream
+  power, and incision.
 - Exact and smoothed reach geometries share endpoints and remain on the unit sphere.
 - Lake and wetland fractions are finite, bounded by `[0, 1]`, mutually exclusive,
   and reproduce catalog water area when weighted by physical cell area.

--- a/docs/specs/08a_basin_refinement.md
+++ b/docs/specs/08a_basin_refinement.md
@@ -9,12 +9,12 @@ does not yet apply erosion, generate new tributaries, or replace Hydrology Pass
 
 ## Objective
 
-Refine one complete coarse drainage-basin footprint without allocating a global fine raster and
-without converting subcell rivers into atomic raster trenches. Preserve the
-accepted coarse basin, registered reach graph, junctions, physical dimensions,
-and flux attributes while realizing fine child terrain and reach paths. A
-complete footprint does not imply that thresholded Hydrology Pass 1 reaches
-already form a complete source-to-sink network.
+Refine one complete coarse drainage-basin footprint without allocating a global
+fine raster and without converting subcell rivers into atomic raster trenches.
+Preserve the accepted coarse basin, registered reach graph, junctions, physical
+dimensions, and flux attributes while realizing fine child terrain and reach
+paths. Zero-width hydrologic connectors preserve routed source-to-sink topology
+across coarse depression support where open-channel geometry is unresolved.
 
 ## Selection
 
@@ -45,6 +45,12 @@ across. Only selected child records are allocated and persisted.
 - Every inherited coarse reach retains its reach ID, basin, downstream reach,
   discharge, velocity, width, depth, valley and floodplain widths, incision
   potential, sediment load, morphology, and bed material.
+- Physical channel reaches and zero-width hydrologic connectors retain distinct
+  `reach_kind` semantics. Connectors preserve topology and flux but contribute
+  no channel dimensions, corridor area, or incision volume.
+- Topological path length includes the shared graph anchors required to cross
+  connectors. Physical channel length includes only fine segments whose parent
+  Hydrology Pass 1 cell contains channel support.
 - Reaches are processed downstream-first. Terminal reaches retain fine anchors;
   each upstream reach merges onto its registered downstream path inside the
   inherited coarse junction cell, and records the actual fine join cell.
@@ -62,7 +68,7 @@ across. Only selected child records are allocated and persisted.
 
 ## Fractional Support
 
-For every fine reach-cell membership:
+Each centerline membership contributes physical corridor demand:
 
 ```text
 channel_fraction = channel_width_m * reach_length_m / cell_area_m2
@@ -71,26 +77,37 @@ floodplain_fraction = floodplain_width_m * reach_length_m / cell_area_m2
 ```
 
 Fractions are bounded by `[0, 1]`. Broad valley and floodplain rectangles can
-exceed their centerline fine cell; current records cap that cell's represented
-support and report both represented and requested unclipped areas. Later lateral
-corridor realization must place the retained area in neighboring cells rather
-than discard it. Potential incision volume is physical channel width times
-in-cell reach length times inherited incision depth. It remains a diagnostic
-volume and does not lower the full fine cell.
+exceed their centerline fine cell. The allocator reserves physical channel
+support, spreads valley area into nearby sparse cells, and constrains floodplain
+area to the allocated valley footprint. Per-cell capacity is shared across
+reaches, so aggregate support cannot exceed physical cell area. Lateral records
+carry zero reach length and do not duplicate channel length or incision.
+Potential incision volume is physical channel width times in-cell reach length
+times inherited incision depth. It remains a diagnostic volume and does not
+lower the full fine cell.
+
+Preserved-depression parents are process-excluded. Reach topology may cross
+them, but no physical channel, valley, floodplain, or incision membership may
+enter them until local waterbody and outlet geometry is resolved. Connector
+reaches therefore have no `RefinedReachCellCatalog` records.
 
 ## Outputs
 
 - `RefinedBasinCellCatalog`: sparse child IDs, parent IDs, cubed-sphere
-  coordinates, areas, terrain prior, offset, and inherited relief.
+  coordinates, areas, terrain prior, offset, inherited relief, and process
+  exclusion.
 - `RefinedBasinParentCatalog`: parent/child area and elevation restriction
-  audit, including boundary membership.
+  audit, including boundary membership and preserved-depression process
+  exclusion.
 - `RefinedRiverReachCatalog`: inherited attributes, fine paths, downstream join
-  cells, terminal classification/readiness, path length, and spherical
-  polylines.
-- `RefinedReachCellCatalog`: sparse reach length, channel/valley/floodplain
-  fractions, and potential incision volume per fine cell.
+  cells, terminal classification/readiness, separate topological and physical
+  channel lengths, and spherical polylines.
+- `RefinedReachCellCatalog`: sparse reach length, centerline/lateral support
+  role, channel/valley/floodplain fractions, and potential incision volume per
+  fine cell.
 - `BasinRefinementMetadata`: selection, dimensions, conservation errors,
-  topology gates, physical totals, and semantic versioning.
+  channel/connector counts, topology gates, physical totals, and semantic
+  versioning.
 
 ## Hard Gates
 
@@ -102,8 +119,15 @@ volume and does not lower the full fine cell.
   inside the shared coarse junction cell.
 - The combined directed fine network is acyclic and contains no reverse-used
   edge.
+- Every terminal reach ends at an ocean boundary or registered hydrologic sink.
+- Hydrologic connectors have zero physical width, local velocity, stream power,
+  and incision.
+- Physical memberships do not enter preserved-depression parents, including
+  shared connector endpoint cells.
 - Inherited discharge is unchanged.
-- Channel, valley, and floodplain fractions remain finite and bounded.
+- Channel, valley, and floodplain fractions remain finite, nested, and bounded.
+- Summed support of each corridor type does not exceed any fine cell's physical
+  capacity, and represented corridor area conserves requested physical area.
 - Identical seed, configuration, inputs, and native build produce identical
   artifacts.
 
@@ -122,14 +146,15 @@ volume and does not lower the full fine cell.
   the conservative erosion pass and may not be inferred from rendering strokes.
 - The prototype refines one basin per stage run and stores Arrow catalogs rather
   than chunked regional rasters.
-- Reach gaps already present in Hydrology Pass 1 remain visible; refinement does
-  not invent connectivity that the accepted parent graph does not contain.
-- `source_to_sink_ready` remains false while those gaps exist. Conservative
-  erosion and sediment routing must not run on such a basin.
-- Capped valley and floodplain support is not yet spread laterally into adjacent
-  fine cells. Requested and represented areas therefore differ.
+- Coarse connectors are topological placeholders. Refined inlet, lake-crossing,
+  outlet, and channel geometry remain unresolved in those cells, and connectors
+  cannot erode terrain.
+- Lateral support currently uses deterministic proximity and lower terrain. It
+  does not yet solve cross-valley direction, flood recurrence, or physically
+  evolved valley morphology.
+- Scarcity ordering and deterministic retries avoid known greedy allocation
+  failures, but the valley allocator is not a general global optimizer.
 
-The next pass closes inherited source-to-sink threshold gaps and realizes broad
-corridors laterally. Conservative fluvial incision and sediment routing can
-follow only after those readiness gates pass, then aggregate physical budgets
-upward before Hydrology Pass 2.
+The next pass solves junction-consistent channel-bed profiles, applies
+conservative fluvial incision and sediment routing only to physical channel
+reaches, and aggregates physical budgets upward before Hydrology Pass 2.

--- a/readme.md
+++ b/readme.md
@@ -81,9 +81,11 @@ regional terrain remain implementation milestones. A first sparse basin-refineme
 stage now realizes one inherited trunk network at approximately 5 km scale,
 preserves parent terrain means and convergent reach junctions, and stores physical
 channel, valley, and floodplain fractions without carving whole cells. It also
-publishes inherited terminal gaps and source-to-sink readiness; the canonical
-basin is not yet cleared for conservative erosion. The current output is a
-functional prototype rather than an atlas-grade world.
+closes coarse extraction gaps with zero-width hydrologic connectors, verifies
+source-to-sink readiness, and conserves broad valley and floodplain support in
+nearby fine cells. The canonical basin now passes the input gates for the first
+conservative erosion pass, but no refined erosion has yet been applied. The
+current output is a functional prototype rather than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -141,7 +143,7 @@ uv run map-maker-pipeline --stage climate --config configs/cubed_sphere_crust_st
 # Canonical lakes, breaches, drainage graph, basins, and vector river reaches
 uv run map-maker-pipeline --stage hydrology --config configs/cubed_sphere_crust_state.yaml
 
-# One sparse face-2048 basin with inherited trunks and subgrid valley fractions
+# One sparse face-2048 basin with connected trunks and conserved corridor support
 uv run map-maker-pipeline --stage basin_refinement --config configs/cubed_sphere_crust_state.yaml
 ```
 

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
+NATIVE_ABI_OVERRIDES = {"refinement_native": 3}
 SIMULATION_NATIVE_LIBRARIES = (
     "climate_native",
     "elevation_native",
@@ -109,9 +110,10 @@ def _native_library_info_cached(
         raise NativeLibraryAbiError(
             f"Native library {path} does not expose required ABI symbol {symbol!r}"
         ) from exc
-    if actual_abi != NATIVE_ABI_VERSION:
+    expected_abi = NATIVE_ABI_OVERRIDES.get(name, NATIVE_ABI_VERSION)
+    if actual_abi != expected_abi:
         raise NativeLibraryAbiError(
-            f"Native library {path} uses ABI {actual_abi}; expected {NATIVE_ABI_VERSION}"
+            f"Native library {path} uses ABI {actual_abi}; expected {expected_abi}"
         )
     return {
         "abi_version": actual_abi,

--- a/src/map_maker/pipeline/_hydrology_native.py
+++ b/src/map_maker/pipeline/_hydrology_native.py
@@ -27,9 +27,11 @@ RIVER_MORPHOLOGY_CLASSES = {
     4: "braided_river",
     5: "delta_distributary",
     6: "endorheic_inflow",
+    7: "hydrologic_connector",
 }
 
 BED_MATERIAL_CLASSES = {
+    0: "not_applicable",
     1: "bedrock",
     2: "gravel",
     3: "sand",
@@ -432,6 +434,10 @@ def _reach_table(records: np.ndarray, vertices: np.ndarray) -> pa.Table:
             "downstream_reach_id": pa.array(downstream, type=pa.int32()),
             "basin_id": pa.array(records["basin_id"], type=pa.int32()),
             "cell_path": pa.array(polylines, type=pa.list_(pa.int32())),
+            "reach_kind": pa.array(
+                np.where(records["morphology_code"] == 7, "connector", "channel"),
+                type=pa.string(),
+            ),
             "flow_direction_vector": _fixed_list(records["flow_direction_vector"], 3),
             "slope": pa.array(records["slope"], type=pa.float32()),
             "strahler_order": pa.array(records["strahler_order"], type=pa.int32()),

--- a/src/map_maker/pipeline/_refinement_native.py
+++ b/src/map_maker/pipeline/_refinement_native.py
@@ -133,6 +133,7 @@ int32_t refinement_run_basin(
     const float* parent_elevation_m,
     const float* parent_relief_m,
     const double* parent_area_steradians,
+    const uint8_t* parent_process_excluded,
     int32_t reach_count,
     const int32_t* reach_ids,
     const int32_t* reach_from_nodes,
@@ -140,6 +141,7 @@ int32_t refinement_run_basin(
     const int32_t* reach_offsets,
     int32_t reach_parent_cell_count,
     const int32_t* reach_parent_cells,
+    const uint8_t* reach_parent_channel_support,
     const float* channel_width_m,
     const float* valley_width_m,
     const float* floodplain_width_m,
@@ -164,8 +166,8 @@ try:
     _abi_version = int(_lib.refinement_native_abi_version())
 except AttributeError as exc:
     raise NativeLibraryAbiError("refinement_native lacks its required API") from exc
-if _abi_version != 2:
-    raise NativeLibraryAbiError(f"refinement_native uses ABI {_abi_version}; expected ABI 2")
+if _abi_version != 3:
+    raise NativeLibraryAbiError(f"refinement_native uses ABI {_abi_version}; expected ABI 3")
 
 for c_name, dtype in (
     ("RefinedCellRecord", REFINED_CELL_DTYPE),
@@ -217,11 +219,13 @@ def run_basin_refinement(
     parent_elevation_m: np.ndarray,
     parent_relief_m: np.ndarray,
     parent_area_steradians: np.ndarray,
+    parent_process_excluded: np.ndarray,
     reach_ids: np.ndarray,
     reach_from_nodes: np.ndarray,
     reach_to_nodes: np.ndarray,
     reach_offsets: np.ndarray,
     reach_parent_cells: np.ndarray,
+    reach_parent_channel_support: np.ndarray,
     channel_width_m: np.ndarray,
     valley_width_m: np.ndarray,
     floodplain_width_m: np.ndarray,
@@ -247,6 +251,11 @@ def run_basin_refinement(
             name="parent_area_steradians",
             dtype=np.dtype(np.float64),
         ),
+        "parent_process_excluded": _input(
+            parent_process_excluded,
+            name="parent_process_excluded",
+            dtype=np.dtype(np.uint8),
+        ),
         "reach_ids": _input(reach_ids, name="reach_ids", dtype=np.dtype(np.int32)),
         "reach_from_nodes": _input(
             reach_from_nodes, name="reach_from_nodes", dtype=np.dtype(np.int32)
@@ -255,6 +264,11 @@ def run_basin_refinement(
         "reach_offsets": _input(reach_offsets, name="reach_offsets", dtype=np.dtype(np.int32)),
         "reach_parent_cells": _input(
             reach_parent_cells, name="reach_parent_cells", dtype=np.dtype(np.int32)
+        ),
+        "reach_parent_channel_support": _input(
+            reach_parent_channel_support,
+            name="reach_parent_channel_support",
+            dtype=np.dtype(np.uint8),
         ),
         "channel_width_m": _input(
             channel_width_m, name="channel_width_m", dtype=np.dtype(np.float32)
@@ -269,8 +283,30 @@ def run_basin_refinement(
     reach_count = len(arrays["reach_ids"])
     if parent_count == 0 or reach_count == 0:
         raise ValueError("selected basin must contain parent cells and river reaches")
+    for name in (
+        "parent_elevation_m",
+        "parent_relief_m",
+        "parent_area_steradians",
+        "parent_process_excluded",
+    ):
+        if len(arrays[name]) != parent_count:
+            raise ValueError(f"{name} must contain parent_count values")
+    for name in (
+        "reach_from_nodes",
+        "reach_to_nodes",
+        "channel_width_m",
+        "valley_width_m",
+        "floodplain_width_m",
+        "incision_m",
+    ):
+        if len(arrays[name]) != reach_count:
+            raise ValueError(f"{name} must contain reach_count values")
     if len(arrays["reach_offsets"]) != reach_count + 1:
         raise ValueError("reach_offsets must contain reach_count + 1 values")
+    if len(arrays["reach_parent_channel_support"]) != len(arrays["reach_parent_cells"]):
+        raise ValueError(
+            "reach_parent_channel_support must contain one value per reach parent cell"
+        )
 
     config = _ffi.new("RefinementConfig*")
     for name, value in controls.items():
@@ -295,6 +331,7 @@ def run_basin_refinement(
         pointer("parent_elevation_m", "float"),
         pointer("parent_relief_m", "float"),
         pointer("parent_area_steradians", "double"),
+        pointer("parent_process_excluded", "uint8_t"),
         reach_count,
         pointer("reach_ids", "int32_t"),
         pointer("reach_from_nodes", "int32_t"),
@@ -302,6 +339,7 @@ def run_basin_refinement(
         pointer("reach_offsets", "int32_t"),
         len(arrays["reach_parent_cells"]),
         pointer("reach_parent_cells", "int32_t"),
+        pointer("reach_parent_channel_support", "uint8_t"),
         pointer("channel_width_m", "float"),
         pointer("valley_width_m", "float"),
         pointer("floodplain_width_m", "float"),
@@ -319,6 +357,7 @@ def run_basin_refinement(
             3: "invalid or duplicate parent cells",
             4: "invalid inherited reach path or physical attributes",
             5: "fine routing could not satisfy the inherited topology",
+            6: "fine corridor support could not be allocated conservatively",
         }
         raise RuntimeError(
             f"refinement_run_basin failed: {messages.get(status, f'status {status}')}"

--- a/src/map_maker/pipeline/native/hydrology/src/lib.rs
+++ b/src/map_maker/pipeline/native/hydrology/src/lib.rs
@@ -1130,6 +1130,35 @@ fn strahler_orders(order: &[usize], receiver: &[i32], river: &[bool]) -> Vec<i32
     result
 }
 
+fn extend_reach_support(
+    receiver: &[i32],
+    ocean: &[u8],
+    river: &[bool],
+    preserved_waterbody_support: &[bool],
+) -> Vec<bool> {
+    let mut support = river.to_vec();
+    for cell in 0..river.len() {
+        if !river[cell] || receiver[cell] < 0 {
+            continue;
+        }
+        let mut downstream = receiver[cell] as usize;
+        while ocean[downstream] == 0 && !river[downstream] {
+            if !preserved_waterbody_support[downstream] {
+                break;
+            }
+            if support[downstream] {
+                break;
+            }
+            support[downstream] = true;
+            if receiver[downstream] < 0 {
+                break;
+            }
+            downstream = receiver[downstream] as usize;
+        }
+    }
+    support
+}
+
 #[allow(clippy::too_many_arguments)]
 fn extract_reaches(
     order: &[usize],
@@ -1138,6 +1167,7 @@ fn extract_reaches(
     basin_id: &[i32],
     sink_type: &[u8],
     river: &[bool],
+    reach_support: &[bool],
     discharge: &[f64],
     direction: &[f32],
     slope: &[f32],
@@ -1149,21 +1179,26 @@ fn extract_reaches(
 ) -> (Vec<RiverReachRecord>, Vec<i32>) {
     let total = receiver.len();
     let mut upstream_count = vec![0usize; total];
+    let mut transition_entry = vec![false; total];
     for cell in 0..total {
-        if river[cell] && receiver[cell] >= 0 && river[receiver[cell] as usize] {
-            upstream_count[receiver[cell] as usize] += 1;
+        if reach_support[cell] && receiver[cell] >= 0 && reach_support[receiver[cell] as usize] {
+            let downstream = receiver[cell] as usize;
+            upstream_count[downstream] += 1;
+            transition_entry[downstream] |= river[cell] != river[downstream];
         }
     }
     let starts: Vec<usize> = order
         .iter()
         .copied()
-        .filter(|cell| river[*cell] && upstream_count[*cell] != 1)
+        .filter(|cell| {
+            reach_support[*cell] && (upstream_count[*cell] != 1 || transition_entry[*cell])
+        })
         .collect();
     let mut reach_by_start = vec![-1i32; total];
     for (reach_id, start) in starts.iter().enumerate() {
         reach_by_start[*start] = reach_id as i32;
     }
-    let cell_order = strahler_orders(order, receiver, river);
+    let cell_order = strahler_orders(order, receiver, reach_support);
     let mut records = Vec::with_capacity(starts.len());
     let mut vertices = Vec::new();
     for (reach_index, start) in starts.iter().enumerate() {
@@ -1182,7 +1217,11 @@ fn extract_reaches(
                 vertices.push(next as i32);
                 break;
             }
-            if !river[next] {
+            if !reach_support[next] {
+                vertices.push(next as i32);
+                break;
+            }
+            if river[current] != river[next] {
                 vertices.push(next as i32);
                 break;
             }
@@ -1203,6 +1242,7 @@ fn extract_reaches(
         } else {
             -1
         };
+        let is_connector = !river[*start];
         let mut monthly = [0.0f32; MONTHS];
         let mut monthly_velocity = [0.0f32; MONTHS];
         for month in 0..MONTHS {
@@ -1213,7 +1253,11 @@ fn extract_reaches(
                     .sum::<f64>()
                     / MONTHS as f64)
                     .max(0.01) as f32;
-            monthly_velocity[month] = (velocity[*start] * q_ratio.powf(0.16)).clamp(0.08, 10.0);
+            monthly_velocity[month] = if is_connector {
+                0.0
+            } else {
+                (velocity[*start] * q_ratio.powf(0.16)).clamp(0.08, 10.0)
+            };
         }
         let discharge_mean = monthly.iter().sum::<f32>() / MONTHS as f32;
         let slope_mean =
@@ -1256,7 +1300,9 @@ fn extract_reaches(
         .clamp(0.0, 1.0);
         let downstream_is_ocean = receiver[*cells.last().expect("reach cell")] >= 0
             && ocean[receiver[*cells.last().expect("reach cell")] as usize] != 0;
-        let morphology_code = if sink_type[*start] == SINK_ENDORHEIC {
+        let morphology_code = if is_connector {
+            7
+        } else if sink_type[*start] == SINK_ENDORHEIC {
             6
         } else if downstream_is_ocean && floodplain_mean > 0.45 {
             5
@@ -1269,7 +1315,9 @@ fn extract_reaches(
         } else {
             3
         };
-        let bed_material_code = if slope_mean > 0.012 {
+        let bed_material_code = if is_connector {
+            0
+        } else if slope_mean > 0.012 {
             1
         } else if slope_mean > 0.003 {
             2
@@ -1278,9 +1326,13 @@ fn extract_reaches(
         } else {
             4
         };
-        let incision_m = (hydrologic_elevation[*start] - hydrologic_elevation[to_node])
-            .max(0.0)
-            .min(relief_mean.max(0.0));
+        let incision_m = if is_connector {
+            0.0
+        } else {
+            (hydrologic_elevation[*start] - hydrologic_elevation[to_node])
+                .max(0.0)
+                .min(relief_mean.max(0.0))
+        };
         let sediment_load_kg_s = discharge_mean
             * (0.002 + 0.035 * (relief_mean / 1_000.0).clamp(0.0, 3.0))
             * (1.0 + 10.0 * slope_mean).clamp(1.0, 3.0);
@@ -1299,15 +1351,19 @@ fn extract_reaches(
             slope: slope_mean,
             discharge_mean,
             discharge_seasonal: monthly,
-            velocity_mean,
+            velocity_mean: if is_connector { 0.0 } else { velocity_mean },
             velocity_seasonal: monthly_velocity,
-            stream_power: power_mean,
-            channel_width_m,
-            channel_depth_m,
-            valley_width_m,
-            floodplain_width_m,
-            meander_index,
-            braiding_index,
+            stream_power: if is_connector { 0.0 } else { power_mean },
+            channel_width_m: if is_connector { 0.0 } else { channel_width_m },
+            channel_depth_m: if is_connector { 0.0 } else { channel_depth_m },
+            valley_width_m: if is_connector { 0.0 } else { valley_width_m },
+            floodplain_width_m: if is_connector {
+                0.0
+            } else {
+                floodplain_width_m
+            },
+            meander_index: if is_connector { 1.0 } else { meander_index },
+            braiding_index: if is_connector { 0.0 } else { braiding_index },
             incision_m,
             sediment_load_kg_s,
         });
@@ -1547,6 +1603,12 @@ fn run_hydrology(
         relief,
         config,
     );
+    let reach_support = extend_reach_support(
+        &receiver,
+        ocean,
+        &river_properties.river,
+        &preserved_waterbody_support,
+    );
     let (reach_records, reach_vertices) = extract_reaches(
         &order,
         &receiver,
@@ -1554,6 +1616,7 @@ fn run_hydrology(
         &basin_id,
         &sink_type,
         &river_properties.river,
+        &reach_support,
         &discharge,
         &flow_direction,
         &flow_slope,
@@ -1926,6 +1989,27 @@ mod tests {
         let ocean = [1, 0, 0];
         assert!(topological_order(&[-1, 2, 1], &ocean).is_none());
         assert!(topological_order(&[-1, 0, 1], &ocean).is_some());
+    }
+
+    #[test]
+    fn reach_support_bridges_nonriver_depression_cells() {
+        let receiver = [1, 2, 3, 4, 5, -1, 5];
+        let ocean = [0, 0, 0, 0, 0, 1, 0];
+        let river = [true, true, false, false, true, false, false];
+        let preserved = [false, false, true, true, false, false, false];
+        let support = extend_reach_support(&receiver, &ocean, &river, &preserved);
+        assert_eq!(support, vec![true, true, true, true, true, false, false]);
+        assert_eq!(
+            extend_reach_support(&receiver, &ocean, &river, &[false; 7]),
+            river
+        );
+
+        let branched_receiver = [2, 2, 3, -1];
+        let branched_support = [true; 4];
+        assert_eq!(
+            strahler_orders(&[0, 1, 2, 3], &branched_receiver, &branched_support),
+            vec![1, 1, 2, 2]
+        );
     }
 
     #[test]

--- a/src/map_maker/pipeline/native/refinement/src/lib.rs
+++ b/src/map_maker/pipeline/native/refinement/src/lib.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 
 use topology_native::{
     cubed_sphere_cell_area_steradians, cubed_sphere_cell_xyz, cubed_sphere_decode_index,
@@ -10,7 +10,7 @@ const D4_NEIGHBORS: usize = 4;
 
 #[no_mangle]
 pub extern "C" fn refinement_native_abi_version() -> u32 {
-    2
+    3
 }
 
 #[repr(C)]
@@ -117,6 +117,8 @@ struct Inputs<'a> {
     reach_to_nodes: &'a [i32],
     reach_offsets: &'a [i32],
     reach_parent_cells: &'a [i32],
+    reach_parent_channel_support: &'a [u8],
+    parent_process_excluded: &'a [u8],
     channel_width_m: &'a [f32],
     valley_width_m: &'a [f32],
     floodplain_width_m: &'a [f32],
@@ -206,6 +208,7 @@ fn validate_inputs(inputs: &Inputs<'_>) -> Result<(usize, usize), i32> {
     if inputs.parent_elevation_m.len() != parent_count
         || inputs.parent_relief_m.len() != parent_count
         || inputs.parent_area_steradians.len() != parent_count
+        || inputs.parent_process_excluded.len() != parent_count
     {
         return Err(1);
     }
@@ -222,6 +225,11 @@ fn validate_inputs(inputs: &Inputs<'_>) -> Result<(usize, usize), i32> {
     }
     if inputs.reach_offsets.first() != Some(&0)
         || inputs.reach_offsets.last().copied() != Some(inputs.reach_parent_cells.len() as i32)
+        || inputs.reach_parent_channel_support.len() != inputs.reach_parent_cells.len()
+        || inputs
+            .reach_parent_channel_support
+            .iter()
+            .any(|value| *value > 1)
     {
         return Err(4);
     }
@@ -237,6 +245,7 @@ fn validate_inputs(inputs: &Inputs<'_>) -> Result<(usize, usize), i32> {
             || inputs.parent_relief_m[index] < 0.0
             || !inputs.parent_area_steradians[index].is_finite()
             || inputs.parent_area_steradians[index] <= 0.0
+            || inputs.parent_process_excluded[index] > 1
         {
             return Err(3);
         }
@@ -245,11 +254,13 @@ fn validate_inputs(inputs: &Inputs<'_>) -> Result<(usize, usize), i32> {
     for reach_index in 0..reach_count {
         if !reach_set.insert(inputs.reach_ids[reach_index])
             || !inputs.channel_width_m[reach_index].is_finite()
-            || inputs.channel_width_m[reach_index] <= 0.0
+            || inputs.channel_width_m[reach_index] < 0.0
             || !inputs.valley_width_m[reach_index].is_finite()
             || inputs.valley_width_m[reach_index] < inputs.channel_width_m[reach_index]
             || !inputs.floodplain_width_m[reach_index].is_finite()
             || inputs.floodplain_width_m[reach_index] < 0.0
+            || inputs.floodplain_width_m[reach_index] < inputs.channel_width_m[reach_index]
+            || inputs.valley_width_m[reach_index] < inputs.floodplain_width_m[reach_index]
             || !inputs.incision_m[reach_index].is_finite()
             || inputs.incision_m[reach_index] < 0.0
         {
@@ -624,6 +635,504 @@ fn bounded_fraction(numerator: f64, denominator: f64) -> f32 {
     }
 }
 
+#[derive(Clone, Copy)]
+struct CorridorDemand {
+    reach_index: usize,
+    reach_id: i32,
+    path_order: i32,
+    center_cell: i32,
+    length_m: f64,
+}
+
+fn nearby_cells(
+    origin: i32,
+    maximum_hops: usize,
+    fine: usize,
+    cells: &[RefinedCellRecord],
+    local_by_id: &HashMap<i32, usize>,
+    process_excluded: &[bool],
+) -> Vec<i32> {
+    let mut visited = HashSet::from([origin]);
+    let mut queue = VecDeque::from([(origin, 0usize)]);
+    let mut candidates = Vec::<(usize, f32, i32)>::new();
+    while let Some((cell, hops)) = queue.pop_front() {
+        if let Some(&local) = local_by_id.get(&cell) {
+            if process_excluded[local] {
+                continue;
+            }
+            candidates.push((hops, cells[local].terrain_elevation_m, cell));
+        }
+        if hops == maximum_hops {
+            continue;
+        }
+        for slot in 0..D4_NEIGHBORS {
+            let Some(neighbor) = cubed_sphere_neighbor_index(cell as usize, slot, fine) else {
+                continue;
+            };
+            let neighbor = neighbor as i32;
+            if local_by_id.contains_key(&neighbor) && visited.insert(neighbor) {
+                queue.push_back((neighbor, hops + 1));
+            }
+        }
+    }
+    candidates.sort_by(|first, second| {
+        first
+            .0
+            .cmp(&second.0)
+            .then_with(|| first.1.total_cmp(&second.1))
+            .then_with(|| first.2.cmp(&second.2))
+    });
+    candidates.into_iter().map(|(_, _, cell)| cell).collect()
+}
+
+fn corridor_hops(width_m: f64, center_area_m2: f64) -> usize {
+    let cell_width_m = center_area_m2.sqrt().max(1.0);
+    ((width_m / cell_width_m).ceil() as usize + 2).clamp(2, 8)
+}
+
+struct CorridorAllocationContext<'a> {
+    fine: usize,
+    cells: &'a [RefinedCellRecord],
+    local_by_id: &'a HashMap<i32, usize>,
+    process_excluded: &'a [bool],
+}
+
+fn reserve_corridor_area(
+    key: (i32, i32),
+    local: usize,
+    amount_m2: f64,
+    allocations: &mut HashMap<(i32, i32), f64>,
+    global_used_m2: &mut [f64],
+    cells: &[RefinedCellRecord],
+) -> Result<(), i32> {
+    let capacity_m2 = cells[local].area_km2 * 1_000_000.0;
+    if global_used_m2[local] + amount_m2 > capacity_m2 + 1e-6 {
+        return Err(6);
+    }
+    *allocations.entry(key).or_insert(0.0) += amount_m2;
+    global_used_m2[local] += amount_m2;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn allocate_corridor_demand(
+    demand: CorridorDemand,
+    width_m: f64,
+    reserved_m2: f64,
+    allocations: &mut HashMap<(i32, i32), f64>,
+    global_used_m2: &mut [f64],
+    upper_bound: Option<&HashMap<(i32, i32), f64>>,
+    path_orders: &mut HashMap<(i32, i32), i32>,
+    context: &CorridorAllocationContext<'_>,
+) -> Result<(), i32> {
+    let requested_m2 = width_m * demand.length_m;
+    let mut remaining_m2 = (requested_m2 - reserved_m2).max(0.0);
+    if remaining_m2 <= 1e-6 {
+        return Ok(());
+    }
+    let center_local = *context.local_by_id.get(&demand.center_cell).ok_or(6)?;
+    let maximum_hops = corridor_hops(width_m, context.cells[center_local].area_km2 * 1_000_000.0);
+    for fine_cell in nearby_cells(
+        demand.center_cell,
+        maximum_hops,
+        context.fine,
+        context.cells,
+        context.local_by_id,
+        context.process_excluded,
+    ) {
+        let local = *context.local_by_id.get(&fine_cell).ok_or(6)?;
+        let key = (demand.reach_id, fine_cell);
+        let cell_area_m2 = context.cells[local].area_km2 * 1_000_000.0;
+        let global_available = (cell_area_m2 - global_used_m2[local]).max(0.0);
+        let nested_available = upper_bound.map_or(f64::INFINITY, |upper| {
+            (upper.get(&key).copied().unwrap_or(0.0)
+                - allocations.get(&key).copied().unwrap_or(0.0))
+            .max(0.0)
+        });
+        let allocated_m2 = remaining_m2.min(global_available).min(nested_available);
+        if allocated_m2 <= 0.0 {
+            continue;
+        }
+        *allocations.entry(key).or_insert(0.0) += allocated_m2;
+        global_used_m2[local] += allocated_m2;
+        path_orders
+            .entry(key)
+            .and_modify(|order| *order = (*order).min(demand.path_order))
+            .or_insert(demand.path_order);
+        remaining_m2 -= allocated_m2;
+        if remaining_m2 <= requested_m2.max(1.0) * 1e-12 {
+            return Ok(());
+        }
+    }
+    Err(6)
+}
+
+fn demand_allocation_capacity(
+    demand: CorridorDemand,
+    width_m: f64,
+    reserved_m2: f64,
+    allocations: &HashMap<(i32, i32), f64>,
+    global_used_m2: &[f64],
+    upper_bound: Option<&HashMap<(i32, i32), f64>>,
+    context: &CorridorAllocationContext<'_>,
+) -> (f64, f64) {
+    let requested_m2 = (width_m * demand.length_m - reserved_m2).max(0.0);
+    let center_local = match context.local_by_id.get(&demand.center_cell) {
+        Some(local) => *local,
+        None => return (requested_m2, 0.0),
+    };
+    let maximum_hops = corridor_hops(width_m, context.cells[center_local].area_km2 * 1_000_000.0);
+    let available_m2 = nearby_cells(
+        demand.center_cell,
+        maximum_hops,
+        context.fine,
+        context.cells,
+        context.local_by_id,
+        context.process_excluded,
+    )
+    .into_iter()
+    .map(|fine_cell| {
+        let local = context.local_by_id[&fine_cell];
+        let key = (demand.reach_id, fine_cell);
+        let cell_area_m2 = context.cells[local].area_km2 * 1_000_000.0;
+        let global_available = (cell_area_m2 - global_used_m2[local]).max(0.0);
+        let nested_available = upper_bound.map_or(f64::INFINITY, |upper| {
+            (upper.get(&key).copied().unwrap_or(0.0)
+                - allocations.get(&key).copied().unwrap_or(0.0))
+            .max(0.0)
+        });
+        global_available.min(nested_available)
+    })
+    .sum();
+    (requested_m2, available_m2)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn allocate_corridor_demands(
+    demands: &[CorridorDemand],
+    widths_m: &[f32],
+    reserved_widths_m: &[f32],
+    allocations: &mut HashMap<(i32, i32), f64>,
+    global_used_m2: &mut [f64],
+    upper_bound: Option<&HashMap<(i32, i32), f64>>,
+    path_orders: &mut HashMap<(i32, i32), i32>,
+    context: &CorridorAllocationContext<'_>,
+) -> Result<(), i32> {
+    let baseline_allocations = allocations.clone();
+    let baseline_used = global_used_m2.to_vec();
+    let baseline_path_orders = path_orders.clone();
+    for attempt in 0..3 {
+        let mut trial_allocations = baseline_allocations.clone();
+        let mut trial_used = baseline_used.clone();
+        let mut trial_path_orders = baseline_path_orders.clone();
+        let mut order = demands.to_vec();
+        if attempt == 0 {
+            let mut scored = order
+                .into_iter()
+                .map(|demand| {
+                    let reserved_m2 =
+                        reserved_widths_m[demand.reach_index] as f64 * demand.length_m;
+                    let (requested, available) = demand_allocation_capacity(
+                        demand,
+                        widths_m[demand.reach_index] as f64,
+                        reserved_m2,
+                        &baseline_allocations,
+                        &baseline_used,
+                        upper_bound,
+                        context,
+                    );
+                    (demand, available - requested, available, requested)
+                })
+                .collect::<Vec<_>>();
+            scored.sort_by(|first, second| {
+                first
+                    .1
+                    .total_cmp(&second.1)
+                    .then_with(|| first.2.total_cmp(&second.2))
+                    .then_with(|| second.3.total_cmp(&first.3))
+                    .then_with(|| first.0.reach_id.cmp(&second.0.reach_id))
+                    .then_with(|| first.0.path_order.cmp(&second.0.path_order))
+            });
+            order = scored.into_iter().map(|entry| entry.0).collect();
+        } else if attempt == 1 {
+            order.sort_by(|first, second| {
+                widths_m[second.reach_index]
+                    .total_cmp(&widths_m[first.reach_index])
+                    .then_with(|| first.reach_id.cmp(&second.reach_id))
+                    .then_with(|| first.path_order.cmp(&second.path_order))
+            });
+        } else {
+            order.sort_by(|first, second| {
+                second
+                    .reach_id
+                    .cmp(&first.reach_id)
+                    .then_with(|| second.path_order.cmp(&first.path_order))
+            });
+        }
+        let succeeded = order.into_iter().all(|demand| {
+            let reserved_m2 = reserved_widths_m[demand.reach_index] as f64 * demand.length_m;
+            allocate_corridor_demand(
+                demand,
+                widths_m[demand.reach_index] as f64,
+                reserved_m2,
+                &mut trial_allocations,
+                &mut trial_used,
+                upper_bound,
+                &mut trial_path_orders,
+                context,
+            )
+            .is_ok()
+        });
+        if succeeded {
+            *allocations = trial_allocations;
+            global_used_m2.copy_from_slice(&trial_used);
+            *path_orders = trial_path_orders;
+            return Ok(());
+        }
+    }
+    Err(6)
+}
+
+fn allocate_nested_corridor_by_reach(
+    demands: &[CorridorDemand],
+    widths_m: &[f32],
+    allocations: &mut HashMap<(i32, i32), f64>,
+    global_used_m2: &mut [f64],
+    upper_bound: &HashMap<(i32, i32), f64>,
+    path_orders: &HashMap<(i32, i32), i32>,
+    context: &CorridorAllocationContext<'_>,
+) -> Result<(), i32> {
+    let mut upper_entries = upper_bound
+        .iter()
+        .map(|(key, area)| (*key, *area))
+        .collect::<Vec<_>>();
+    upper_entries.sort_by_key(|(key, _)| *key);
+    let mut upper_by_cell = vec![0.0f64; context.cells.len()];
+    for ((reach_id, fine_cell), area_m2) in upper_entries {
+        if !area_m2.is_finite() || area_m2 < 0.0 {
+            return Err(6);
+        }
+        let local = *context.local_by_id.get(&fine_cell).ok_or(6)?;
+        upper_by_cell[local] += area_m2;
+        let cell_area_m2 = context.cells[local].area_km2 * 1_000_000.0;
+        if upper_by_cell[local] > cell_area_m2 + 1e-6
+            || allocations
+                .get(&(reach_id, fine_cell))
+                .is_some_and(|allocated| *allocated > area_m2 + 1e-6)
+        {
+            return Err(6);
+        }
+    }
+    let mut requested_by_reach = HashMap::<i32, f64>::new();
+    for demand in demands {
+        *requested_by_reach.entry(demand.reach_id).or_insert(0.0) +=
+            widths_m[demand.reach_index] as f64 * demand.length_m;
+    }
+    let mut reach_ids = requested_by_reach.keys().copied().collect::<Vec<_>>();
+    reach_ids.sort_unstable();
+    for reach_id in reach_ids {
+        let requested_m2 = requested_by_reach[&reach_id];
+        let mut represented_entries = allocations
+            .iter()
+            .filter_map(|((allocated_reach, fine_cell), area)| {
+                (*allocated_reach == reach_id).then_some((*fine_cell, *area))
+            })
+            .collect::<Vec<_>>();
+        represented_entries.sort_by_key(|entry| entry.0);
+        let represented_m2 = represented_entries
+            .into_iter()
+            .map(|(_, area)| area)
+            .sum::<f64>();
+        let mut remaining_m2 = (requested_m2 - represented_m2).max(0.0);
+        let mut candidates = upper_bound
+            .iter()
+            .filter_map(|(&(candidate_reach, fine_cell), &upper_area)| {
+                if candidate_reach != reach_id {
+                    return None;
+                }
+                let key = (reach_id, fine_cell);
+                let available =
+                    (upper_area - allocations.get(&key).copied().unwrap_or(0.0)).max(0.0);
+                (available > 0.0).then_some((
+                    *path_orders.get(&key).unwrap_or(&i32::MAX),
+                    fine_cell,
+                    available,
+                ))
+            })
+            .collect::<Vec<_>>();
+        candidates
+            .sort_by(|first, second| first.0.cmp(&second.0).then_with(|| first.1.cmp(&second.1)));
+        for (_, fine_cell, available_m2) in candidates {
+            let local = *context.local_by_id.get(&fine_cell).ok_or(6)?;
+            let cell_area_m2 = context.cells[local].area_km2 * 1_000_000.0;
+            let global_available_m2 = (cell_area_m2 - global_used_m2[local]).max(0.0);
+            let amount_m2 = remaining_m2.min(available_m2).min(global_available_m2);
+            if amount_m2 <= 0.0 {
+                continue;
+            }
+            *allocations.entry((reach_id, fine_cell)).or_insert(0.0) += amount_m2;
+            global_used_m2[local] += amount_m2;
+            remaining_m2 -= amount_m2;
+            if remaining_m2 <= requested_m2.max(1.0) * 1e-12 {
+                break;
+            }
+        }
+        if remaining_m2 > requested_m2.max(1.0) * 1e-12 {
+            return Err(6);
+        }
+    }
+    Ok(())
+}
+
+fn realize_corridor_memberships(
+    inputs: &Inputs<'_>,
+    fine: usize,
+    cells: &[RefinedCellRecord],
+    local_by_id: &HashMap<i32, usize>,
+    centerline_memberships: Vec<ReachCellRecord>,
+) -> Result<Vec<ReachCellRecord>, i32> {
+    let reach_index_by_id = inputs
+        .reach_ids
+        .iter()
+        .enumerate()
+        .map(|(index, reach_id)| (*reach_id, index))
+        .collect::<HashMap<_, _>>();
+    let mut centerline = HashMap::<(i32, i32), ReachCellRecord>::new();
+    let mut path_orders = HashMap::<(i32, i32), i32>::new();
+    let mut demands = Vec::<CorridorDemand>::with_capacity(centerline_memberships.len());
+    let mut channel_used_m2 = vec![0.0f64; cells.len()];
+    let excluded_parents = inputs
+        .parent_ids
+        .iter()
+        .zip(inputs.parent_process_excluded)
+        .filter_map(|(parent, excluded)| (*excluded != 0).then_some(*parent))
+        .collect::<HashSet<_>>();
+    let process_excluded = cells
+        .iter()
+        .map(|cell| excluded_parents.contains(&cell.parent_cell_id))
+        .collect::<Vec<_>>();
+    for mut record in centerline_memberships {
+        let reach_index = *reach_index_by_id.get(&record.reach_id).ok_or(6)?;
+        let local = *local_by_id.get(&record.fine_cell_id).ok_or(6)?;
+        if process_excluded[local] {
+            return Err(6);
+        }
+        let cell_area_m2 = cells[local].area_km2 * 1_000_000.0;
+        let channel_area_m2 = inputs.channel_width_m[reach_index] as f64 * record.reach_length_m;
+        channel_used_m2[local] += channel_area_m2;
+        if channel_used_m2[local] > cell_area_m2 + 1e-6 {
+            return Err(6);
+        }
+        demands.push(CorridorDemand {
+            reach_index,
+            reach_id: record.reach_id,
+            path_order: record.path_order,
+            center_cell: record.fine_cell_id,
+            length_m: record.reach_length_m,
+        });
+        record.valley_fraction = 0.0;
+        record.floodplain_fraction = 0.0;
+        let key = (record.reach_id, record.fine_cell_id);
+        path_orders.insert(key, record.path_order);
+        centerline.insert(key, record);
+    }
+
+    let context = CorridorAllocationContext {
+        fine,
+        cells,
+        local_by_id,
+        process_excluded: &process_excluded,
+    };
+    let mut valley_allocations = HashMap::<(i32, i32), f64>::new();
+    let mut floodplain_allocations = HashMap::<(i32, i32), f64>::new();
+    let mut valley_used_m2 = vec![0.0f64; cells.len()];
+    let mut floodplain_used_m2 = vec![0.0f64; cells.len()];
+
+    for demand in &demands {
+        let channel_m2 = inputs.channel_width_m[demand.reach_index] as f64 * demand.length_m;
+        if channel_m2 <= 0.0 {
+            continue;
+        }
+        let local = *local_by_id.get(&demand.center_cell).ok_or(6)?;
+        let key = (demand.reach_id, demand.center_cell);
+        reserve_corridor_area(
+            key,
+            local,
+            channel_m2,
+            &mut valley_allocations,
+            &mut valley_used_m2,
+            cells,
+        )?;
+        reserve_corridor_area(
+            key,
+            local,
+            channel_m2,
+            &mut floodplain_allocations,
+            &mut floodplain_used_m2,
+            cells,
+        )?;
+    }
+
+    allocate_corridor_demands(
+        &demands,
+        inputs.valley_width_m,
+        inputs.channel_width_m,
+        &mut valley_allocations,
+        &mut valley_used_m2,
+        None,
+        &mut path_orders,
+        &context,
+    )?;
+
+    allocate_nested_corridor_by_reach(
+        &demands,
+        inputs.floodplain_width_m,
+        &mut floodplain_allocations,
+        &mut floodplain_used_m2,
+        &valley_allocations,
+        &path_orders,
+        &context,
+    )?;
+
+    let mut keys = centerline.keys().copied().collect::<HashSet<_>>();
+    keys.extend(valley_allocations.keys().copied());
+    keys.extend(floodplain_allocations.keys().copied());
+    let mut memberships = Vec::with_capacity(keys.len());
+    for key in keys {
+        let local = *local_by_id.get(&key.1).ok_or(6)?;
+        let cell = cells[local];
+        let cell_area_m2 = cell.area_km2 * 1_000_000.0;
+        let mut record = centerline.get(&key).copied().unwrap_or(ReachCellRecord {
+            reach_id: key.0,
+            fine_cell_id: key.1,
+            parent_cell_id: cell.parent_cell_id,
+            path_order: *path_orders.get(&key).ok_or(6)?,
+            reach_length_m: 0.0,
+            channel_fraction: 0.0,
+            valley_fraction: 0.0,
+            floodplain_fraction: 0.0,
+            potential_incised_volume_m3: 0.0,
+        });
+        record.valley_fraction = bounded_fraction(
+            valley_allocations.get(&key).copied().unwrap_or(0.0),
+            cell_area_m2,
+        );
+        record.floodplain_fraction = bounded_fraction(
+            floodplain_allocations.get(&key).copied().unwrap_or(0.0),
+            cell_area_m2,
+        );
+        memberships.push(record);
+    }
+    memberships.sort_by(|first, second| {
+        first
+            .reach_id
+            .cmp(&second.reach_id)
+            .then_with(|| first.path_order.cmp(&second.path_order))
+            .then_with(|| first.fine_cell_id.cmp(&second.fine_cell_id))
+    });
+    Ok(memberships)
+}
+
 fn refine_reaches(
     inputs: &Inputs<'_>,
     fine: usize,
@@ -632,6 +1141,12 @@ fn refine_reaches(
     ranges: &ParentRanges,
 ) -> Result<ReachGeneration, i32> {
     let factor = inputs.config.factor as usize;
+    let excluded_parent_ids = inputs
+        .parent_ids
+        .iter()
+        .zip(inputs.parent_process_excluded)
+        .filter_map(|(parent, excluded)| (*excluded != 0).then_some(*parent))
+        .collect::<HashSet<_>>();
     let mut anchors = HashMap::<i32, i32>::new();
     for &node in inputs.reach_from_nodes.iter().chain(inputs.reach_to_nodes) {
         if let std::collections::hash_map::Entry::Vacant(entry) = anchors.entry(node) {
@@ -664,6 +1179,17 @@ fn refine_reaches(
         let coarse_start = inputs.reach_offsets[reach_index] as usize;
         let coarse_end = inputs.reach_offsets[reach_index + 1] as usize;
         let coarse_path = &inputs.reach_parent_cells[coarse_start..coarse_end];
+        let supported_parents = coarse_path
+            .iter()
+            .zip(&inputs.reach_parent_channel_support[coarse_start..coarse_end])
+            .filter_map(|(parent, supported)| (*supported != 0).then_some(*parent))
+            .collect::<HashSet<_>>();
+        if supported_parents
+            .iter()
+            .any(|parent| excluded_parent_ids.contains(parent))
+        {
+            return Err(4);
+        }
         let mut transitions = Vec::with_capacity(coarse_path.len() - 1);
         for pair in coarse_path.windows(2) {
             let key = (pair[0], pair[1]);
@@ -762,12 +1288,13 @@ fn refine_reaches(
         });
 
         let channel_width = inputs.channel_width_m[reach_index] as f64;
-        let valley_width = inputs.valley_width_m[reach_index] as f64;
-        let floodplain_width = inputs.floodplain_width_m[reach_index] as f64;
         let incision = inputs.incision_m[reach_index] as f64;
         for (path_order, (&fine_cell, &length)) in path.iter().zip(&cell_lengths).enumerate() {
             let local = *local_by_id.get(&fine_cell).ok_or(5)?;
             let cell = cells[local];
+            if channel_width <= 0.0 || !supported_parents.contains(&cell.parent_cell_id) {
+                continue;
+            }
             let area_m2 = cell.area_km2 * 1_000_000.0;
             memberships.push(ReachCellRecord {
                 reach_id: inputs.reach_ids[reach_index],
@@ -776,12 +1303,13 @@ fn refine_reaches(
                 path_order: path_order as i32,
                 reach_length_m: length,
                 channel_fraction: bounded_fraction(channel_width * length, area_m2),
-                valley_fraction: bounded_fraction(valley_width * length, area_m2),
-                floodplain_fraction: bounded_fraction(floodplain_width * length, area_m2),
+                valley_fraction: 0.0,
+                floodplain_fraction: 0.0,
                 potential_incised_volume_m3: channel_width * length * incision,
             });
         }
     }
+    let memberships = realize_corridor_memberships(inputs, fine, cells, local_by_id, memberships)?;
     Ok((reach_records, all_path_cells, memberships))
 }
 
@@ -900,6 +1428,7 @@ pub unsafe extern "C" fn refinement_run_basin(
     parent_elevation_m: *const f32,
     parent_relief_m: *const f32,
     parent_area_steradians: *const f64,
+    parent_process_excluded: *const u8,
     reach_count: i32,
     reach_ids: *const i32,
     reach_from_nodes: *const i32,
@@ -907,6 +1436,7 @@ pub unsafe extern "C" fn refinement_run_basin(
     reach_offsets: *const i32,
     reach_parent_cell_count: i32,
     reach_parent_cells: *const i32,
+    reach_parent_channel_support: *const u8,
     channel_width_m: *const f32,
     valley_width_m: *const f32,
     floodplain_width_m: *const f32,
@@ -923,6 +1453,7 @@ pub unsafe extern "C" fn refinement_run_basin(
         || parent_elevation_m.is_null()
         || parent_relief_m.is_null()
         || parent_area_steradians.is_null()
+        || parent_process_excluded.is_null()
         || reach_count <= 0
         || reach_ids.is_null()
         || reach_from_nodes.is_null()
@@ -930,6 +1461,7 @@ pub unsafe extern "C" fn refinement_run_basin(
         || reach_offsets.is_null()
         || reach_parent_cell_count <= 0
         || reach_parent_cells.is_null()
+        || reach_parent_channel_support.is_null()
         || channel_width_m.is_null()
         || valley_width_m.is_null()
         || floodplain_width_m.is_null()
@@ -955,12 +1487,20 @@ pub unsafe extern "C" fn refinement_run_basin(
                 parent_area_steradians,
                 parent_count,
             ),
+            parent_process_excluded: std::slice::from_raw_parts(
+                parent_process_excluded,
+                parent_count,
+            ),
             reach_ids: std::slice::from_raw_parts(reach_ids, reach_count),
             reach_from_nodes: std::slice::from_raw_parts(reach_from_nodes, reach_count),
             reach_to_nodes: std::slice::from_raw_parts(reach_to_nodes, reach_count),
             reach_offsets: std::slice::from_raw_parts(reach_offsets, reach_count + 1),
             reach_parent_cells: std::slice::from_raw_parts(
                 reach_parent_cells,
+                reach_parent_cell_count,
+            ),
+            reach_parent_channel_support: std::slice::from_raw_parts(
+                reach_parent_channel_support,
                 reach_parent_cell_count,
             ),
             channel_width_m: std::slice::from_raw_parts(channel_width_m, reach_count),
@@ -1062,6 +1602,8 @@ mod tests {
         let to = [second];
         let offsets = [0i32, 2];
         let path = [first, second];
+        let channel_support = [1u8, 0];
+        let process_excluded = [0u8, 1];
         let channel = [40.0f32];
         let valley = [1_200.0f32];
         let floodplain = [600.0f32];
@@ -1078,11 +1620,13 @@ mod tests {
             parent_elevation_m: &elevations,
             parent_relief_m: &relief,
             parent_area_steradians: &areas,
+            parent_process_excluded: &process_excluded,
             reach_ids: &reach_ids,
             reach_from_nodes: &from,
             reach_to_nodes: &to,
             reach_offsets: &offsets,
             reach_parent_cells: &path,
+            reach_parent_channel_support: &channel_support,
             channel_width_m: &channel,
             valley_width_m: &valley,
             floodplain_width_m: &floodplain,
@@ -1096,6 +1640,10 @@ mod tests {
         assert_eq!(result.stats.path_topology_valid, 1);
         assert!(result.stats.maximum_parent_area_relative_error < 1e-12);
         assert!(result.stats.maximum_parent_elevation_error_m < 1e-3);
+        assert!(result
+            .memberships
+            .iter()
+            .all(|record| record.parent_cell_id == first));
         assert!(result
             .memberships
             .iter()
@@ -1128,6 +1676,8 @@ mod tests {
         let to = [second];
         let offsets = [0i32, 2];
         let path = [first, second];
+        let channel_support = [1u8, 1];
+        let process_excluded = [0u8, 0];
         let channel = [25.0f32];
         let valley = [800.0f32];
         let floodplain = [500.0f32];
@@ -1144,11 +1694,13 @@ mod tests {
             parent_elevation_m: &elevations,
             parent_relief_m: &relief,
             parent_area_steradians: &areas,
+            parent_process_excluded: &process_excluded,
             reach_ids: &reach_ids,
             reach_from_nodes: &from,
             reach_to_nodes: &to,
             reach_offsets: &offsets,
             reach_parent_cells: &path,
+            reach_parent_channel_support: &channel_support,
             channel_width_m: &channel,
             valley_width_m: &valley,
             floodplain_width_m: &floodplain,
@@ -1170,5 +1722,230 @@ mod tests {
             }
         }
         assert_eq!(collapsed, path);
+    }
+
+    #[test]
+    fn wide_corridors_spread_laterally_and_conserve_area() {
+        let coarse = 128usize;
+        let first = cubed_sphere_global_index(0, 64, 63, coarse).unwrap() as i32;
+        let second = cubed_sphere_global_index(0, 64, 64, coarse).unwrap() as i32;
+        let parent_ids = [first, second];
+        let elevations = [140.0f32, 90.0];
+        let relief = [120.0f32, 80.0];
+        let areas = [parent_area(first, coarse), parent_area(second, coarse)];
+        let reach_ids = [11i32];
+        let from = [first];
+        let to = [second];
+        let offsets = [0i32, 2];
+        let path = [first, second];
+        let channel_support = [1u8, 1];
+        let process_excluded = [0u8, 0];
+        let channel = [120.0f32];
+        let valley = [8_000.0f32];
+        let floodplain = [6_000.0f32];
+        let incision = [18.0f32];
+        let inputs = Inputs {
+            config: RefinementConfig {
+                coarse_resolution: coarse as i32,
+                factor: 16,
+                planet_radius_m: 6_371_000.0,
+                terrain_seed: 91,
+                terrain_noise_fraction: 0.4,
+            },
+            parent_ids: &parent_ids,
+            parent_elevation_m: &elevations,
+            parent_relief_m: &relief,
+            parent_area_steradians: &areas,
+            parent_process_excluded: &process_excluded,
+            reach_ids: &reach_ids,
+            reach_from_nodes: &from,
+            reach_to_nodes: &to,
+            reach_offsets: &offsets,
+            reach_parent_cells: &path,
+            reach_parent_channel_support: &channel_support,
+            channel_width_m: &channel,
+            valley_width_m: &valley,
+            floodplain_width_m: &floodplain,
+            incision_m: &incision,
+        };
+        let result = run_refinement(&inputs).unwrap();
+        assert!(result
+            .memberships
+            .iter()
+            .any(|record| record.reach_length_m == 0.0 && record.valley_fraction > 0.0));
+        let requested_valley_km2 = result.reaches[0].path_length_m * valley[0] as f64 / 1_000_000.0;
+        let requested_floodplain_km2 =
+            result.reaches[0].path_length_m * floodplain[0] as f64 / 1_000_000.0;
+        assert!(
+            (result.stats.represented_valley_area_km2 / requested_valley_km2 - 1.0).abs() < 1e-6
+        );
+        assert!(
+            (result.stats.represented_floodplain_area_km2 / requested_floodplain_km2 - 1.0).abs()
+                < 1e-6
+        );
+        let mut valley_by_cell = HashMap::<i32, f64>::new();
+        for record in &result.memberships {
+            *valley_by_cell.entry(record.fine_cell_id).or_insert(0.0) +=
+                record.valley_fraction as f64;
+            assert!(record.channel_fraction <= record.floodplain_fraction + 1e-7);
+            assert!(record.floodplain_fraction <= record.valley_fraction + 1e-7);
+        }
+        assert!(valley_by_cell
+            .values()
+            .all(|fraction| *fraction <= 1.0 + 1e-6));
+    }
+
+    #[test]
+    fn corridor_allocator_prioritizes_spatially_constrained_demands() {
+        let fine = 16usize;
+        let cells = (3..=9)
+            .map(|col| RefinedCellRecord {
+                fine_cell_id: cubed_sphere_global_index(0, 8, col, fine).unwrap() as i32,
+                parent_cell_id: col as i32,
+                face: 0,
+                row: 8,
+                col: col as i32,
+                xyz: [1.0, 0.0, 0.0],
+                area_km2: 1e-6,
+                terrain_elevation_m: 0.0,
+                terrain_offset_m: 0.0,
+                parent_relief_m: 0.0,
+            })
+            .collect::<Vec<_>>();
+        let local_by_id = cells
+            .iter()
+            .enumerate()
+            .map(|(local, cell)| (cell.fine_cell_id, local))
+            .collect::<HashMap<_, _>>();
+        let excluded = vec![false; cells.len()];
+        let context = CorridorAllocationContext {
+            fine,
+            cells: &cells,
+            local_by_id: &local_by_id,
+            process_excluded: &excluded,
+        };
+        let demands = [
+            CorridorDemand {
+                reach_index: 0,
+                reach_id: 1,
+                path_order: 0,
+                center_cell: cells[3].fine_cell_id,
+                length_m: 3.5,
+            },
+            CorridorDemand {
+                reach_index: 1,
+                reach_id: 2,
+                path_order: 0,
+                center_cell: cells[0].fine_cell_id,
+                length_m: 3.125,
+            },
+        ];
+        let widths = [1.0f32, 0.8];
+        let reserved = [0.0f32, 0.0];
+        let mut allocations = HashMap::new();
+        let mut used = vec![0.0; cells.len()];
+        let mut path_orders = HashMap::new();
+        allocate_corridor_demands(
+            &demands,
+            &widths,
+            &reserved,
+            &mut allocations,
+            &mut used,
+            None,
+            &mut path_orders,
+            &context,
+        )
+        .unwrap();
+        let allocated = |reach_id| {
+            allocations
+                .iter()
+                .filter_map(|((reach, _), area)| (*reach == reach_id).then_some(*area))
+                .sum::<f64>()
+        };
+        assert!((allocated(1) - 3.5).abs() < 1e-6);
+        assert!((allocated(2) - 2.5).abs() < 1e-6);
+        assert!(used.iter().all(|area| *area <= 1.0 + 1e-9));
+    }
+
+    #[test]
+    fn nested_corridors_share_cell_capacity_across_reaches() {
+        let fine = 16usize;
+        let cells = (3..=5)
+            .map(|col| RefinedCellRecord {
+                fine_cell_id: cubed_sphere_global_index(0, 8, col, fine).unwrap() as i32,
+                parent_cell_id: col as i32,
+                face: 0,
+                row: 8,
+                col: col as i32,
+                xyz: [1.0, 0.0, 0.0],
+                area_km2: 1e-6,
+                terrain_elevation_m: 0.0,
+                terrain_offset_m: 0.0,
+                parent_relief_m: 0.0,
+            })
+            .collect::<Vec<_>>();
+        let local_by_id = cells
+            .iter()
+            .enumerate()
+            .map(|(local, cell)| (cell.fine_cell_id, local))
+            .collect::<HashMap<_, _>>();
+        let excluded = vec![false; cells.len()];
+        let context = CorridorAllocationContext {
+            fine,
+            cells: &cells,
+            local_by_id: &local_by_id,
+            process_excluded: &excluded,
+        };
+        let demands = [
+            CorridorDemand {
+                reach_index: 0,
+                reach_id: 1,
+                path_order: 0,
+                center_cell: cells[0].fine_cell_id,
+                length_m: 1.0,
+            },
+            CorridorDemand {
+                reach_index: 1,
+                reach_id: 2,
+                path_order: 0,
+                center_cell: cells[2].fine_cell_id,
+                length_m: 1.0,
+            },
+        ];
+        let widths = [0.8f32, 0.8];
+        let upper = HashMap::from([
+            ((1, cells[0].fine_cell_id), 0.4),
+            ((1, cells[1].fine_cell_id), 0.6),
+            ((2, cells[1].fine_cell_id), 0.4),
+            ((2, cells[2].fine_cell_id), 0.6),
+        ]);
+        let path_orders = HashMap::from([
+            ((1, cells[0].fine_cell_id), 1),
+            ((1, cells[1].fine_cell_id), 0),
+            ((2, cells[1].fine_cell_id), 0),
+            ((2, cells[2].fine_cell_id), 1),
+        ]);
+        let mut allocations = HashMap::new();
+        let mut used = vec![0.0; cells.len()];
+        allocate_nested_corridor_by_reach(
+            &demands,
+            &widths,
+            &mut allocations,
+            &mut used,
+            &upper,
+            &path_orders,
+            &context,
+        )
+        .unwrap();
+        for reach_id in [1, 2] {
+            let allocated = allocations
+                .iter()
+                .filter_map(|((reach, _), area)| (*reach == reach_id).then_some(*area))
+                .sum::<f64>();
+            assert!((allocated - 0.8).abs() < 1e-6);
+        }
+        assert!((allocations[&(1, cells[1].fine_cell_id)] - 0.6).abs() < 1e-9);
+        assert!((allocations[&(2, cells[1].fine_cell_id)] - 0.4).abs() < 1e-9);
+        assert!(used.iter().all(|area| *area <= 1.0 + 1e-9));
     }
 }

--- a/src/map_maker/pipeline/stages/basin_refinement.py
+++ b/src/map_maker/pipeline/stages/basin_refinement.py
@@ -164,6 +164,7 @@ def _parent_table(
     parent_elevation_m: np.ndarray,
     parent_relief_m: np.ndarray,
     parent_areas_km2: np.ndarray,
+    parent_process_excluded: np.ndarray,
     factor: int,
 ) -> pa.Table:
     children_per_parent = factor * factor
@@ -178,6 +179,7 @@ def _parent_table(
         {
             "parent_cell_id": pa.array(parent_ids, type=pa.int32()),
             "inside_selected_basin": pa.array(inside_selected_basin, type=pa.bool_()),
+            "process_excluded": pa.array(parent_process_excluded != 0, type=pa.bool_()),
             "child_count": pa.array(
                 np.full(len(parent_ids), children_per_parent, dtype=np.int32), type=pa.int32()
             ),
@@ -257,6 +259,7 @@ def _reach_table(
             "reach_id": source["reach_id"],
             "parent_reach_id": source["reach_id"],
             "basin_id": source["basin_id"],
+            "reach_kind": source["reach_kind"],
             "from_parent_cell": source["from_node"],
             "to_parent_cell": source["to_node"],
             "downstream_reach_id": source["downstream_reach_id"],
@@ -435,7 +438,7 @@ def _classify_reach_terminals(
 def _corridor_area_metadata(
     reaches: pa.Table, metadata: Mapping[str, int | float]
 ) -> dict[str, float]:
-    path_length_m = np.asarray(reaches["path_length_km"], dtype=np.float64) * 1_000.0
+    path_length_m = np.asarray(reaches["physical_channel_length_km"], dtype=np.float64) * 1_000.0
     result: dict[str, float] = {}
     for corridor in ("channel", "valley", "floodplain"):
         requested = float(
@@ -456,6 +459,10 @@ def _membership_table(records: np.ndarray) -> pa.Table:
             "parent_cell_id": pa.array(records["parent_cell_id"], type=pa.int32()),
             "path_order": pa.array(records["path_order"], type=pa.int32()),
             "reach_length_m": pa.array(records["reach_length_m"], type=pa.float64()),
+            "support_role": pa.array(
+                np.where(records["reach_length_m"] > 0.0, "centerline", "lateral"),
+                type=pa.string(),
+            ),
             "channel_fraction": pa.array(records["channel_fraction"], type=pa.float32()),
             "valley_fraction": pa.array(records["valley_fraction"], type=pa.float32()),
             "floodplain_fraction": pa.array(records["floodplain_fraction"], type=pa.float32()),
@@ -466,9 +473,54 @@ def _membership_table(records: np.ndarray) -> pa.Table:
     )
 
 
+def _append_physical_reach_lengths(reaches: pa.Table, memberships: pa.Table) -> pa.Table:
+    reach_ids = np.asarray(reaches["reach_id"], dtype=np.int32)
+    row_by_reach = {int(reach_id): row for row, reach_id in enumerate(reach_ids)}
+    physical_length_m = np.zeros(reaches.num_rows, dtype=np.float64)
+    for reach_id, length_m in zip(
+        np.asarray(memberships["reach_id"], dtype=np.int32),
+        np.asarray(memberships["reach_length_m"], dtype=np.float64),
+        strict=True,
+    ):
+        physical_length_m[row_by_reach[int(reach_id)]] += float(length_m)
+    return reaches.append_column(
+        "physical_channel_length_km", pa.array(physical_length_m / 1_000.0, type=pa.float64())
+    )
+
+
+def _corridor_capacity_metadata(memberships: pa.Table) -> dict[str, int | float]:
+    fine_cell_ids = np.asarray(memberships["fine_cell_id"], dtype=np.int32)
+    _, inverse = np.unique(fine_cell_ids, return_inverse=True)
+    metadata: dict[str, int | float] = {
+        "centerline_membership_count": int(
+            pc.sum(pc.equal(memberships["support_role"], "centerline")).as_py() or 0
+        ),
+        "lateral_support_membership_count": int(
+            pc.sum(pc.equal(memberships["support_role"], "lateral")).as_py() or 0
+        ),
+    }
+    capacity_valid = True
+    for corridor in ("channel", "valley", "floodplain"):
+        fraction = np.asarray(memberships[f"{corridor}_fraction"], dtype=np.float64)
+        summed = np.bincount(inverse, weights=fraction)
+        maximum = float(np.max(summed, initial=0.0))
+        metadata[f"maximum_cell_{corridor}_fraction_sum"] = maximum
+        capacity_valid &= maximum <= 1.0 + 1e-6
+    channel = np.asarray(memberships["channel_fraction"], dtype=np.float64)
+    valley = np.asarray(memberships["valley_fraction"], dtype=np.float64)
+    floodplain = np.asarray(memberships["floodplain_fraction"], dtype=np.float64)
+    nested_valid = bool(
+        np.all(channel <= floodplain + 1e-7) and np.all(floodplain <= valley + 1e-7)
+    )
+    metadata["nested_corridor_support_valid"] = int(nested_valid)
+    metadata["corridor_cell_capacity_valid"] = int(capacity_valid)
+    return metadata
+
+
 def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
     cell_record = result.artifact_records.get("RefinedBasinCellCatalog")
     reach_record = result.artifact_records.get("RefinedRiverReachCatalog")
+    membership_record = result.artifact_records.get("RefinedReachCellCatalog")
     metadata_record = result.artifact_records.get("BasinRefinementMetadata")
     if (
         cell_record is None
@@ -500,12 +552,56 @@ def _cube_net_visualizer(result, request: VisualizationRequest) -> Visualization
     net_col = placements[face, 1] * display_resolution + display_col
     image[net_row, net_col] = colors
 
+    if membership_record is not None and isinstance(membership_record.value, pa.Table):
+        memberships = membership_record.value
+        fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+        order = np.argsort(fine_ids)
+        sorted_ids = fine_ids[order]
+        membership_ids = np.asarray(memberships["fine_cell_id"], dtype=np.int32)
+        support_rows = _lookup_rows(sorted_ids, order, membership_ids)
+        valley = np.asarray(memberships["valley_fraction"], dtype=np.float32)
+        floodplain = np.asarray(memberships["floodplain_fraction"], dtype=np.float32)
+        support_strength: dict[tuple[int, int], tuple[float, float]] = {}
+        for row_index, valley_fraction, floodplain_fraction in zip(
+            support_rows, valley, floodplain, strict=True
+        ):
+            support_row = int(
+                placements[face[row_index], 0] * display_resolution
+                + min(
+                    row[row_index] * display_resolution // fine_resolution, display_resolution - 1
+                )
+            )
+            support_col = int(
+                placements[face[row_index], 1] * display_resolution
+                + min(
+                    col[row_index] * display_resolution // fine_resolution, display_resolution - 1
+                )
+            )
+            previous = support_strength.get((support_row, support_col), (0.0, 0.0))
+            support_strength[(support_row, support_col)] = (
+                max(previous[0], float(valley_fraction)),
+                max(previous[1], float(floodplain_fraction)),
+            )
+        for (support_row, support_col), (
+            valley_fraction,
+            floodplain_fraction,
+        ) in support_strength.items():
+            target = np.array(
+                (63, 137, 91) if floodplain_fraction > 0.0 else (104, 132, 73),
+                dtype=np.float32,
+            )
+            alpha = min(0.50, 0.16 + 0.34 * max(valley_fraction, floodplain_fraction))
+            image[support_row, support_col] = (
+                image[support_row, support_col].astype(np.float32) * (1.0 - alpha) + target * alpha
+            ).astype(np.uint8)
+
     rendered = Image.fromarray(image, mode="RGB")
     draw = ImageDraw.Draw(rendered)
     fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
     order = np.argsort(fine_ids)
     sorted_ids = fine_ids[order]
-    for path in reaches["fine_cell_path"].to_pylist():
+    reach_kinds = reaches["reach_kind"].to_pylist()
+    for path, reach_kind in zip(reaches["fine_cell_path"].to_pylist(), reach_kinds, strict=True):
         path_array = np.asarray(path, dtype=np.int32)
         rows = _lookup_rows(sorted_ids, order, path_array)
         path_face = face[rows]
@@ -524,8 +620,8 @@ def _cube_net_visualizer(result, request: VisualizationRequest) -> Visualization
                             (int(path_col[position]), int(path_row[position]))
                             for position in range(segment_start, index)
                         ],
-                        fill=(29, 174, 235),
-                        width=2,
+                        fill=(29, 174, 235) if reach_kind == "channel" else (73, 122, 143),
+                        width=2 if reach_kind == "channel" else 1,
                     )
                 segment_start = index
     output = request.output_dir / "refined_basin.png"
@@ -559,7 +655,7 @@ def _cube_net_visualizer(result, request: VisualizationRequest) -> Visualization
         "RefinedReachCellCatalog",
         "BasinRefinementMetadata",
     ),
-    version="v4",
+    version="v5",
     native_libraries=("refinement_native",),
     visualizer=_cube_net_visualizer,
 )
@@ -581,6 +677,19 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
     )
     if selected_reaches.num_rows == 0:
         raise ValueError(f"selected basin {selected_basin_id} has no river reaches")
+    selected_connectors = np.asarray(pc.equal(selected_reaches["reach_kind"], "connector"))
+    for field in (
+        "channel_width_m",
+        "channel_depth_m",
+        "valley_width_m",
+        "floodplain_width_m",
+        "velocity_mean",
+        "stream_power",
+        "incision_m",
+    ):
+        values = np.asarray(selected_reaches[field], dtype=np.float32)
+        if np.any(values[selected_connectors] != 0.0):
+            raise RuntimeError(f"hydrologic connectors must publish zero {field}")
 
     paths = [[int(cell) for cell in path] for path in selected_reaches["cell_path"].to_pylist()]
     basin_ids = _artifact_array(hydrology, "BasinID").reshape(-1)
@@ -604,8 +713,23 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
     parent_area_steradians = np.ascontiguousarray(
         context.topology.cell_areas.reshape(-1)[parent_ids], dtype=np.float64
     )
+    depression_catalog = _artifact_table(hydrology, "DepressionCatalog")
+    preserved_depression_ids = np.asarray(
+        depression_catalog.filter(pc.not_equal(depression_catalog["class_code"], 5))[
+            "depression_id"
+        ],
+        dtype=np.int32,
+    )
+    depression_ids = _artifact_array(hydrology, "DepressionID").reshape(-1)
+    parent_process_excluded = np.ascontiguousarray(
+        np.isin(depression_ids[parent_ids], preserved_depression_ids), dtype=np.uint8
+    )
 
     reach_offsets, reach_parent_cells = _flatten_paths(paths)
+    river_corridor = _artifact_array(hydrology, "RiverCorridor").reshape(-1)
+    reach_parent_channel_support = np.ascontiguousarray(
+        river_corridor[reach_parent_cells] > 0.0, dtype=np.uint8
+    )
     planet = deps["planet"].artifact_records["PlanetMetadata"].value
     radius_m = float(planet["planet_radius_earth"]) * EARTH_RADIUS_M
     rng = context.rng("basin_refinement")
@@ -624,11 +748,13 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
             parent_elevation_m=parent_elevation,
             parent_relief_m=parent_relief,
             parent_area_steradians=parent_area_steradians,
+            parent_process_excluded=parent_process_excluded,
             reach_ids=_column_numpy(selected_reaches, "reach_id", np.dtype(np.int32)),
             reach_from_nodes=_column_numpy(selected_reaches, "from_node", np.dtype(np.int32)),
             reach_to_nodes=_column_numpy(selected_reaches, "to_node", np.dtype(np.int32)),
             reach_offsets=reach_offsets,
             reach_parent_cells=reach_parent_cells,
+            reach_parent_channel_support=reach_parent_channel_support,
             channel_width_m=_column_numpy(
                 selected_reaches, "channel_width_m", np.dtype(np.float32)
             ),
@@ -642,6 +768,13 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
     radius_km = radius_m / 1_000.0
     parent_areas_km2 = parent_area_steradians * radius_km * radius_km
     cells = _cell_table(cell_records)
+    cells = cells.append_column(
+        "process_excluded",
+        pa.array(
+            np.repeat(parent_process_excluded != 0, config.refinement_factor**2),
+            type=pa.bool_(),
+        ),
+    )
     parents = _parent_table(
         cell_records,
         parent_ids,
@@ -649,6 +782,7 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
         parent_elevation,
         parent_relief,
         parent_areas_km2,
+        parent_process_excluded,
         config.refinement_factor,
     )
     reaches, junctions_valid, maximum_length_error = _reach_table(
@@ -664,18 +798,37 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
         reaches, basin_ids, flow_receiver, flow_sink_type
     )
     reach_cells = _membership_table(memberships)
+    reaches = _append_physical_reach_lengths(reaches, reach_cells)
+    process_excluded_parent_ids = parent_ids[parent_process_excluded != 0]
+    process_exclusion_valid = not np.any(
+        np.isin(
+            np.asarray(reach_cells["parent_cell_id"], dtype=np.int32),
+            process_excluded_parent_ids,
+        )
+    )
     path_graph_metadata = _directed_path_graph_metadata(reaches)
     corridor_area_metadata = _corridor_area_metadata(reaches, metadata)
+    corridor_capacity_metadata = _corridor_capacity_metadata(reach_cells)
     metadata.update(
         {
             **asdict(config),
             **terminal_metadata,
             **path_graph_metadata,
             **corridor_area_metadata,
+            **corridor_capacity_metadata,
             "selected_basin_id": selected_basin_id,
             "selected_basin_parent_count": int(np.count_nonzero(inside_selected_basin)),
             "boundary_parent_count": int(np.count_nonzero(~inside_selected_basin)),
+            "process_excluded_parent_count": int(np.count_nonzero(parent_process_excluded)),
+            "process_exclusion_valid": int(process_exclusion_valid),
+            "channel_reach_count": int(
+                selected_reaches.num_rows - np.count_nonzero(selected_connectors)
+            ),
+            "connector_reach_count": int(np.count_nonzero(selected_connectors)),
             "selected_basin_area_km2": float(np.sum(parent_areas_km2[inside_selected_basin])),
+            "total_physical_channel_length_km": float(
+                pc.sum(reaches["physical_channel_length_km"]).as_py() or 0.0
+            ),
             "coarse_resolution": coarse_resolution,
             "terrain_seed": terrain_seed,
             "junction_merge_valid": int(junctions_valid),
@@ -683,9 +836,9 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
             "inherited_discharge_relative_error": 0.0,
             "topology": "sparse_selected_basin_on_cubed_sphere",
             "terrain_semantics": "parent_mean_conserving_unresolved_relief_realization",
-            "river_semantics": "subgrid_physical_width_vector_reaches",
+            "river_semantics": "physical_channel_reaches_with_zero_width_hydrologic_connectors",
             "corridor_area_semantics": (
-                "represented_centerline_cell_support_with_requested_unclipped_rectangles"
+                "conservative_nested_lateral_support_with_per_cell_capacity"
             ),
             "incision_semantics": "potential_reach_volume_not_cell_wide_elevation_change",
         }
@@ -706,6 +859,17 @@ def basin_refinement_stage(context, deps, config_mapping: Mapping[str, object]):
             f"reverse_conflicts={metadata['reverse_directed_edge_conflict_count']}, "
             f"dag_valid={metadata['directed_path_dag_valid']}"
         )
+    if metadata["source_to_sink_ready"] != 1:
+        raise RuntimeError("refined reach graph contains an unresolved source-to-sink terminal")
+    if metadata["corridor_cell_capacity_valid"] != 1:
+        raise RuntimeError("refined corridor support exceeds fine-cell physical capacity")
+    if metadata["nested_corridor_support_valid"] != 1:
+        raise RuntimeError("refined channel, floodplain, and valley support is not nested")
+    if not process_exclusion_valid:
+        raise RuntimeError("refined physical reach support enters a process-excluded parent")
+    for corridor in ("channel", "valley", "floodplain"):
+        if metadata[f"{corridor}_area_retention_fraction"] < 1.0 - 1e-6:
+            raise RuntimeError(f"refined {corridor} support does not conserve requested area")
     context.logger.log_event(
         {"type": "basin_refinement_summary", "stage": "basin_refinement", **metadata}
     )

--- a/src/map_maker/pipeline/stages/hydrology.py
+++ b/src/map_maker/pipeline/stages/hydrology.py
@@ -444,6 +444,48 @@ def _waterbody_cell_catalog(
     )
 
 
+def _reach_readiness(
+    reaches: pa.Table,
+    receiver: np.ndarray,
+    sink_type: np.ndarray,
+    basin_id: np.ndarray,
+) -> dict[str, int]:
+    flat_receiver = receiver.reshape(-1)
+    flat_sink = sink_type.reshape(-1)
+    flat_basin = basin_id.reshape(-1)
+    terminal_ocean = 0
+    terminal_registered_sink = 0
+    terminal_unresolved = 0
+    terminal_count = 0
+    for downstream, to_node in zip(
+        np.asarray(reaches["downstream_reach_id"], dtype=np.int32),
+        np.asarray(reaches["to_node"], dtype=np.int32),
+        strict=True,
+    ):
+        if downstream >= 0:
+            continue
+        terminal_count += 1
+        cell = int(to_node)
+        if not 0 <= cell < len(flat_basin):
+            terminal_unresolved += 1
+            continue
+        target = int(flat_receiver[cell])
+        target_is_ocean = 0 <= target < len(flat_basin) and int(flat_basin[target]) < 0
+        if int(flat_basin[cell]) < 0 or target_is_ocean:
+            terminal_ocean += 1
+        elif target < 0 and int(flat_sink[cell]) in (2, 3, 4):
+            terminal_registered_sink += 1
+        else:
+            terminal_unresolved += 1
+    return {
+        "reach_terminal_count": terminal_count,
+        "reach_terminal_ocean_count": terminal_ocean,
+        "reach_terminal_registered_sink_count": terminal_registered_sink,
+        "reach_terminal_unresolved_count": terminal_unresolved,
+        "reach_source_to_sink_ready": int(terminal_unresolved == 0),
+    }
+
+
 ARRAY_DTYPES = {
     "DepressionID": np.int32,
     "LakeID": np.int32,
@@ -483,7 +525,7 @@ ARRAY_DTYPES = {
         "RiverReachCatalog",
         "HydrologyMetadata",
     ),
-    version="v5",
+    version="v6",
     native_libraries=("hydrology_native",),
     visualizer=_hydrology_visualizer,
 )
@@ -581,6 +623,28 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
         views["WetlandFraction"],
         physical_areas_km2,
     )
+    connector_mask = np.asarray(pc.equal(reach_catalog["reach_kind"], "connector"))
+    connector_count = int(np.count_nonzero(connector_mask))
+    for field in (
+        "channel_width_m",
+        "channel_depth_m",
+        "valley_width_m",
+        "floodplain_width_m",
+        "velocity_mean",
+        "stream_power",
+        "incision_m",
+    ):
+        values = np.asarray(reach_catalog[field], dtype=np.float32)
+        if connector_count and np.any(values[connector_mask] != 0.0):
+            raise RuntimeError(f"hydrologic connectors must publish zero {field}")
+    reach_readiness = _reach_readiness(
+        reach_catalog,
+        views["FlowReceiverID"],
+        views["FlowSinkType"],
+        views["BasinID"],
+    )
+    if reach_readiness["reach_source_to_sink_ready"] != 1:
+        raise RuntimeError("river reach graph contains unresolved source-to-sink terminals")
     flat_sink = views["FlowSinkType"][land_mask]
     closed_land_fraction = float(np.mean(flat_sink != 1))
     waterbody_support_land_cell_fraction = float(
@@ -601,12 +665,21 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
     metadata.update(
         {
             **asdict(config),
+            **reach_readiness,
             "planet_radius_m": radius_m,
             "median_land_cell_area_km2": median_land_cell_area,
             "effective_river_contributing_area_threshold_km2": controls[
                 "river_contributing_area_threshold_km2"
             ],
             "waterbody_count": lake_catalog.num_rows + wetland_catalog.num_rows,
+            "connector_reach_count": connector_count,
+            "connector_reach_cell_count": sum(
+                len(path)
+                for path, is_connector in zip(
+                    reach_catalog["cell_path"].to_pylist(), connector_mask, strict=True
+                )
+                if is_connector
+            ),
             "open_lake_count": int(pc.sum(lake_catalog["open_outlet"]).as_py() or 0),
             "open_wetland_count": int(pc.sum(wetland_catalog["open_outlet"]).as_py() or 0),
             "mean_lake_depth_m": mean_lake_depth_m,
@@ -632,7 +705,7 @@ def hydrology_stage(context, deps, config_mapping: Mapping[str, object]):
             "model": "fractional_priority_flood_fill_spill_breach_hydrology_v2",
             "runoff_semantics": "monthly_climate_runoff_potential_routed_conservatively",
             "lake_semantics": "subgrid_fractional_open_or_closed_water_balance_depressions",
-            "river_semantics": "vector_reach_graph_with_support_rasters",
+            "river_semantics": ("vector_channel_reaches_with_zero_width_hydrologic_connectors"),
             "breach_semantics": "selective_sustained_overflow_outlet_incision",
         }
     )

--- a/tests/test_basin_refinement.py
+++ b/tests/test_basin_refinement.py
@@ -92,10 +92,14 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
     assert metadata["reverse_directed_edge_conflict_count"] == 0
     assert metadata["directed_path_dag_valid"] == 1
     assert metadata["directed_path_graph_valid"] == 1
+    assert metadata["corridor_cell_capacity_valid"] == 1
+    assert metadata["nested_corridor_support_valid"] == 1
+    assert metadata["process_exclusion_valid"] == 1
     assert metadata["inherited_discharge_relative_error"] == 0.0
     assert metadata["parent_count"] == parents.num_rows
     assert metadata["child_count"] == cells.num_rows == parents.num_rows * factor * factor
     assert metadata["reach_count"] == reaches.num_rows > 0
+    assert metadata["channel_reach_count"] + metadata["connector_reach_count"] == reaches.num_rows
     assert metadata["reach_cell_count"] == memberships.num_rows > 0
     assert metadata["maximum_parent_area_relative_error"] < 1e-10
     assert metadata["maximum_parent_elevation_error_m"] < 1e-3
@@ -105,6 +109,12 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
     assert np.max(np.abs(np.asarray(parents["elevation_error_m"]))) < 1e-3
     assert np.any(np.asarray(cells["terrain_offset_m"]) > 0.0)
     assert np.any(np.asarray(cells["terrain_offset_m"]) < 0.0)
+    assert "process_excluded" in cells.column_names
+    assert "process_excluded" in parents.column_names
+    assert (
+        int(np.count_nonzero(np.asarray(parents["process_excluded"])))
+        == metadata["process_excluded_parent_count"]
+    )
 
     fine_grid = CubedSphereGrid.create(fine_resolution)
     fine_to_parent = fine_grid.parent_map(factor).reshape(-1)
@@ -133,6 +143,8 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
     valley_fraction = np.asarray(memberships["valley_fraction"])
     floodplain_fraction = np.asarray(memberships["floodplain_fraction"])
     assert np.all((channel_fraction >= 0.0) & (channel_fraction < 0.01))
+    assert np.all(channel_fraction <= floodplain_fraction + 1e-7)
+    assert np.all(floodplain_fraction <= valley_fraction + 1e-7)
     assert np.all(channel_fraction <= valley_fraction)
     assert np.all((floodplain_fraction >= 0.0) & (floodplain_fraction <= 1.0))
 
@@ -156,7 +168,10 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
     for reach_id, expected_length in path_lengths_by_reach.items():
         selected = membership_reach == reach_id
         actual_length = float(np.sum(membership_length[selected]))
-        assert actual_length == pytest.approx(expected_length, rel=1e-12)
+        row = int(np.flatnonzero(np.asarray(reaches["reach_id"]) == reach_id)[0])
+        physical_length = float(reaches["physical_channel_length_km"][row].as_py()) * 1_000.0
+        assert physical_length <= expected_length
+        assert actual_length == pytest.approx(physical_length, rel=1e-12)
         assert float(np.sum(potential_volume[selected])) == pytest.approx(
             width_by_reach[reach_id] * actual_length * incision_by_reach[reach_id], rel=1e-6
         )
@@ -173,16 +188,46 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
         )
         assert metadata[f"represented_{corridor}_area_km2"] == pytest.approx(represented, rel=1e-12)
         assert metadata[f"requested_{corridor}_area_km2"] >= represented
-        assert 0.0 < metadata[f"{corridor}_area_retention_fraction"] <= 1.0 + 1e-7
+        assert 1.0 - 1e-6 < metadata[f"{corridor}_area_retention_fraction"] <= 1.0 + 1e-7
+        _, inverse = np.unique(membership_cell_ids, return_inverse=True)
+        per_cell = np.bincount(
+            inverse, weights=np.asarray(memberships[f"{corridor}_fraction"], dtype=np.float64)
+        )
+        assert np.max(per_cell, initial=0.0) <= 1.0 + 1e-6
 
     assert {
         "terminal_kind",
         "downstream_join_fine_cell",
+        "reach_kind",
         "terminal_parent_cell",
         "terminal_receiver_cell",
         "terminal_sink_type",
         "terminal_resolved",
     }.issubset(reaches.column_names)
+    assert "support_role" in memberships.column_names
+    lateral = np.asarray(memberships["support_role"]) == "lateral"
+    assert np.all(membership_length[lateral] == 0.0)
+    assert np.all(channel_fraction[lateral] == 0.0)
+    assert np.all(potential_volume[lateral] == 0.0)
+    connector_ids = set(
+        np.asarray(reaches["reach_id"], dtype=np.int32)[
+            np.asarray(reaches["reach_kind"]) == "connector"
+        ].tolist()
+    )
+    if connector_ids:
+        connector_memberships = np.isin(membership_reach, list(connector_ids))
+        assert not np.any(connector_memberships)
+        connector_parent_cells: set[int] = set()
+        for path, kind in zip(
+            reaches["parent_cell_path"].to_pylist(), reaches["reach_kind"].to_pylist(), strict=True
+        ):
+            if kind == "connector":
+                connector_parent_cells.update(int(cell) for cell in path[:-1])
+        assert not connector_parent_cells.intersection(
+            np.asarray(memberships["parent_cell_id"], dtype=np.int32).tolist()
+        )
+        connector_rows = np.asarray(reaches["reach_kind"]) == "connector"
+        assert np.all(np.asarray(reaches["physical_channel_length_km"])[connector_rows] == 0.0)
     unresolved = [
         kind for kind in reaches["terminal_kind"].to_pylist() if kind.startswith("unresolved_")
     ]
@@ -193,12 +238,10 @@ def test_refines_complete_basin_without_cell_wide_rivers(tmp_path: Path):
 
 
 def test_refinement_is_deterministic_and_cacheable(tmp_path: Path):
-    first = ExecutionEngine(_config(tmp_path, "refinement-first")).run(["basin_refinement"])[
-        "basin_refinement"
-    ]
-    second = ExecutionEngine(_config(tmp_path, "refinement-second")).run(["basin_refinement"])[
-        "basin_refinement"
-    ]
+    first_config = _config(tmp_path / "independent-first", "refinement-first")
+    second_config = _config(tmp_path / "independent-second", "refinement-second")
+    first = ExecutionEngine(first_config).run(["basin_refinement"])["basin_refinement"]
+    second = ExecutionEngine(second_config).run(["basin_refinement"])["basin_refinement"]
     for name in (
         "RefinedBasinCellCatalog",
         "RefinedBasinParentCatalog",
@@ -210,7 +253,9 @@ def test_refinement_is_deterministic_and_cacheable(tmp_path: Path):
         first.artifact_records["BasinRefinementMetadata"].value
         == second.artifact_records["BasinRefinementMetadata"].value
     )
-    assert second.stats is not None and second.stats.cache_hit
+    assert second.stats is not None and not second.stats.cache_hit
+    cached = ExecutionEngine(second_config).run(["basin_refinement"])["basin_refinement"]
+    assert cached.stats is not None and cached.stats.cache_hit
 
 
 def test_refinement_config_rejects_invalid_controls():

--- a/tests/test_hydrology.py
+++ b/tests/test_hydrology.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 import pytest
 
 from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
@@ -259,6 +260,7 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
         "downstream_reach_id",
         "basin_id",
         "cell_path",
+        "reach_kind",
         "polyline_on_cubed_sphere",
         "flow_direction_vector",
         "slope",
@@ -284,6 +286,15 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
     downstream = np.asarray(reaches["downstream_reach_id"].combine_chunks())
     np.testing.assert_array_equal(reach_ids, np.arange(len(reach_ids), dtype=np.int32))
     assert np.all((downstream == -1) | ((downstream >= 0) & (downstream < len(reach_ids))))
+    connector = np.asarray(pc.equal(reaches["reach_kind"], "connector"))
+    if np.any(connector):
+        assert np.all(np.asarray(reaches["channel_width_m"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["channel_depth_m"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["valley_width_m"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["floodplain_width_m"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["incision_m"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["velocity_mean"])[connector] == 0.0)
+        assert np.all(np.asarray(reaches["stream_power"])[connector] == 0.0)
     for reach_id in reach_ids:
         seen: set[int] = set()
         current = int(reach_id)
@@ -312,6 +323,9 @@ def test_hydrology_outputs_depression_aware_global_graph_and_catalogs(tmp_path: 
     assert metadata["waterbody_count"] == lake_catalog.num_rows + wetland_catalog.num_rows
     assert metadata["basin_count"] == basin_catalog.num_rows
     assert metadata["reach_count"] == reaches.num_rows
+    assert metadata["connector_reach_count"] == int(np.count_nonzero(connector))
+    assert metadata["reach_source_to_sink_ready"] == 1
+    assert metadata["reach_terminal_unresolved_count"] == 0
     assert metadata["open_lake_count"] > 0
     assert 0.0 < metadata["lake_land_cell_fraction"] < 0.25
     assert 0.0 < metadata["lake_land_area_fraction"] < metadata["lake_land_cell_fraction"]

--- a/tests/test_native_loader.py
+++ b/tests/test_native_loader.py
@@ -48,3 +48,6 @@ def test_built_library_exposes_expected_abi_and_fingerprint() -> None:
     assert info["abi_version"] == NATIVE_ABI_VERSION
     assert len(info["sha256"]) == 64
     assert Path(info["path"]).is_file()
+
+    refinement = native_library_info("refinement_native")
+    assert refinement["abi_version"] == 3


### PR DESCRIPTION
## What changed

- close river reach topology through preserved depression and waterbody support with explicit zero-width hydrologic connectors
- separate topological paths from physical channel support and exclude preserved depression cells from erosion support
- conservatively allocate channel, valley, and floodplain support with per-cell capacity and nesting invariants
- hard-gate source-to-sink readiness and document the decision, semantics, and canonical validation metrics

## Why

County-scale erosion cannot safely consume coarse raster river widths. The refinement stage now supplies connected vector routing plus conservative subgrid physical support without treating connectors or entire coarse cells as incised channels.

## Validation

- `100 passed` with `pytest -q`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Ruff, Black, Cargo fmt, and `git diff --check`
- release native build, `map-maker doctor`, and `uv build -q`
- canonical basin regeneration and visual inspection
- independent subagent review; all findings resolved