### PR TITLE
Add conservative basin erosion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,10 @@ name = "erosion_native"
 version = "0.1.0"
 
 [[package]]
+name = "fluvial_native"
+version = "0.1.0"
+
+[[package]]
 name = "geology_native"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "src/map_maker/pipeline/native/climate",
     "src/map_maker/pipeline/native/elevation",
     "src/map_maker/pipeline/native/erosion",
+    "src/map_maker/pipeline/native/fluvial",
     "src/map_maker/pipeline/native/geology",
     "src/map_maker/pipeline/native/hydrology",
     "src/map_maker/pipeline/native/planet",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -79,3 +79,8 @@ stage_overrides:
   basin_refinement:
     refinement_factor: 16
     terrain_noise_fraction: 0.45
+  basin_erosion:
+    minimum_bed_slope: 0.00001
+    maximum_deposition_fraction: 0.35
+    deposition_slope_scale: 0.001
+    maximum_deposition_depth_m: 10.0

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1263,3 +1263,68 @@ Failure conditions:
 - Per-cell support greater than physical cell area or non-nested channel,
   floodplain, and valley footprints.
 - Lateral support counted as extra reach length or erodible channel area.
+
+## Decision 025: Junction Beds And Conservative First-Pass Fluvial Budgets
+
+Status: implemented, provisional
+
+Decision:
+The first refined fluvial pass solves the least-incision downstream-graded bed
+surface compatible with the inherited physical channel graph. It then converts
+that cut to solid volume and routes every removed volume unit to allocated
+floodplain support, a registered inland sink, or an ocean terminal. It does not
+force the provisional coarse potential-incision field into the fine terrain.
+
+Bed-profile contract:
+- Consecutive physical centerline memberships form a directed node DAG.
+- A fine cell shared at a confluence has exactly one bed elevation.
+- Bed elevation does not rise downstream and meets the configured minimum
+  grade within numerical tolerance.
+- Bed/profile coordinates and grade diagnostics persist as float64, and the
+  grade gate is recomputed from emitted records after native serialization.
+- The terrain prior is lowered only where required by the downstream envelope.
+- A path-order gap across process-excluded support breaks the physical bed
+  component. A connector does not invent a bed through an unresolved lake or
+  depression.
+
+Incision contract:
+- Physical volume is channel width times represented in-cell length times solved
+  incision depth.
+- Incision remains a subgrid channel property. Full-cell mean elevation changes
+  only by net process volume divided by full physical cell area.
+- Child erosion and deposition volumes restrict exactly to their coarse parent.
+- The inherited potential-incision volume is reported as a comparison. It is
+  neither a target nor a cap until calibrated process history exists.
+
+Sediment contract:
+- Only newly eroded solid volume enters this historical routing budget.
+- Physical reaches may retain a bounded, support-area-capped fraction on their
+  allocated floodplains. Connectors retain none and transfer all incoming
+  sediment downstream.
+- Registered inland terminals retain their remainder in a terminal inventory.
+  Ocean terminals export their remainder to the future delta/shelf model.
+- Eroded volume must equal floodplain deposition plus terminal deposition plus
+  ocean export. Reach-level incoming, local, deposited, and transferred budgets
+  are persisted for inspection and surrogate training.
+- Python independently reconciles profile, reach, fine-cell, parent, and native
+  totals, including every reach's input/output balance and downstream transfer.
+- Instantaneous inherited sediment load remains a separate flux diagnostic and
+  may not be added dimensionally to historical solid volume.
+
+Current approximation:
+The minimum-grade envelope is terrain conditioning, not a calibrated
+geological-time stream-power model. Floodplain retention uses inherited slope
+and allocated floodplain-to-valley support with bounded depth. Its parameters
+remain provisional until multi-seed morphology and Earth-derived sediment
+benchmarks exist.
+
+Failure conditions:
+- Different bed elevations for reaches sharing a physical junction cell.
+- A downstream physical bed rise above the configured grade tolerance.
+- Connector bed, incision, floodplain deposition, or local sediment production.
+- Process volume in a preserved-depression parent.
+- Cell-mean terrain change based on incision depth rather than conserved volume.
+- Eroded sediment disappearing, appearing, or changing under parent
+  restriction.
+- Native statistics agreeing internally while emitted catalogs disagree.
+- Treating the canonical seed's potential-incision value as calibration.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -201,8 +201,56 @@ physical memberships. Physical channel reaches also stop their process support
 at shared connector endpoints, so no channel, valley, floodplain, or incision
 area enters a connector-owned or preserved-depression parent. The basin
 therefore passes the topology and corridor input gates for conservative
-incision and sediment routing. These are contract and conservation results, not
-accepted erosion calibration.
+incision and sediment routing.
+
+## Selected-Basin Erosion
+
+The first conservative fluvial pass builds 2,434 physical bed nodes and 2,421
+physical edges in 13 components. The components are separated where zero-width
+connectors cross process-excluded depression support. All 2,442 physical
+centerline memberships receive bed and incision records; connectors receive
+none.
+
+Observed profile and sediment diagnostics:
+
+| Metric | Canonical result |
+| --- | ---: |
+| Shared-junction bed error | `0 m` |
+| Minimum realized downstream slope | `1.0e-5` |
+| Maximum conditioning incision | `537.11 m` |
+| Potential incision diagnostic | `150.20 km3` |
+| Actual grade-conditioning incision | `145.53 km3` |
+| Floodplain deposition | `95.96 km3` |
+| Inland terminal deposition | `0 km3` |
+| Ocean sediment export | `49.57 km3` |
+| Sediment conservation residual | `< 7.7e-6 m3` |
+| Maximum full-cell mean change | `12.41 m` |
+| Maximum coarse-parent mean change | `0.95 m` |
+| Preserved-depression process exclusion | Pass |
+| Connector physical-process exclusion | Pass |
+| Post-serialization float64 grade audit | Pass |
+| Cross-catalog reach/cell/parent budget audit | Pass |
+
+The actual-to-potential incision ratio is approximately `0.969`, but this
+agreement is not a calibration target. Actual incision is the volume required
+to make the unresolved fine terrain prior downstream-graded; potential incision
+was inherited from coarse reach relief. Their proximity in one basin and seed
+may be coincidental. The maximum cut shows why the next validation phase must
+inspect longitudinal profiles and multi-seed distributions before accepting
+morphology.
+
+Floodplain deposition is allocated only inside the previously conserved
+floodplain footprint. Every remaining solid volume exits through the registered
+ocean terminal. Cell means change by net volume divided by physical cell area,
+not by applying channel depth to the entire cell. These are contract and
+conservation results, not accepted erosion or sediment calibration.
+
+The stage recomputes grade from persisted float64 bed records and cell
+coordinates. It also reconciles profile erosion with reach-local and cell-local
+erosion, reach deposition with cell deposition, every reach's available and
+outgoing volume, downstream inputs, parent restrictions, and native totals. A
+face-16 seed-22 regression fixture contains both a connector and an excluded
+parent so the corresponding tests are non-vacuous.
 
 ## Calibration Rule
 

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -32,16 +32,21 @@
      conservation before erosion. It reports complete source-to-sink readiness
      through physical channels and zero-width hydrologic connectors.
 9. Erosion and sedimentation.
+   - The sparse selected-basin pass now solves junction-consistent physical bed
+     profiles, applies volume-based subgrid incision, routes newly eroded
+     sediment through connectors, and deposits only on allocated floodplain or
+     terminal support.
 10. Hydrology pass 2.
 11. Soils and biomes.
 12. Mineral and energy systems.
 13. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches Hydrology Pass 1 and
-passes the selected-basin refinement readiness gate with a
+The current canonical cubed-sphere implementation reaches the first sparse
+selected-basin erosion and sedimentation pass after Hydrology Pass 1, with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
 relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
-climate/orography pass. The older
+climate/orography pass. Bed-profile and sediment budgets are conservative but
+remain uncalibrated and have not yet fed Hydrology Pass 2. The older
 rectangular compatibility path runs directly from world age into provisional
 erosion and final rendering; it is reference behavior, not the canonical stage
 order.

--- a/docs/specs/02_topology.md
+++ b/docs/specs/02_topology.md
@@ -132,7 +132,9 @@ The cube net is a topology diagnostic, not an atlas projection.
 ## Migration Boundary
 
 The canonical tectonics, world-age, and geology kernels consume global IDs,
-exact spherical areas, and topology-owned D4 neighbors. Erosion remains on the
-provisional two-dimensional grid and explicitly rejects cubed-sphere input. It
-must not be migrated by flattening the six faces, because that would create
-false adjacency between face rows.
+exact spherical areas, and topology-owned D4 neighbors. The legacy whole-grid
+erosion stage remains on the provisional two-dimensional grid and explicitly
+rejects cubed-sphere input. Canonical sparse fluvial processing instead uses
+cubed-sphere child IDs and spherical edge lengths in `basin_erosion`. Neither
+path may flatten the six faces, because that would create false adjacency
+between face rows.

--- a/docs/specs/06_erosion.md
+++ b/docs/specs/06_erosion.md
@@ -1,39 +1,132 @@
-# Stage 5 – Erosion & Sedimentation
+# Erosion And Sedimentation
 
-## Objective
-- Evolve the elevation field through uplift, fluvial erosion, coastal abrasion, and sediment deposition.
+## Status
+
+The canonical cubed-sphere path implements a first conservative fluvial pass in
+`basin_erosion` for one sparse refined basin. The older `erosion` stage remains
+a rectangular compatibility prototype and is not the scientific implementation
+described here.
+
+## Scientific Intent
+
+Erosion changes subgrid landforms and moves solid material from source to sink.
+An ordinary river does not lower an entire regional cell by its channel depth.
+The first pass therefore solves a channel-bed constraint, converts only the
+physical channel cut into sediment volume, routes that volume through the
+registered reach graph, and applies overbank deposition only to allocated
+floodplain support.
+
+This is structural realism rather than a geological-time landscape evolution
+model. It establishes correct topology and budgets before adding lithology,
+weathering, hillslope diffusion, mass wasting, lateral migration, delta growth,
+compaction, flexure, or repeated hydrology feedback.
 
 ## Inputs
-- `CrustThickness`, `UpliftRate`, `SubsidenceRate`, `HotspotEvents`, `PlateField`, `BaseOceanMask`.
-- Config: `erosion_steps`, `dt`, `stream_power_k`, `sediment_capacity`, `coastal_wave_energy`, `tile_size`, `gpu_backend` (optional).
 
-## Algorithm Outline (Rust core with optional GPU kernels)
-1. **Initialize Elevation Prototype**
-   - Combine isostatic offsets and uplift/subsidence to produce `InitialDEM` (arena-backed float32 grid).
-2. **Iterative Solver (T timesteps)** – executed in Rust with tile-based parallelism (configurable `tile_size`, halo width):
-   - **Uplift Update:** fused multiply-add on elevation buffer using `UpliftRate` and `SubsidenceRate`.
-   - **Fluvial Erosion:**
-     - Compute flow direction/accumulation via D-infinity implemented with SIMD (fallback) or GPU kernel when `gpu_backend == metal`.
-     - Apply stream power law `dz = k * (flow^m) * (slope^n) * dt` on tiles; maintain mass balance accumulator per tile.
-     - Enforce sediment capacity, advect excess downstream via queue-based solver.
-   - **Mass Wasting:** slope-threshold cellular automata using bitmasks for active cells to avoid branching.
-   - **Coastal Erosion:** process shoreline tiles only, applying precomputed wave energy coefficients.
-   - **Sediment Deposition:** deposit into basins/continental shelves; maintain `SedimentDepth` buffer (float32) and per-tile residual mass.
-   - Multi-resolution loop: coarse level update (1/4 res) first, then inject correction into native grid to reduce iteration count.
-3. **Outputs**
-   - `ElevationRaw`, `SedimentDepth`, `RiverIncision`, intermediate diagnostics (erosion flux, deposition flux) stored in Arrow tables.
+- Sparse refined child terrain and physical cell areas.
+- Source-to-sink-ready physical reaches and zero-width connectors.
+- Ordered centerline memberships with physical width and in-cell length.
+- Conserved valley and floodplain support fractions.
+- Reach slope, terminal class, and downstream reach identity.
+- Coarse potential incision and sediment-load fields as diagnostics. They are
+  not silently converted into calibrated fine-scale process history.
 
-## Performance Targets
-- Rust SIMD + Rayon path: <4 s for 8 k grid with default 20 timesteps.
-- GPU backend (Metal compute shader) optional to cut flow solver to <1 s; asynchronous overlap with CPU tasks where possible.
-- Tile scheduler avoids loading entire grid into cache; memory residency limited to a few tiles + global buffers.
+## Bed Profiles
 
-## Logging
-- Per iteration: mean elevation, mass removed/added, max incision, tile-level throughput (cells/sec).
-- Final summary: erosion vs uplift balance, global sediment budget, GPU/CPU split timings.
+Physical centerline memberships create a directed node graph. A node shared by
+several reaches at a confluence has one bed elevation. Starting from the refined
+terrain prior, the native solver constructs the greatest downstream-graded
+surface satisfying:
 
-## Testing
-- Mass conservation within tolerance (<0.5% drift) verified per tile and globally.
-- River incision increases with higher flow power.
-- Coastal erosion reduces protruding landforms over iterations.
-- GPU and CPU backends produce matching results within tolerance.
+```text
+bed_downstream <= bed_upstream - minimum_bed_slope * edge_length
+bed <= terrain_prior
+```
+
+This is the least-incision downstream envelope. It removes only the material
+required to condition the unresolved terrain prior into a routable bed. It does
+not force the inherited coarse potential-incision volume into the fine terrain.
+That potential remains an explicit comparison metric.
+
+Connectors have no physical bed. A channel component on either side of an
+unresolved lake or depression is graded independently until local waterbody and
+outlet geometry replaces the connector.
+
+## Incision And Terrain Feedback
+
+For every physical centerline membership:
+
+```text
+incision_depth = terrain_prior - channel_bed
+eroded_volume = channel_width * in_cell_reach_length * incision_depth
+```
+
+The channel bed is a subgrid feature. The full cell mean changes only by net
+physical volume divided by full cell area:
+
+```text
+cell_mean_delta = (deposited_volume - eroded_volume) / cell_area
+```
+
+This preserves both the narrow channel morphology and a restriction-compatible
+terrain response without creating cell-wide trenches.
+
+## Sediment Routing
+
+Newly eroded solid volume is routed upstream-to-downstream through every reach.
+Physical reaches may retain a bounded fraction on their allocated floodplain
+support. The provisional retention fraction increases with floodplain-to-valley
+support and decreases with inherited reach slope; deposition is capped by a
+configured maximum support depth. Connectors transfer the complete incoming
+volume without erosion or deposition.
+
+At a registered inland sink, remaining volume enters a terminal sediment
+inventory. At an ocean terminal it is exported to the future delta/shelf model.
+The following identity is a hard gate:
+
+```text
+eroded = floodplain_deposited + terminal_deposited + ocean_exported
+```
+
+The inherited `sediment_load` field is an instantaneous flux diagnostic. It is
+preserved on the reach catalog but is not mixed dimensionally with the newly
+eroded historical volume.
+
+## Outputs
+
+- `ChannelBedProfileCatalog`: junction-consistent physical bed elevations,
+  incision depths, lengths, and eroded volumes.
+- `FluvialRiverReachCatalog`: inherited reach data plus local, incoming,
+  deposited, transferred, terminal, and exported sediment budgets.
+- `ErodedBasinCellCatalog`: sparse process volumes and volume-derived terrain
+  mean feedback for every refined child.
+- `BasinErosionParentCatalog`: child process volumes restricted to each coarse
+  parent.
+- `BasinErosionMetadata`: profile, connector, exclusion, and conservation gates
+  plus canonical totals.
+
+## Hard Gates
+
+- The inherited reach graph is source-to-sink ready and acyclic.
+- Every shared physical junction has one bed elevation.
+- Every physical edge meets the configured downstream grade.
+- Bed elevation never exceeds the terrain prior in this incision-only pass.
+- Connectors have no bed, incision, support deposition, or local sediment.
+- No process volume enters a preserved-depression parent.
+- Membership volumes equal width times length times incision depth.
+- Cell-mean and parent-restricted changes reproduce physical volumes.
+- All newly eroded sediment is deposited at a registered support/sink or
+  exported through a registered ocean terminal.
+
+## Current Limits
+
+- The least-incision envelope can expose hundreds of metres of conditioning
+  where the unresolved terrain prior rises along an inherited trunk. Such cuts
+  are budget-correct but not accepted calibration.
+- Floodplain retention is a bounded structural approximation, not a calibrated
+  settling, competence, or grain-size model.
+- Sediment provenance, lithology, suspended/bed-load partition, transport time,
+  avulsion, meander migration, deltas, shelves, and compaction are absent.
+- Hydrology Pass 2 has not yet consumed the altered terrain distribution.
+- Repeated geological-time erosion, uplift, sediment loading, flexure, and
+  isostatic response remain future passes.

--- a/docs/specs/08a_basin_refinement.md
+++ b/docs/specs/08a_basin_refinement.md
@@ -3,9 +3,9 @@
 ## Status
 
 Implemented prototype following Hydrology Pass 1. This stage proves the
-cross-resolution river and terrain contract required before fluvial erosion. It
-does not yet apply erosion, generate new tributaries, or replace Hydrology Pass
-2.
+cross-resolution river and terrain contract consumed by the first sparse
+fluvial erosion pass. It does not generate new tributaries or replace Hydrology
+Pass 2.
 
 ## Objective
 
@@ -140,10 +140,9 @@ reaches therefore have no `RefinedReachCellCatalog` records.
   terrain and erosion.
 - Lake and wetland fractions are not yet spatially realized inside refined
   parents.
-- Potential incision volume is not applied, and sediment is not yet routed or
-  deposited.
-- Junction-consistent channel-bed profiles are not yet solved. They belong to
-  the conservative erosion pass and may not be inferred from rendering strokes.
+- Potential incision remains a diagnostic comparison rather than a mandatory
+  fine-scale cut. `basin_erosion` now solves the actual least-incision bed
+  envelope and routes the resulting sediment volume.
 - The prototype refines one basin per stage run and stores Arrow catalogs rather
   than chunked regional rasters.
 - Coarse connectors are topological placeholders. Refined inlet, lake-crossing,
@@ -155,6 +154,4 @@ reaches therefore have no `RefinedReachCellCatalog` records.
 - Scarcity ordering and deterministic retries avoid known greedy allocation
   failures, but the valley allocator is not a general global optimizer.
 
-The next pass solves junction-consistent channel-bed profiles, applies
-conservative fluvial incision and sediment routing only to physical channel
-reaches, and aggregates physical budgets upward before Hydrology Pass 2.
+The implemented downstream pass is specified in `08b_basin_erosion.md`.

--- a/docs/specs/08b_basin_erosion.md
+++ b/docs/specs/08b_basin_erosion.md
@@ -1,0 +1,81 @@
+# Sparse Selected-Basin Erosion
+
+## Status
+
+Implemented provisional process pass following `basin_refinement`.
+
+## Objective
+
+Turn the accepted sparse reach and corridor contract into a physically
+accounted first erosion state without widening subgrid rivers to cell size.
+Solve one bed at confluences, cut only physical centerline area, route every
+removed cubic metre to a floodplain, registered inland sink, or ocean terminal,
+and restrict the resulting volume changes to coarse parents.
+
+## Native Solver
+
+The Rust `fluvial_native` kernel receives compact structure-of-arrays inputs for
+selected child cells, reaches, and sparse memberships. It builds two DAGs:
+
+- a physical node DAG from consecutive channel centerline memberships;
+- the complete reach DAG, including zero-width connectors.
+
+The physical DAG supplies bed elevations and incision volume. The complete DAG
+routes sediment source to sink. Python performs orchestration, Arrow conversion,
+independent conservation audits, persistence, and visualization.
+
+## Profile Construction
+
+Fine terrain is an unresolved prior, not an accepted channel bed. The solver
+visits physical nodes in deterministic topological order and lowers a downstream
+node only when needed to satisfy the configured minimum grade. Multiple incoming
+reaches reference the same fine-cell node, so their confluence elevation is
+identical by construction.
+
+Terrain, bed elevation, incision depth, reach-end elevation, and realized grade
+cross the native ABI and persist as float64. The emitted profile, rather than an
+internal pre-serialization statistic, must still satisfy the minimum grade.
+
+Membership path-order gaps mark physical discontinuities across process-excluded
+support. No bed edge crosses such a gap. Connectors remain in the reach graph for
+sediment transfer but never enter the physical DAG.
+
+## Volume Budgets
+
+Incision is calculated at every centerline membership from physical channel
+width, represented in-cell length, and solved depth. Eroded volume accumulates
+to the reach and fine cell. Floodplain deposition is allocated in proportion to
+the already-conserved per-reach floodplain support area, including lateral
+memberships, and is capped by support area times maximum deposition depth.
+
+Sparse cell budgets are expanded onto the full selected child catalog only when
+artifacts are published. Coarse-parent budgets are exact sums of child erosion
+and deposition. Neither routing nor restriction changes total material.
+
+## Determinism
+
+- Cell and reach identifiers define all map and queue tie breaks.
+- Physical and reach DAG queues use ascending stable identifiers.
+- Sparse outputs are sorted by reach/path/cell or fine-cell identity.
+- The native binary fingerprint participates in the stage cache key.
+
+## Validation
+
+Synthetic native tests cover a downstream terrain rise, a shared confluence,
+and channel-to-connector-to-channel transport. CFFI tests also cover a grade
+smaller than float32 precision at the profile elevation, connector transfer,
+physical-component separation at a path gap, native record layout, and rejected
+connector membership. Pipeline tests independently recompute emitted grade,
+physical volume, junction equality, reach flow balances, profile-to-reach and
+profile-to-cell allocations, cell-mean feedback, parent sums, connector
+emptiness, source-to-sink conservation, independent-run determinism, and cache
+reuse. A fixture with real connectors and process-excluded parents prevents
+those gates from passing vacuously.
+
+## Next Step
+
+Hydrology Pass 2 must consume the volume-derived terrain distribution, rerun
+local drainage and depression stability, and decide whether one bounded
+erosion/hydrology correction is required. Calibration of profile depths and
+floodplain retention requires multi-seed distributions and Earth-derived
+benchmarks rather than tuning the canonical seed alone.

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,9 @@ The native build is explicit. Importing `map_maker` never invokes Cargo or a
 C++ compiler. To load native libraries built elsewhere, set
 `MAP_MAKER_NATIVE_LIB_DIR` to their containing directory.
 
-Every native library currently exposes ABI version `2`. `map-maker doctor`
-verifies that ABI and reports the binary SHA-256 fingerprint. Simulation-library fingerprints
+Simulation native libraries expose ABI version `2`, except the refinement
+library's versioned ABI `3`. `map-maker doctor` verifies those contracts and
+reports each binary SHA-256 fingerprint. Simulation-library fingerprints
 are included in stage cache keys and run manifests, so replacing a native binary
 cannot silently reuse outputs from different code.
 
@@ -83,9 +84,13 @@ preserves parent terrain means and convergent reach junctions, and stores physic
 channel, valley, and floodplain fractions without carving whole cells. It also
 closes coarse extraction gaps with zero-width hydrologic connectors, verifies
 source-to-sink readiness, and conserves broad valley and floodplain support in
-nearby fine cells. The canonical basin now passes the input gates for the first
-conservative erosion pass, but no refined erosion has yet been applied. The
-current output is a functional prototype rather than an atlas-grade world.
+nearby fine cells. The downstream sparse erosion pass now solves shared-junction
+bed profiles, applies volume-based subgrid incision, routes newly eroded sediment
+through connectors, deposits only on allocated floodplain support, and restricts
+terrain-volume feedback to coarse parents. Its morphology and retention
+parameters remain provisional, and Hydrology Pass 2 has not yet consumed the
+result. The current output is a functional prototype rather than an atlas-grade
+world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -108,8 +113,9 @@ uv run map-maker topology --face-resolution 96 --output-dir out/topology
 This writes a globally continuous XYZ-colored cube net and a geometry report.
 The canonical tectonic snapshot, age-conditioned crust state, connected
 geological provinces, and initial elevation now run directly on cubed-sphere
-neighbor IDs. Erosion remains on the provisional two-dimensional path and
-explicitly rejects six-face fields.
+neighbor IDs. The legacy whole-grid `erosion` stage remains on the provisional
+two-dimensional path and explicitly rejects six-face fields; canonical sparse
+cubed-sphere fluvial processing runs through `basin_erosion`.
 
 Run the previous procedural generator for comparison:
 
@@ -145,6 +151,9 @@ uv run map-maker-pipeline --stage hydrology --config configs/cubed_sphere_crust_
 
 # One sparse face-2048 basin with connected trunks and conserved corridor support
 uv run map-maker-pipeline --stage basin_refinement --config configs/cubed_sphere_crust_state.yaml
+
+# Junction-consistent subgrid incision and conservative sediment routing
+uv run map-maker-pipeline --stage basin_erosion --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -10,11 +10,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
-NATIVE_ABI_OVERRIDES = {"refinement_native": 3}
+NATIVE_ABI_OVERRIDES = {"fluvial_native": 3, "refinement_native": 3}
 SIMULATION_NATIVE_LIBRARIES = (
     "climate_native",
     "elevation_native",
     "erosion_native",
+    "fluvial_native",
     "geology_native",
     "hydrology_native",
     "planet_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -12,6 +12,7 @@ NATIVE_LIBRARIES = (
     "climate_native",
     "elevation_native",
     "erosion_native",
+    "fluvial_native",
     "geology_native",
     "hydrology_native",
     "planet_native",

--- a/src/map_maker/pipeline/_fluvial_native.py
+++ b/src/map_maker/pipeline/_fluvial_native.py
@@ -1,0 +1,406 @@
+"""Rust-backed sparse-basin fluvial erosion bindings."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import numpy as np
+from cffi import FFI
+
+from .._native import native_library_info, native_library_path
+
+BED_PROFILE_DTYPE = np.dtype(
+    [
+        ("reach_id", "=i4"),
+        ("fine_cell_id", "=i4"),
+        ("parent_cell_id", "=i4"),
+        ("path_order", "=i4"),
+        ("terrain_elevation_m", "=f8"),
+        ("bed_elevation_m", "=f8"),
+        ("incision_depth_m", "=f8"),
+        ("reach_length_m", "=f8"),
+        ("eroded_volume_m3", "=f8"),
+    ],
+    align=True,
+)
+
+REACH_BUDGET_DTYPE = np.dtype(
+    [
+        ("reach_id", "=i4"),
+        ("has_physical_bed", "u1"),
+        ("entry_bed_elevation_m", "=f8"),
+        ("exit_bed_elevation_m", "=f8"),
+        ("minimum_realized_slope", "=f8"),
+        ("maximum_incision_depth_m", "=f8"),
+        ("upstream_input_volume_m3", "=f8"),
+        ("local_erosion_volume_m3", "=f8"),
+        ("available_sediment_volume_m3", "=f8"),
+        ("floodplain_deposition_volume_m3", "=f8"),
+        ("downstream_transfer_volume_m3", "=f8"),
+        ("terminal_deposition_volume_m3", "=f8"),
+        ("exported_sediment_volume_m3", "=f8"),
+    ],
+    align=True,
+)
+
+CELL_BUDGET_DTYPE = np.dtype(
+    [
+        ("fine_cell_id", "=i4"),
+        ("parent_cell_id", "=i4"),
+        ("eroded_volume_m3", "=f8"),
+        ("deposited_volume_m3", "=f8"),
+        ("maximum_incision_depth_m", "=f8"),
+    ],
+    align=True,
+)
+
+_CDEF = """
+typedef struct {
+    double planet_radius_m;
+    double minimum_bed_slope;
+    double maximum_deposition_fraction;
+    double deposition_slope_scale;
+    double maximum_deposition_depth_m;
+} FluvialConfig;
+
+typedef struct {
+    int32_t reach_id;
+    int32_t fine_cell_id;
+    int32_t parent_cell_id;
+    int32_t path_order;
+    double terrain_elevation_m;
+    double bed_elevation_m;
+    double incision_depth_m;
+    double reach_length_m;
+    double eroded_volume_m3;
+} BedProfileRecord;
+
+typedef struct {
+    int32_t reach_id;
+    uint8_t has_physical_bed;
+    double entry_bed_elevation_m;
+    double exit_bed_elevation_m;
+    double minimum_realized_slope;
+    double maximum_incision_depth_m;
+    double upstream_input_volume_m3;
+    double local_erosion_volume_m3;
+    double available_sediment_volume_m3;
+    double floodplain_deposition_volume_m3;
+    double downstream_transfer_volume_m3;
+    double terminal_deposition_volume_m3;
+    double exported_sediment_volume_m3;
+} ReachBudgetRecord;
+
+typedef struct {
+    int32_t fine_cell_id;
+    int32_t parent_cell_id;
+    double eroded_volume_m3;
+    double deposited_volume_m3;
+    double maximum_incision_depth_m;
+} CellBudgetRecord;
+
+typedef struct { BedProfileRecord* data; size_t len; } BedProfileArray;
+typedef struct { ReachBudgetRecord* data; size_t len; } ReachBudgetArray;
+typedef struct { CellBudgetRecord* data; size_t len; } CellBudgetArray;
+
+typedef struct {
+    int32_t physical_node_count;
+    int32_t physical_edge_count;
+    int32_t physical_component_count;
+    int32_t profile_record_count;
+    int32_t reach_count;
+    int32_t connector_reach_count;
+    double maximum_incision_depth_m;
+    double minimum_realized_slope;
+    double total_eroded_volume_m3;
+    double total_floodplain_deposition_volume_m3;
+    double total_terminal_deposition_volume_m3;
+    double total_exported_sediment_volume_m3;
+    double sediment_conservation_residual_m3;
+    double maximum_junction_bed_error_m;
+    int32_t bed_profile_valid;
+    int32_t sediment_conservation_valid;
+} FluvialStats;
+
+int32_t fluvial_run(
+    FluvialConfig config,
+    size_t cell_count,
+    size_t reach_count,
+    size_t membership_count,
+    const int32_t* cell_ids,
+    const int32_t* cell_parent_ids,
+    const float* cell_terrain_m,
+    const double* cell_areas_km2,
+    const float* cell_xyz,
+    const int32_t* reach_ids,
+    const int32_t* downstream_reach_ids,
+    const uint8_t* reach_kinds,
+    const uint8_t* terminal_kinds,
+    const float* channel_width_m,
+    const float* reach_slope,
+    const int32_t* membership_reach_ids,
+    const int32_t* membership_cell_ids,
+    const int32_t* membership_parent_ids,
+    const int32_t* membership_path_order,
+    const double* membership_reach_length_m,
+    const float* membership_channel_fraction,
+    const float* membership_valley_fraction,
+    const float* membership_floodplain_fraction,
+    BedProfileArray* profiles_out,
+    ReachBudgetArray* reaches_out,
+    CellBudgetArray* cells_out,
+    FluvialStats* stats_out
+);
+
+void fluvial_free_profiles(BedProfileArray array);
+void fluvial_free_reaches(ReachBudgetArray array);
+void fluvial_free_cells(CellBudgetArray array);
+"""
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+
+
+def _validate_record_layout(c_name: str, dtype: np.dtype) -> None:
+    if not dtype.isnative or dtype.itemsize != _ffi.sizeof(c_name):
+        raise ImportError(
+            f"{c_name} native layout mismatch: numpy={dtype.itemsize}, "
+            f"cffi={_ffi.sizeof(c_name)}, native_byte_order={dtype.isnative}"
+        )
+    for field in dtype.names or ():
+        numpy_offset = int(dtype.fields[field][1])
+        cffi_offset = int(_ffi.offsetof(c_name, field))
+        if numpy_offset != cffi_offset:
+            raise ImportError(
+                f"{c_name}.{field} offset mismatch: numpy={numpy_offset}, cffi={cffi_offset}"
+            )
+
+
+for _c_name, _dtype in (
+    ("BedProfileRecord", BED_PROFILE_DTYPE),
+    ("ReachBudgetRecord", REACH_BUDGET_DTYPE),
+    ("CellBudgetRecord", CELL_BUDGET_DTYPE),
+):
+    _validate_record_layout(_c_name, _dtype)
+
+native_library_info("fluvial_native")
+_lib = _ffi.dlopen(str(native_library_path("fluvial_native")))
+
+
+def _input(values: np.ndarray, *, name: str, dtype: np.dtype) -> np.ndarray:
+    array = np.asarray(values)
+    if array.dtype != dtype:
+        array = array.astype(dtype)
+    if not array.flags.c_contiguous:
+        array = np.ascontiguousarray(array, dtype=dtype)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional, got {array.shape}")
+    return array
+
+
+def _records(record_array: Any, *, dtype: np.dtype, free) -> np.ndarray:
+    length = int(record_array.len)
+    if length == 0:
+        free(record_array)
+        return np.empty(0, dtype=dtype)
+    buffer = _ffi.buffer(record_array.data, length * dtype.itemsize)
+    records = np.frombuffer(buffer, dtype=dtype, count=length).copy()
+    free(record_array)
+    return records
+
+
+def run_fluvial_erosion(
+    *,
+    controls: Mapping[str, float],
+    cell_ids: np.ndarray,
+    cell_parent_ids: np.ndarray,
+    cell_terrain_m: np.ndarray,
+    cell_areas_km2: np.ndarray,
+    cell_xyz: np.ndarray,
+    reach_ids: np.ndarray,
+    downstream_reach_ids: np.ndarray,
+    reach_kinds: np.ndarray,
+    terminal_kinds: np.ndarray,
+    channel_width_m: np.ndarray,
+    reach_slope: np.ndarray,
+    membership_reach_ids: np.ndarray,
+    membership_cell_ids: np.ndarray,
+    membership_parent_ids: np.ndarray,
+    membership_path_order: np.ndarray,
+    membership_reach_length_m: np.ndarray,
+    membership_channel_fraction: np.ndarray,
+    membership_valley_fraction: np.ndarray,
+    membership_floodplain_fraction: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
+    expected_controls = {
+        "planet_radius_m",
+        "minimum_bed_slope",
+        "maximum_deposition_fraction",
+        "deposition_slope_scale",
+        "maximum_deposition_depth_m",
+    }
+    if set(controls) != expected_controls:
+        raise ValueError(
+            "fluvial controls mismatch: "
+            f"missing={sorted(expected_controls - set(controls))}, "
+            f"extra={sorted(set(controls) - expected_controls)}"
+        )
+    cell_inputs = {
+        "cell_ids": _input(cell_ids, name="cell_ids", dtype=np.dtype(np.int32)),
+        "cell_parent_ids": _input(
+            cell_parent_ids, name="cell_parent_ids", dtype=np.dtype(np.int32)
+        ),
+        "cell_terrain_m": _input(cell_terrain_m, name="cell_terrain_m", dtype=np.dtype(np.float32)),
+        "cell_areas_km2": _input(cell_areas_km2, name="cell_areas_km2", dtype=np.dtype(np.float64)),
+    }
+    cell_count = len(cell_inputs["cell_ids"])
+    if any(len(values) != cell_count for values in cell_inputs.values()):
+        raise ValueError("fluvial cell inputs must have equal lengths")
+    xyz = np.ascontiguousarray(cell_xyz, dtype=np.float32)
+    if xyz.shape != (cell_count, 3):
+        raise ValueError(f"cell_xyz expected shape {(cell_count, 3)}, got {xyz.shape}")
+    xyz_flat = xyz.reshape(-1)
+
+    reach_inputs = {
+        "reach_ids": _input(reach_ids, name="reach_ids", dtype=np.dtype(np.int32)),
+        "downstream_reach_ids": _input(
+            downstream_reach_ids, name="downstream_reach_ids", dtype=np.dtype(np.int32)
+        ),
+        "reach_kinds": _input(reach_kinds, name="reach_kinds", dtype=np.dtype(np.uint8)),
+        "terminal_kinds": _input(terminal_kinds, name="terminal_kinds", dtype=np.dtype(np.uint8)),
+        "channel_width_m": _input(
+            channel_width_m, name="channel_width_m", dtype=np.dtype(np.float32)
+        ),
+        "reach_slope": _input(reach_slope, name="reach_slope", dtype=np.dtype(np.float32)),
+    }
+    reach_count = len(reach_inputs["reach_ids"])
+    if any(len(values) != reach_count for values in reach_inputs.values()):
+        raise ValueError("fluvial reach inputs must have equal lengths")
+
+    membership_inputs = {
+        "membership_reach_ids": _input(
+            membership_reach_ids, name="membership_reach_ids", dtype=np.dtype(np.int32)
+        ),
+        "membership_cell_ids": _input(
+            membership_cell_ids, name="membership_cell_ids", dtype=np.dtype(np.int32)
+        ),
+        "membership_parent_ids": _input(
+            membership_parent_ids, name="membership_parent_ids", dtype=np.dtype(np.int32)
+        ),
+        "membership_path_order": _input(
+            membership_path_order, name="membership_path_order", dtype=np.dtype(np.int32)
+        ),
+        "membership_reach_length_m": _input(
+            membership_reach_length_m,
+            name="membership_reach_length_m",
+            dtype=np.dtype(np.float64),
+        ),
+        "membership_channel_fraction": _input(
+            membership_channel_fraction,
+            name="membership_channel_fraction",
+            dtype=np.dtype(np.float32),
+        ),
+        "membership_valley_fraction": _input(
+            membership_valley_fraction,
+            name="membership_valley_fraction",
+            dtype=np.dtype(np.float32),
+        ),
+        "membership_floodplain_fraction": _input(
+            membership_floodplain_fraction,
+            name="membership_floodplain_fraction",
+            dtype=np.dtype(np.float32),
+        ),
+    }
+    membership_count = len(membership_inputs["membership_reach_ids"])
+    if any(len(values) != membership_count for values in membership_inputs.values()):
+        raise ValueError("fluvial membership inputs must have equal lengths")
+
+    config = _ffi.new(
+        "FluvialConfig*",
+        {
+            name: float(controls[name])
+            for name in (
+                "planet_radius_m",
+                "minimum_bed_slope",
+                "maximum_deposition_fraction",
+                "deposition_slope_scale",
+                "maximum_deposition_depth_m",
+            )
+        },
+    )[0]
+    profiles_out = _ffi.new("BedProfileArray*")
+    reaches_out = _ffi.new("ReachBudgetArray*")
+    cells_out = _ffi.new("CellBudgetArray*")
+    stats_out = _ffi.new("FluvialStats*")
+
+    def pointer(array: np.ndarray, ctype: str):
+        return _ffi.cast(
+            f"const {ctype}*", _ffi.from_buffer(f"{ctype}[]", array, require_writable=False)
+        )
+
+    status = _lib.fluvial_run(
+        config,
+        cell_count,
+        reach_count,
+        membership_count,
+        pointer(cell_inputs["cell_ids"], "int32_t"),
+        pointer(cell_inputs["cell_parent_ids"], "int32_t"),
+        pointer(cell_inputs["cell_terrain_m"], "float"),
+        pointer(cell_inputs["cell_areas_km2"], "double"),
+        pointer(xyz_flat, "float"),
+        pointer(reach_inputs["reach_ids"], "int32_t"),
+        pointer(reach_inputs["downstream_reach_ids"], "int32_t"),
+        pointer(reach_inputs["reach_kinds"], "uint8_t"),
+        pointer(reach_inputs["terminal_kinds"], "uint8_t"),
+        pointer(reach_inputs["channel_width_m"], "float"),
+        pointer(reach_inputs["reach_slope"], "float"),
+        pointer(membership_inputs["membership_reach_ids"], "int32_t"),
+        pointer(membership_inputs["membership_cell_ids"], "int32_t"),
+        pointer(membership_inputs["membership_parent_ids"], "int32_t"),
+        pointer(membership_inputs["membership_path_order"], "int32_t"),
+        pointer(membership_inputs["membership_reach_length_m"], "double"),
+        pointer(membership_inputs["membership_channel_fraction"], "float"),
+        pointer(membership_inputs["membership_valley_fraction"], "float"),
+        pointer(membership_inputs["membership_floodplain_fraction"], "float"),
+        profiles_out,
+        reaches_out,
+        cells_out,
+        stats_out,
+    )
+    if status != 0:
+        messages = {
+            1: "invalid controls or array lengths",
+            2: "null input or output pointer",
+            3: "unknown or inconsistent cell/reach reference",
+            4: "invalid channel/connector physical support",
+            5: "cyclic or reversed physical/reach graph",
+            6: "non-finite or invalid physical input",
+        }
+        raise RuntimeError(f"fluvial_run failed: {messages.get(status, f'status {status}')}")
+
+    profiles = _records(profiles_out[0], dtype=BED_PROFILE_DTYPE, free=_lib.fluvial_free_profiles)
+    reaches = _records(reaches_out[0], dtype=REACH_BUDGET_DTYPE, free=_lib.fluvial_free_reaches)
+    cells = _records(cells_out[0], dtype=CELL_BUDGET_DTYPE, free=_lib.fluvial_free_cells)
+    stats = stats_out[0]
+    metadata = {
+        "physical_node_count": int(stats.physical_node_count),
+        "physical_edge_count": int(stats.physical_edge_count),
+        "physical_component_count": int(stats.physical_component_count),
+        "profile_record_count": int(stats.profile_record_count),
+        "reach_count": int(stats.reach_count),
+        "connector_reach_count": int(stats.connector_reach_count),
+        "maximum_incision_depth_m": float(stats.maximum_incision_depth_m),
+        "minimum_realized_slope": float(stats.minimum_realized_slope),
+        "total_eroded_volume_m3": float(stats.total_eroded_volume_m3),
+        "total_floodplain_deposition_volume_m3": float(stats.total_floodplain_deposition_volume_m3),
+        "total_terminal_deposition_volume_m3": float(stats.total_terminal_deposition_volume_m3),
+        "total_exported_sediment_volume_m3": float(stats.total_exported_sediment_volume_m3),
+        "sediment_conservation_residual_m3": float(stats.sediment_conservation_residual_m3),
+        "maximum_junction_bed_error_m": float(stats.maximum_junction_bed_error_m),
+        "bed_profile_valid": int(stats.bed_profile_valid),
+        "sediment_conservation_valid": int(stats.sediment_conservation_valid),
+    }
+    return profiles, reaches, cells, metadata
+
+
+__all__ = ["run_fluvial_erosion"]

--- a/src/map_maker/pipeline/native/fluvial/Cargo.toml
+++ b/src/map_maker/pipeline/native/fluvial/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fluvial_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/fluvial/src/lib.rs
+++ b/src/map_maker/pipeline/native/fluvial/src/lib.rs
@@ -1,0 +1,925 @@
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
+use std::slice;
+
+const REACH_CHANNEL: u8 = 1;
+const REACH_CONNECTOR: u8 = 2;
+const TERMINAL_NONE: u8 = 0;
+const TERMINAL_OCEAN: u8 = 1;
+const TERMINAL_SINK: u8 = 2;
+
+#[no_mangle]
+pub extern "C" fn fluvial_native_abi_version() -> u32 {
+    3
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FluvialConfig {
+    pub planet_radius_m: f64,
+    pub minimum_bed_slope: f64,
+    pub maximum_deposition_fraction: f64,
+    pub deposition_slope_scale: f64,
+    pub maximum_deposition_depth_m: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct BedProfileRecord {
+    pub reach_id: i32,
+    pub fine_cell_id: i32,
+    pub parent_cell_id: i32,
+    pub path_order: i32,
+    pub terrain_elevation_m: f64,
+    pub bed_elevation_m: f64,
+    pub incision_depth_m: f64,
+    pub reach_length_m: f64,
+    pub eroded_volume_m3: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct ReachBudgetRecord {
+    pub reach_id: i32,
+    pub has_physical_bed: u8,
+    pub entry_bed_elevation_m: f64,
+    pub exit_bed_elevation_m: f64,
+    pub minimum_realized_slope: f64,
+    pub maximum_incision_depth_m: f64,
+    pub upstream_input_volume_m3: f64,
+    pub local_erosion_volume_m3: f64,
+    pub available_sediment_volume_m3: f64,
+    pub floodplain_deposition_volume_m3: f64,
+    pub downstream_transfer_volume_m3: f64,
+    pub terminal_deposition_volume_m3: f64,
+    pub exported_sediment_volume_m3: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct CellBudgetRecord {
+    pub fine_cell_id: i32,
+    pub parent_cell_id: i32,
+    pub eroded_volume_m3: f64,
+    pub deposited_volume_m3: f64,
+    pub maximum_incision_depth_m: f64,
+}
+
+#[repr(C)]
+pub struct BedProfileArray {
+    pub data: *mut BedProfileRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct ReachBudgetArray {
+    pub data: *mut ReachBudgetRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct CellBudgetArray {
+    pub data: *mut CellBudgetRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FluvialStats {
+    pub physical_node_count: i32,
+    pub physical_edge_count: i32,
+    pub physical_component_count: i32,
+    pub profile_record_count: i32,
+    pub reach_count: i32,
+    pub connector_reach_count: i32,
+    pub maximum_incision_depth_m: f64,
+    pub minimum_realized_slope: f64,
+    pub total_eroded_volume_m3: f64,
+    pub total_floodplain_deposition_volume_m3: f64,
+    pub total_terminal_deposition_volume_m3: f64,
+    pub total_exported_sediment_volume_m3: f64,
+    pub sediment_conservation_residual_m3: f64,
+    pub maximum_junction_bed_error_m: f64,
+    pub bed_profile_valid: i32,
+    pub sediment_conservation_valid: i32,
+}
+
+struct Inputs<'a> {
+    cell_ids: &'a [i32],
+    cell_parent_ids: &'a [i32],
+    cell_terrain_m: &'a [f32],
+    cell_areas_km2: &'a [f64],
+    cell_xyz: &'a [f32],
+    reach_ids: &'a [i32],
+    downstream_reach_ids: &'a [i32],
+    reach_kinds: &'a [u8],
+    terminal_kinds: &'a [u8],
+    channel_width_m: &'a [f32],
+    reach_slope: &'a [f32],
+    membership_reach_ids: &'a [i32],
+    membership_cell_ids: &'a [i32],
+    membership_parent_ids: &'a [i32],
+    membership_path_order: &'a [i32],
+    membership_reach_length_m: &'a [f64],
+    membership_channel_fraction: &'a [f32],
+    membership_valley_fraction: &'a [f32],
+    membership_floodplain_fraction: &'a [f32],
+}
+
+struct Outcome {
+    profiles: Vec<BedProfileRecord>,
+    reaches: Vec<ReachBudgetRecord>,
+    cells: Vec<CellBudgetRecord>,
+    stats: FluvialStats,
+}
+
+#[derive(Clone, Copy, Default)]
+struct CellAccumulator {
+    parent_cell_id: i32,
+    eroded_volume_m3: f64,
+    deposited_volume_m3: f64,
+    maximum_incision_depth_m: f64,
+}
+
+fn finite_nonnegative(value: f64) -> bool {
+    value.is_finite() && value >= 0.0
+}
+
+fn angular_distance(first: [f32; 3], second: [f32; 3]) -> f64 {
+    let dot = first[0] as f64 * second[0] as f64
+        + first[1] as f64 * second[1] as f64
+        + first[2] as f64 * second[2] as f64;
+    dot.clamp(-1.0, 1.0).acos()
+}
+
+fn topological_order(adjacency: &[Vec<usize>], indegree: &[usize]) -> Result<Vec<usize>, i32> {
+    let mut degree = indegree.to_vec();
+    let mut ready = BinaryHeap::new();
+    for (node, &value) in degree.iter().enumerate() {
+        if value == 0 {
+            ready.push(Reverse(node));
+        }
+    }
+    let mut order = Vec::with_capacity(adjacency.len());
+    while let Some(Reverse(node)) = ready.pop() {
+        order.push(node);
+        for &target in &adjacency[node] {
+            degree[target] -= 1;
+            if degree[target] == 0 {
+                ready.push(Reverse(target));
+            }
+        }
+    }
+    if order.len() != adjacency.len() {
+        return Err(5);
+    }
+    Ok(order)
+}
+
+fn validate_inputs(config: FluvialConfig, inputs: &Inputs<'_>) -> Result<(), i32> {
+    if !config.planet_radius_m.is_finite()
+        || config.planet_radius_m <= 0.0
+        || !finite_nonnegative(config.minimum_bed_slope)
+        || !finite_nonnegative(config.maximum_deposition_fraction)
+        || config.maximum_deposition_fraction > 1.0
+        || !config.deposition_slope_scale.is_finite()
+        || config.deposition_slope_scale <= 0.0
+        || !finite_nonnegative(config.maximum_deposition_depth_m)
+    {
+        return Err(1);
+    }
+    let cell_count = inputs.cell_ids.len();
+    let reach_count = inputs.reach_ids.len();
+    let membership_count = inputs.membership_reach_ids.len();
+    if cell_count == 0
+        || reach_count == 0
+        || inputs.cell_parent_ids.len() != cell_count
+        || inputs.cell_terrain_m.len() != cell_count
+        || inputs.cell_areas_km2.len() != cell_count
+        || inputs.cell_xyz.len() != cell_count * 3
+        || inputs.downstream_reach_ids.len() != reach_count
+        || inputs.reach_kinds.len() != reach_count
+        || inputs.terminal_kinds.len() != reach_count
+        || inputs.channel_width_m.len() != reach_count
+        || inputs.reach_slope.len() != reach_count
+        || inputs.membership_cell_ids.len() != membership_count
+        || inputs.membership_parent_ids.len() != membership_count
+        || inputs.membership_path_order.len() != membership_count
+        || inputs.membership_reach_length_m.len() != membership_count
+        || inputs.membership_channel_fraction.len() != membership_count
+        || inputs.membership_valley_fraction.len() != membership_count
+        || inputs.membership_floodplain_fraction.len() != membership_count
+    {
+        return Err(1);
+    }
+    if inputs.cell_terrain_m.iter().any(|value| !value.is_finite())
+        || inputs
+            .cell_areas_km2
+            .iter()
+            .any(|value| !value.is_finite() || *value <= 0.0)
+        || inputs.cell_xyz.iter().any(|value| !value.is_finite())
+        || inputs
+            .channel_width_m
+            .iter()
+            .chain(inputs.reach_slope)
+            .any(|value| !value.is_finite() || *value < 0.0)
+        || inputs
+            .membership_reach_length_m
+            .iter()
+            .any(|value| !finite_nonnegative(*value))
+        || inputs
+            .membership_channel_fraction
+            .iter()
+            .chain(inputs.membership_valley_fraction)
+            .chain(inputs.membership_floodplain_fraction)
+            .any(|value| !value.is_finite() || !(0.0..=1.0).contains(value))
+    {
+        return Err(6);
+    }
+    Ok(())
+}
+
+fn run_fluvial(config: FluvialConfig, inputs: &Inputs<'_>) -> Result<Outcome, i32> {
+    validate_inputs(config, inputs)?;
+    let cell_row_by_id = inputs
+        .cell_ids
+        .iter()
+        .enumerate()
+        .map(|(row, &cell_id)| (cell_id, row))
+        .collect::<HashMap<_, _>>();
+    if cell_row_by_id.len() != inputs.cell_ids.len() {
+        return Err(3);
+    }
+    let reach_row_by_id = inputs
+        .reach_ids
+        .iter()
+        .enumerate()
+        .map(|(row, &reach_id)| (reach_id, row))
+        .collect::<HashMap<_, _>>();
+    if reach_row_by_id.len() != inputs.reach_ids.len() {
+        return Err(3);
+    }
+
+    let mut centerline_by_reach = vec![Vec::<usize>::new(); inputs.reach_ids.len()];
+    let mut support_by_reach = vec![Vec::<usize>::new(); inputs.reach_ids.len()];
+    let mut physical_cell_ids = BTreeSet::new();
+    for reach in 0..inputs.reach_ids.len() {
+        if !matches!(inputs.reach_kinds[reach], REACH_CHANNEL | REACH_CONNECTOR)
+            || (inputs.reach_kinds[reach] == REACH_CONNECTOR
+                && inputs.channel_width_m[reach] != 0.0)
+        {
+            return Err(4);
+        }
+    }
+    for membership in 0..inputs.membership_reach_ids.len() {
+        let reach = *reach_row_by_id
+            .get(&inputs.membership_reach_ids[membership])
+            .ok_or(3)?;
+        let cell = *cell_row_by_id
+            .get(&inputs.membership_cell_ids[membership])
+            .ok_or(3)?;
+        if inputs.cell_parent_ids[cell] != inputs.membership_parent_ids[membership] {
+            return Err(3);
+        }
+        if inputs.reach_kinds[reach] == REACH_CONNECTOR {
+            return Err(4);
+        }
+        support_by_reach[reach].push(membership);
+        if inputs.membership_reach_length_m[membership] > 0.0 {
+            if inputs.reach_kinds[reach] != REACH_CHANNEL
+                || inputs.channel_width_m[reach] <= 0.0
+                || inputs.membership_channel_fraction[membership] <= 0.0
+            {
+                return Err(4);
+            }
+            centerline_by_reach[reach].push(membership);
+            physical_cell_ids.insert(inputs.membership_cell_ids[membership]);
+        }
+    }
+    for centerline in &mut centerline_by_reach {
+        centerline.sort_by_key(|&membership| {
+            (
+                inputs.membership_path_order[membership],
+                inputs.membership_cell_ids[membership],
+            )
+        });
+        if centerline.windows(2).any(|pair| {
+            inputs.membership_path_order[pair[0]] == inputs.membership_path_order[pair[1]]
+        }) {
+            return Err(3);
+        }
+    }
+
+    let node_cell_ids = physical_cell_ids.into_iter().collect::<Vec<_>>();
+    let node_by_cell = node_cell_ids
+        .iter()
+        .enumerate()
+        .map(|(node, &cell_id)| (cell_id, node))
+        .collect::<HashMap<_, _>>();
+    let mut node_terrain = Vec::with_capacity(node_cell_ids.len());
+    let mut node_xyz = Vec::with_capacity(node_cell_ids.len());
+    for &cell_id in &node_cell_ids {
+        let row = *cell_row_by_id.get(&cell_id).ok_or(3)?;
+        node_terrain.push(inputs.cell_terrain_m[row] as f64);
+        node_xyz.push([
+            inputs.cell_xyz[row * 3],
+            inputs.cell_xyz[row * 3 + 1],
+            inputs.cell_xyz[row * 3 + 2],
+        ]);
+    }
+
+    let mut edge_set = HashSet::new();
+    let mut adjacency = vec![Vec::<(usize, f64)>::new(); node_cell_ids.len()];
+    let mut undirected = vec![Vec::<usize>::new(); node_cell_ids.len()];
+    let mut indegree = vec![0usize; node_cell_ids.len()];
+    for centerline in &centerline_by_reach {
+        for pair in centerline.windows(2) {
+            let first_order = inputs.membership_path_order[pair[0]];
+            let second_order = inputs.membership_path_order[pair[1]];
+            if second_order != first_order + 1 {
+                continue;
+            }
+            let source = *node_by_cell
+                .get(&inputs.membership_cell_ids[pair[0]])
+                .ok_or(3)?;
+            let target = *node_by_cell
+                .get(&inputs.membership_cell_ids[pair[1]])
+                .ok_or(3)?;
+            if source == target || edge_set.contains(&(target, source)) {
+                return Err(5);
+            }
+            if edge_set.insert((source, target)) {
+                let length_m =
+                    angular_distance(node_xyz[source], node_xyz[target]) * config.planet_radius_m;
+                if !length_m.is_finite() || length_m <= 0.0 {
+                    return Err(6);
+                }
+                adjacency[source].push((target, length_m));
+                undirected[source].push(target);
+                undirected[target].push(source);
+                indegree[target] += 1;
+            }
+        }
+    }
+    for targets in &mut adjacency {
+        targets.sort_by_key(|(target, _)| *target);
+    }
+    let adjacency_nodes = adjacency
+        .iter()
+        .map(|targets| {
+            targets
+                .iter()
+                .map(|(target, _)| *target)
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let node_order = topological_order(&adjacency_nodes, &indegree)?;
+    let mut bed = node_terrain.clone();
+    for &source in &node_order {
+        for &(target, length_m) in &adjacency[source] {
+            let maximum_target = bed[source] - config.minimum_bed_slope * length_m;
+            bed[target] = bed[target].min(maximum_target);
+        }
+    }
+
+    let mut component_count = 0usize;
+    let mut seen = vec![false; node_cell_ids.len()];
+    for start in 0..node_cell_ids.len() {
+        if seen[start] {
+            continue;
+        }
+        component_count += 1;
+        seen[start] = true;
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            for &neighbor in &undirected[node] {
+                if !seen[neighbor] {
+                    seen[neighbor] = true;
+                    stack.push(neighbor);
+                }
+            }
+        }
+    }
+
+    let mut cell_accumulators = BTreeMap::<i32, CellAccumulator>::new();
+    let mut profiles = Vec::new();
+    let mut local_erosion = vec![0.0f64; inputs.reach_ids.len()];
+    let mut maximum_reach_incision = vec![0.0f64; inputs.reach_ids.len()];
+    let mut entry_bed = vec![f64::NAN; inputs.reach_ids.len()];
+    let mut exit_bed = vec![f64::NAN; inputs.reach_ids.len()];
+    let mut minimum_reach_slope = vec![f64::NAN; inputs.reach_ids.len()];
+    let mut maximum_incision_depth = 0.0f64;
+    let mut minimum_realized_slope = f64::INFINITY;
+    for (reach, centerline) in centerline_by_reach.iter().enumerate() {
+        if !centerline.is_empty() {
+            let first_node = *node_by_cell
+                .get(&inputs.membership_cell_ids[centerline[0]])
+                .ok_or(3)?;
+            let last_node = *node_by_cell
+                .get(&inputs.membership_cell_ids[*centerline.last().ok_or(3)?])
+                .ok_or(3)?;
+            entry_bed[reach] = bed[first_node];
+            exit_bed[reach] = bed[last_node];
+        }
+        let mut reach_minimum_slope = f64::INFINITY;
+        for pair in centerline.windows(2) {
+            if inputs.membership_path_order[pair[1]] != inputs.membership_path_order[pair[0]] + 1 {
+                continue;
+            }
+            let source = *node_by_cell
+                .get(&inputs.membership_cell_ids[pair[0]])
+                .ok_or(3)?;
+            let target = *node_by_cell
+                .get(&inputs.membership_cell_ids[pair[1]])
+                .ok_or(3)?;
+            let length_m =
+                angular_distance(node_xyz[source], node_xyz[target]) * config.planet_radius_m;
+            let realized = (bed[source] - bed[target]) / length_m;
+            reach_minimum_slope = reach_minimum_slope.min(realized);
+            minimum_realized_slope = minimum_realized_slope.min(realized);
+        }
+        if reach_minimum_slope.is_finite() {
+            minimum_reach_slope[reach] = reach_minimum_slope;
+        }
+        for &membership in centerline {
+            let cell_id = inputs.membership_cell_ids[membership];
+            let cell_row = *cell_row_by_id.get(&cell_id).ok_or(3)?;
+            let node = *node_by_cell.get(&cell_id).ok_or(3)?;
+            let incision_depth_m = (node_terrain[node] - bed[node]).max(0.0);
+            let eroded_volume_m3 = incision_depth_m
+                * inputs.channel_width_m[reach] as f64
+                * inputs.membership_reach_length_m[membership];
+            local_erosion[reach] += eroded_volume_m3;
+            maximum_reach_incision[reach] = maximum_reach_incision[reach].max(incision_depth_m);
+            maximum_incision_depth = maximum_incision_depth.max(incision_depth_m);
+            let accumulator = cell_accumulators.entry(cell_id).or_insert(CellAccumulator {
+                parent_cell_id: inputs.cell_parent_ids[cell_row],
+                ..CellAccumulator::default()
+            });
+            accumulator.eroded_volume_m3 += eroded_volume_m3;
+            accumulator.maximum_incision_depth_m =
+                accumulator.maximum_incision_depth_m.max(incision_depth_m);
+            profiles.push(BedProfileRecord {
+                reach_id: inputs.reach_ids[reach],
+                fine_cell_id: cell_id,
+                parent_cell_id: inputs.membership_parent_ids[membership],
+                path_order: inputs.membership_path_order[membership],
+                terrain_elevation_m: node_terrain[node],
+                bed_elevation_m: bed[node],
+                incision_depth_m,
+                reach_length_m: inputs.membership_reach_length_m[membership],
+                eroded_volume_m3,
+            });
+        }
+    }
+    profiles.sort_by_key(|record| (record.reach_id, record.path_order, record.fine_cell_id));
+
+    let mut reach_adjacency = vec![Vec::<usize>::new(); inputs.reach_ids.len()];
+    let mut reach_indegree = vec![0usize; inputs.reach_ids.len()];
+    for (reach, downstream_targets) in reach_adjacency.iter_mut().enumerate() {
+        let downstream_id = inputs.downstream_reach_ids[reach];
+        if downstream_id >= 0 {
+            let downstream = *reach_row_by_id.get(&downstream_id).ok_or(3)?;
+            downstream_targets.push(downstream);
+            reach_indegree[downstream] += 1;
+            if inputs.terminal_kinds[reach] != TERMINAL_NONE {
+                return Err(3);
+            }
+        } else if !matches!(inputs.terminal_kinds[reach], TERMINAL_OCEAN | TERMINAL_SINK) {
+            return Err(3);
+        }
+    }
+    let reach_order = topological_order(&reach_adjacency, &reach_indegree)?;
+    let mut upstream_input = vec![0.0f64; inputs.reach_ids.len()];
+    let mut reaches = vec![ReachBudgetRecord::default(); inputs.reach_ids.len()];
+    let mut total_floodplain_deposition = 0.0f64;
+    let mut total_terminal_deposition = 0.0f64;
+    let mut total_exported = 0.0f64;
+    for &reach in &reach_order {
+        let available = upstream_input[reach] + local_erosion[reach];
+        let mut floodplain_area_m2 = 0.0f64;
+        let mut valley_area_m2 = 0.0f64;
+        for &membership in &support_by_reach[reach] {
+            let cell = *cell_row_by_id
+                .get(&inputs.membership_cell_ids[membership])
+                .ok_or(3)?;
+            let area_m2 = inputs.cell_areas_km2[cell] * 1_000_000.0;
+            floodplain_area_m2 +=
+                inputs.membership_floodplain_fraction[membership] as f64 * area_m2;
+            valley_area_m2 += inputs.membership_valley_fraction[membership] as f64 * area_m2;
+        }
+        let deposition_fraction = if inputs.reach_kinds[reach] == REACH_CHANNEL
+            && floodplain_area_m2 > 0.0
+            && valley_area_m2 > 0.0
+        {
+            let support_ratio = (floodplain_area_m2 / valley_area_m2).clamp(0.0, 1.0);
+            let slope_factor = config.deposition_slope_scale
+                / (inputs.reach_slope[reach] as f64 + config.deposition_slope_scale);
+            (config.maximum_deposition_fraction * support_ratio * slope_factor).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let deposition_capacity = floodplain_area_m2 * config.maximum_deposition_depth_m;
+        let deposition = (available * deposition_fraction).min(deposition_capacity);
+        if deposition > 0.0 {
+            for &membership in &support_by_reach[reach] {
+                let cell_id = inputs.membership_cell_ids[membership];
+                let cell = *cell_row_by_id.get(&cell_id).ok_or(3)?;
+                let support_area_m2 = inputs.membership_floodplain_fraction[membership] as f64
+                    * inputs.cell_areas_km2[cell]
+                    * 1_000_000.0;
+                if support_area_m2 <= 0.0 {
+                    continue;
+                }
+                let allocated = deposition * support_area_m2 / floodplain_area_m2;
+                let accumulator = cell_accumulators.entry(cell_id).or_insert(CellAccumulator {
+                    parent_cell_id: inputs.cell_parent_ids[cell],
+                    ..CellAccumulator::default()
+                });
+                accumulator.deposited_volume_m3 += allocated;
+            }
+        }
+        total_floodplain_deposition += deposition;
+        let remainder = (available - deposition).max(0.0);
+        let downstream_id = inputs.downstream_reach_ids[reach];
+        let mut downstream_transfer = 0.0;
+        let mut terminal_deposition = 0.0;
+        let mut exported = 0.0;
+        if downstream_id >= 0 {
+            let downstream = *reach_row_by_id.get(&downstream_id).ok_or(3)?;
+            upstream_input[downstream] += remainder;
+            downstream_transfer = remainder;
+        } else if inputs.terminal_kinds[reach] == TERMINAL_SINK {
+            terminal_deposition = remainder;
+            total_terminal_deposition += remainder;
+        } else {
+            exported = remainder;
+            total_exported += remainder;
+        }
+        reaches[reach] = ReachBudgetRecord {
+            reach_id: inputs.reach_ids[reach],
+            has_physical_bed: u8::from(!centerline_by_reach[reach].is_empty()),
+            entry_bed_elevation_m: entry_bed[reach],
+            exit_bed_elevation_m: exit_bed[reach],
+            minimum_realized_slope: minimum_reach_slope[reach],
+            maximum_incision_depth_m: maximum_reach_incision[reach],
+            upstream_input_volume_m3: upstream_input[reach],
+            local_erosion_volume_m3: local_erosion[reach],
+            available_sediment_volume_m3: available,
+            floodplain_deposition_volume_m3: deposition,
+            downstream_transfer_volume_m3: downstream_transfer,
+            terminal_deposition_volume_m3: terminal_deposition,
+            exported_sediment_volume_m3: exported,
+        };
+    }
+
+    let cells = cell_accumulators
+        .into_iter()
+        .map(|(fine_cell_id, value)| CellBudgetRecord {
+            fine_cell_id,
+            parent_cell_id: value.parent_cell_id,
+            eroded_volume_m3: value.eroded_volume_m3,
+            deposited_volume_m3: value.deposited_volume_m3,
+            maximum_incision_depth_m: value.maximum_incision_depth_m,
+        })
+        .collect::<Vec<_>>();
+    let total_eroded = local_erosion.iter().sum::<f64>();
+    let conservation_residual =
+        total_eroded - total_floodplain_deposition - total_terminal_deposition - total_exported;
+    let conservation_tolerance = 1e-9 * total_eroded.max(1.0);
+    let bed_profile_valid = bed
+        .iter()
+        .enumerate()
+        .all(|(node, value)| value.is_finite() && *value <= node_terrain[node] + 1e-6)
+        && adjacency.iter().enumerate().all(|(source, targets)| {
+            targets.iter().all(|(target, length_m)| {
+                bed[source] + 1e-6 >= bed[*target] + config.minimum_bed_slope * *length_m
+            })
+        });
+    let stats = FluvialStats {
+        physical_node_count: i32::try_from(node_cell_ids.len()).map_err(|_| 1)?,
+        physical_edge_count: i32::try_from(edge_set.len()).map_err(|_| 1)?,
+        physical_component_count: i32::try_from(component_count).map_err(|_| 1)?,
+        profile_record_count: i32::try_from(profiles.len()).map_err(|_| 1)?,
+        reach_count: i32::try_from(inputs.reach_ids.len()).map_err(|_| 1)?,
+        connector_reach_count: i32::try_from(
+            inputs
+                .reach_kinds
+                .iter()
+                .filter(|kind| **kind == REACH_CONNECTOR)
+                .count(),
+        )
+        .map_err(|_| 1)?,
+        maximum_incision_depth_m: maximum_incision_depth,
+        minimum_realized_slope: if minimum_realized_slope.is_finite() {
+            minimum_realized_slope
+        } else {
+            0.0
+        },
+        total_eroded_volume_m3: total_eroded,
+        total_floodplain_deposition_volume_m3: total_floodplain_deposition,
+        total_terminal_deposition_volume_m3: total_terminal_deposition,
+        total_exported_sediment_volume_m3: total_exported,
+        sediment_conservation_residual_m3: conservation_residual,
+        maximum_junction_bed_error_m: 0.0,
+        bed_profile_valid: i32::from(bed_profile_valid),
+        sediment_conservation_valid: i32::from(
+            conservation_residual.abs() <= conservation_tolerance,
+        ),
+    };
+    Ok(Outcome {
+        profiles,
+        reaches,
+        cells,
+        stats,
+    })
+}
+
+fn into_raw_array<T>(values: Vec<T>) -> (*mut T, usize) {
+    let mut values = values.into_boxed_slice();
+    let result = (values.as_mut_ptr(), values.len());
+    let _ = Box::leak(values);
+    result
+}
+
+fn free_raw_array<T>(data: *mut T, len: usize) {
+    if !data.is_null() {
+        unsafe {
+            let values = std::ptr::slice_from_raw_parts_mut(data, len);
+            drop(Box::from_raw(values));
+        }
+    }
+}
+
+unsafe fn read_slice<'a, T>(pointer: *const T, len: usize) -> &'a [T] {
+    unsafe { slice::from_raw_parts(pointer, len) }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+/// Solve sparse channel-bed profiles and route their eroded sediment.
+///
+/// # Safety
+///
+/// Every pointer must reference a contiguous buffer of the declared length.
+/// Output pointers must be valid and must not alias input buffers.
+pub unsafe extern "C" fn fluvial_run(
+    config: FluvialConfig,
+    cell_count: usize,
+    reach_count: usize,
+    membership_count: usize,
+    cell_ids: *const i32,
+    cell_parent_ids: *const i32,
+    cell_terrain_m: *const f32,
+    cell_areas_km2: *const f64,
+    cell_xyz: *const f32,
+    reach_ids: *const i32,
+    downstream_reach_ids: *const i32,
+    reach_kinds: *const u8,
+    terminal_kinds: *const u8,
+    channel_width_m: *const f32,
+    reach_slope: *const f32,
+    membership_reach_ids: *const i32,
+    membership_cell_ids: *const i32,
+    membership_parent_ids: *const i32,
+    membership_path_order: *const i32,
+    membership_reach_length_m: *const f64,
+    membership_channel_fraction: *const f32,
+    membership_valley_fraction: *const f32,
+    membership_floodplain_fraction: *const f32,
+    profiles_out: *mut BedProfileArray,
+    reaches_out: *mut ReachBudgetArray,
+    cells_out: *mut CellBudgetArray,
+    stats_out: *mut FluvialStats,
+) -> i32 {
+    if cell_count == 0
+        || reach_count == 0
+        || cell_ids.is_null()
+        || cell_parent_ids.is_null()
+        || cell_terrain_m.is_null()
+        || cell_areas_km2.is_null()
+        || cell_xyz.is_null()
+        || reach_ids.is_null()
+        || downstream_reach_ids.is_null()
+        || reach_kinds.is_null()
+        || terminal_kinds.is_null()
+        || channel_width_m.is_null()
+        || reach_slope.is_null()
+        || (membership_count > 0
+            && (membership_reach_ids.is_null()
+                || membership_cell_ids.is_null()
+                || membership_parent_ids.is_null()
+                || membership_path_order.is_null()
+                || membership_reach_length_m.is_null()
+                || membership_channel_fraction.is_null()
+                || membership_valley_fraction.is_null()
+                || membership_floodplain_fraction.is_null()))
+        || profiles_out.is_null()
+        || reaches_out.is_null()
+        || cells_out.is_null()
+        || stats_out.is_null()
+    {
+        return 2;
+    }
+    let inputs = Inputs {
+        cell_ids: unsafe { read_slice(cell_ids, cell_count) },
+        cell_parent_ids: unsafe { read_slice(cell_parent_ids, cell_count) },
+        cell_terrain_m: unsafe { read_slice(cell_terrain_m, cell_count) },
+        cell_areas_km2: unsafe { read_slice(cell_areas_km2, cell_count) },
+        cell_xyz: unsafe { read_slice(cell_xyz, cell_count * 3) },
+        reach_ids: unsafe { read_slice(reach_ids, reach_count) },
+        downstream_reach_ids: unsafe { read_slice(downstream_reach_ids, reach_count) },
+        reach_kinds: unsafe { read_slice(reach_kinds, reach_count) },
+        terminal_kinds: unsafe { read_slice(terminal_kinds, reach_count) },
+        channel_width_m: unsafe { read_slice(channel_width_m, reach_count) },
+        reach_slope: unsafe { read_slice(reach_slope, reach_count) },
+        membership_reach_ids: unsafe { read_slice(membership_reach_ids, membership_count) },
+        membership_cell_ids: unsafe { read_slice(membership_cell_ids, membership_count) },
+        membership_parent_ids: unsafe { read_slice(membership_parent_ids, membership_count) },
+        membership_path_order: unsafe { read_slice(membership_path_order, membership_count) },
+        membership_reach_length_m: unsafe {
+            read_slice(membership_reach_length_m, membership_count)
+        },
+        membership_channel_fraction: unsafe {
+            read_slice(membership_channel_fraction, membership_count)
+        },
+        membership_valley_fraction: unsafe {
+            read_slice(membership_valley_fraction, membership_count)
+        },
+        membership_floodplain_fraction: unsafe {
+            read_slice(membership_floodplain_fraction, membership_count)
+        },
+    };
+    match run_fluvial(config, &inputs) {
+        Ok(outcome) => {
+            let (profiles, profile_count) = into_raw_array(outcome.profiles);
+            let (reaches, output_reach_count) = into_raw_array(outcome.reaches);
+            let (cells, output_cell_count) = into_raw_array(outcome.cells);
+            unsafe {
+                *profiles_out = BedProfileArray {
+                    data: profiles,
+                    len: profile_count,
+                };
+                *reaches_out = ReachBudgetArray {
+                    data: reaches,
+                    len: output_reach_count,
+                };
+                *cells_out = CellBudgetArray {
+                    data: cells,
+                    len: output_cell_count,
+                };
+                *stats_out = outcome.stats;
+            }
+            0
+        }
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn fluvial_free_profiles(array: BedProfileArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[no_mangle]
+pub extern "C" fn fluvial_free_reaches(array: ReachBudgetArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[no_mangle]
+pub extern "C" fn fluvial_free_cells(array: CellBudgetArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> FluvialConfig {
+        FluvialConfig {
+            planet_radius_m: 1.0,
+            minimum_bed_slope: 0.0,
+            maximum_deposition_fraction: 0.25,
+            deposition_slope_scale: 0.001,
+            maximum_deposition_depth_m: 10.0,
+        }
+    }
+
+    #[test]
+    fn profile_cuts_downstream_rise_and_conserves_sediment() {
+        let inputs = Inputs {
+            cell_ids: &[10, 11, 12],
+            cell_parent_ids: &[1, 1, 1],
+            cell_terrain_m: &[10.0, 8.0, 9.0],
+            cell_areas_km2: &[1.0, 1.0, 1.0],
+            cell_xyz: &[1.0, 0.0, 0.0, 0.999, 0.04, 0.0, 0.996, 0.08, 0.0],
+            reach_ids: &[1],
+            downstream_reach_ids: &[-1],
+            reach_kinds: &[REACH_CHANNEL],
+            terminal_kinds: &[TERMINAL_OCEAN],
+            channel_width_m: &[10.0],
+            reach_slope: &[0.01],
+            membership_reach_ids: &[1, 1, 1],
+            membership_cell_ids: &[10, 11, 12],
+            membership_parent_ids: &[1, 1, 1],
+            membership_path_order: &[0, 1, 2],
+            membership_reach_length_m: &[50.0, 100.0, 50.0],
+            membership_channel_fraction: &[0.0005, 0.001, 0.0005],
+            membership_valley_fraction: &[0.01, 0.01, 0.01],
+            membership_floodplain_fraction: &[0.005, 0.005, 0.005],
+        };
+        let outcome = run_fluvial(config(), &inputs).expect("valid fluvial result");
+        let beds = outcome
+            .profiles
+            .iter()
+            .map(|record| record.bed_elevation_m)
+            .collect::<Vec<_>>();
+        assert_eq!(beds, vec![10.0, 8.0, 8.0]);
+        assert_eq!(outcome.profiles[2].incision_depth_m, 1.0);
+        assert_eq!(outcome.stats.bed_profile_valid, 1);
+        assert_eq!(outcome.stats.sediment_conservation_valid, 1);
+        assert!(outcome.stats.total_eroded_volume_m3 > 0.0);
+        assert!(outcome.stats.total_exported_sediment_volume_m3 > 0.0);
+    }
+
+    #[test]
+    fn connector_transfers_without_physical_process_support() {
+        let inputs = Inputs {
+            cell_ids: &[10, 11, 12, 13],
+            cell_parent_ids: &[1, 1, 2, 2],
+            cell_terrain_m: &[10.0, 8.0, 7.0, 8.0],
+            cell_areas_km2: &[1.0; 4],
+            cell_xyz: &[
+                1.0, 0.0, 0.0, 0.999, 0.04, 0.0, 0.996, 0.08, 0.0, 0.992, 0.12, 0.0,
+            ],
+            reach_ids: &[1, 2, 3],
+            downstream_reach_ids: &[2, 3, -1],
+            reach_kinds: &[REACH_CHANNEL, REACH_CONNECTOR, REACH_CHANNEL],
+            terminal_kinds: &[TERMINAL_NONE, TERMINAL_NONE, TERMINAL_OCEAN],
+            channel_width_m: &[10.0, 0.0, 20.0],
+            reach_slope: &[0.01, 0.0, 0.001],
+            membership_reach_ids: &[1, 1, 3, 3],
+            membership_cell_ids: &[10, 11, 12, 13],
+            membership_parent_ids: &[1, 1, 2, 2],
+            membership_path_order: &[0, 1, 0, 1],
+            membership_reach_length_m: &[50.0; 4],
+            membership_channel_fraction: &[0.0005, 0.0005, 0.001, 0.001],
+            membership_valley_fraction: &[0.01; 4],
+            membership_floodplain_fraction: &[0.005; 4],
+        };
+        let outcome = run_fluvial(config(), &inputs).expect("valid connector routing");
+        let connector = &outcome.reaches[1];
+        assert_eq!(connector.has_physical_bed, 0);
+        assert_eq!(connector.local_erosion_volume_m3, 0.0);
+        assert_eq!(connector.floodplain_deposition_volume_m3, 0.0);
+        assert_eq!(
+            connector.upstream_input_volume_m3,
+            outcome.reaches[0].downstream_transfer_volume_m3
+        );
+        assert_eq!(
+            connector.downstream_transfer_volume_m3,
+            connector.upstream_input_volume_m3
+        );
+        assert_eq!(outcome.stats.sediment_conservation_valid, 1);
+    }
+
+    #[test]
+    fn confluences_share_one_junction_bed() {
+        let inputs = Inputs {
+            cell_ids: &[10, 20, 12, 13],
+            cell_parent_ids: &[1, 2, 3, 3],
+            cell_terrain_m: &[10.0, 9.0, 8.0, 9.0],
+            cell_areas_km2: &[1.0; 4],
+            cell_xyz: &[
+                1.0, 0.0, 0.0, 0.999, -0.04, 0.0, 0.999, 0.04, 0.0, 0.996, 0.08, 0.0,
+            ],
+            reach_ids: &[1, 2, 3],
+            downstream_reach_ids: &[3, 3, -1],
+            reach_kinds: &[REACH_CHANNEL; 3],
+            terminal_kinds: &[TERMINAL_NONE, TERMINAL_NONE, TERMINAL_OCEAN],
+            channel_width_m: &[10.0, 10.0, 20.0],
+            reach_slope: &[0.01, 0.01, 0.001],
+            membership_reach_ids: &[1, 1, 2, 2, 3, 3],
+            membership_cell_ids: &[10, 12, 20, 12, 12, 13],
+            membership_parent_ids: &[1, 3, 2, 3, 3, 3],
+            membership_path_order: &[0, 1, 0, 1, 0, 1],
+            membership_reach_length_m: &[50.0; 6],
+            membership_channel_fraction: &[0.0005, 0.0005, 0.0005, 0.0005, 0.001, 0.001],
+            membership_valley_fraction: &[0.01; 6],
+            membership_floodplain_fraction: &[0.005; 6],
+        };
+        let outcome = run_fluvial(config(), &inputs).expect("valid confluence profile");
+        let junction_beds = outcome
+            .profiles
+            .iter()
+            .filter(|record| record.fine_cell_id == 12)
+            .map(|record| record.bed_elevation_m)
+            .collect::<Vec<_>>();
+        assert_eq!(junction_beds, vec![8.0, 8.0, 8.0]);
+        assert_eq!(outcome.reaches[0].exit_bed_elevation_m, 8.0);
+        assert_eq!(outcome.reaches[1].exit_bed_elevation_m, 8.0);
+        assert_eq!(outcome.reaches[2].entry_bed_elevation_m, 8.0);
+        assert_eq!(outcome.stats.maximum_junction_bed_error_m, 0.0);
+        assert_eq!(outcome.stats.sediment_conservation_valid, 1);
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -7,6 +7,7 @@ from . import planet  # noqa: F401
 from . import climate  # noqa: F401
 from . import hydrology  # noqa: F401
 from . import basin_refinement  # noqa: F401
+from . import basin_erosion  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -25,6 +26,7 @@ def ensure_builtin_stages() -> None:
         "climate": climate,
         "hydrology": hydrology,
         "basin_refinement": basin_refinement,
+        "basin_erosion": basin_erosion,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/basin_erosion.py
+++ b/src/map_maker/pipeline/stages/basin_erosion.py
@@ -1,0 +1,822 @@
+"""Conservative fluvial incision and sediment routing for one refined basin."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+import pyarrow as pa
+from PIL import Image, ImageDraw
+
+from .._fluvial_native import run_fluvial_erosion
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+EARTH_RADIUS_M = 6_371_000.0
+
+
+@dataclass(frozen=True)
+class BasinErosionConfig:
+    minimum_bed_slope: float = 1e-5
+    maximum_deposition_fraction: float = 0.35
+    deposition_slope_scale: float = 0.001
+    maximum_deposition_depth_m: float = 10.0
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "BasinErosionConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown basin erosion controls: {', '.join(sorted(unknown))}")
+        values = {
+            name: float(mapping.get(name, field.default))
+            for name, field in cls.__dataclass_fields__.items()
+        }
+        if not np.isfinite(values["minimum_bed_slope"]) or values["minimum_bed_slope"] < 0.0:
+            raise ValueError("minimum_bed_slope must be finite and non-negative")
+        maximum_deposition_fraction = values["maximum_deposition_fraction"]
+        if not np.isfinite(maximum_deposition_fraction) or not (
+            0.0 <= maximum_deposition_fraction <= 1.0
+        ):
+            raise ValueError("maximum_deposition_fraction must be finite and in [0, 1]")
+        if (
+            not np.isfinite(values["deposition_slope_scale"])
+            or values["deposition_slope_scale"] <= 0.0
+        ):
+            raise ValueError("deposition_slope_scale must be finite and positive")
+        if (
+            not np.isfinite(values["maximum_deposition_depth_m"])
+            or values["maximum_deposition_depth_m"] < 0.0
+        ):
+            raise ValueError("maximum_deposition_depth_m must be finite and non-negative")
+        return cls(**values)
+
+
+def _artifact_table(result, name: str) -> pa.Table:
+    record = result.artifact_records.get(name)
+    if record is None or not isinstance(record.value, pa.Table):
+        raise KeyError(f"Missing dependency table '{name}'")
+    return record.value
+
+
+def _column(table: pa.Table, name: str, dtype: np.dtype) -> np.ndarray:
+    return np.ascontiguousarray(
+        table[name].combine_chunks().to_numpy(zero_copy_only=False), dtype=dtype
+    )
+
+
+def _fixed_list_column(table: pa.Table, name: str, width: int) -> np.ndarray:
+    values = table[name].combine_chunks().values.to_numpy(zero_copy_only=False)
+    return np.ascontiguousarray(values.reshape(table.num_rows, width), dtype=np.float32)
+
+
+def _lookup_rows(ids: np.ndarray, query: np.ndarray, *, label: str) -> np.ndarray:
+    order = np.argsort(ids)
+    sorted_ids = ids[order]
+    positions = np.searchsorted(sorted_ids, query)
+    if np.any(positions >= len(sorted_ids)) or np.any(sorted_ids[positions] != query):
+        raise RuntimeError(f"{label} references an unknown identifier")
+    return order[positions]
+
+
+def _profile_table(records: np.ndarray) -> pa.Table:
+    return pa.table(
+        {
+            "reach_id": pa.array(records["reach_id"], type=pa.int32()),
+            "fine_cell_id": pa.array(records["fine_cell_id"], type=pa.int32()),
+            "parent_cell_id": pa.array(records["parent_cell_id"], type=pa.int32()),
+            "path_order": pa.array(records["path_order"], type=pa.int32()),
+            "terrain_elevation_m": pa.array(records["terrain_elevation_m"], type=pa.float64()),
+            "bed_elevation_m": pa.array(records["bed_elevation_m"], type=pa.float64()),
+            "incision_depth_m": pa.array(records["incision_depth_m"], type=pa.float64()),
+            "reach_length_m": pa.array(records["reach_length_m"], type=pa.float64()),
+            "eroded_volume_m3": pa.array(records["eroded_volume_m3"], type=pa.float64()),
+        }
+    )
+
+
+def _reach_table(source: pa.Table, records: np.ndarray) -> pa.Table:
+    source_ids = np.asarray(source["reach_id"], dtype=np.int32)
+    if not np.array_equal(source_ids, records["reach_id"]):
+        raise RuntimeError("fluvial kernel changed reach order or identity")
+    has_bed = records["has_physical_bed"] != 0
+    table = source
+    table = table.append_column("has_physical_bed", pa.array(has_bed, type=pa.bool_()))
+    for name in (
+        "entry_bed_elevation_m",
+        "exit_bed_elevation_m",
+        "minimum_realized_slope",
+        "maximum_incision_depth_m",
+    ):
+        table = table.append_column(
+            name,
+            pa.array(records[name], mask=~has_bed, type=pa.float64()),
+        )
+    for name in (
+        "upstream_input_volume_m3",
+        "local_erosion_volume_m3",
+        "available_sediment_volume_m3",
+        "floodplain_deposition_volume_m3",
+        "downstream_transfer_volume_m3",
+        "terminal_deposition_volume_m3",
+        "exported_sediment_volume_m3",
+    ):
+        table = table.append_column(name, pa.array(records[name], type=pa.float64()))
+    return table
+
+
+def _cell_table(source: pa.Table, records: np.ndarray) -> tuple[pa.Table, dict[str, float]]:
+    fine_ids = np.asarray(source["fine_cell_id"], dtype=np.int32)
+    areas_m2 = np.asarray(source["area_km2"], dtype=np.float64) * 1_000_000.0
+    terrain = np.asarray(source["terrain_elevation_m"], dtype=np.float32)
+    eroded = np.zeros(source.num_rows, dtype=np.float64)
+    deposited = np.zeros(source.num_rows, dtype=np.float64)
+    maximum_incision = np.zeros(source.num_rows, dtype=np.float64)
+    if len(records):
+        rows = _lookup_rows(fine_ids, records["fine_cell_id"], label="fluvial cell budget")
+        if not np.array_equal(
+            np.asarray(source["parent_cell_id"], dtype=np.int32)[rows],
+            records["parent_cell_id"],
+        ):
+            raise RuntimeError("fluvial cell budget changed parent identity")
+        eroded[rows] = records["eroded_volume_m3"]
+        deposited[rows] = records["deposited_volume_m3"]
+        maximum_incision[rows] = records["maximum_incision_depth_m"]
+    mean_delta = (deposited - eroded) / areas_m2
+    terrain_after = terrain.astype(np.float64) + mean_delta
+    table = source.append_column("subgrid_eroded_volume_m3", pa.array(eroded, type=pa.float64()))
+    table = table.append_column(
+        "floodplain_deposited_volume_m3", pa.array(deposited, type=pa.float64())
+    )
+    table = table.append_column(
+        "maximum_channel_incision_m", pa.array(maximum_incision, type=pa.float64())
+    )
+    table = table.append_column("terrain_mean_delta_m", pa.array(mean_delta, type=pa.float64()))
+    table = table.append_column(
+        "terrain_elevation_after_m", pa.array(terrain_after, type=pa.float64())
+    )
+    represented_delta_volume = float(np.sum(mean_delta * areas_m2))
+    expected_delta_volume = float(np.sum(deposited) - np.sum(eroded))
+    return table, {
+        "maximum_absolute_cell_mean_delta_m": float(np.max(np.abs(mean_delta), initial=0.0)),
+        "cell_mean_volume_relation_residual_m3": represented_delta_volume - expected_delta_volume,
+    }
+
+
+def _parent_table(source: pa.Table, cells: pa.Table) -> tuple[pa.Table, dict[str, float]]:
+    parent_ids = np.asarray(source["parent_cell_id"], dtype=np.int32)
+    child_parent_ids = np.asarray(cells["parent_cell_id"], dtype=np.int32)
+    parent_rows = _lookup_rows(parent_ids, child_parent_ids, label="eroded child parent")
+    eroded = np.zeros(source.num_rows, dtype=np.float64)
+    deposited = np.zeros(source.num_rows, dtype=np.float64)
+    np.add.at(
+        eroded,
+        parent_rows,
+        np.asarray(cells["subgrid_eroded_volume_m3"], dtype=np.float64),
+    )
+    np.add.at(
+        deposited,
+        parent_rows,
+        np.asarray(cells["floodplain_deposited_volume_m3"], dtype=np.float64),
+    )
+    area_m2 = np.asarray(source["parent_area_km2"], dtype=np.float64) * 1_000_000.0
+    mean_delta = (deposited - eroded) / area_m2
+    table = source.append_column("child_eroded_volume_m3", pa.array(eroded, type=pa.float64()))
+    table = table.append_column("child_deposited_volume_m3", pa.array(deposited, type=pa.float64()))
+    table = table.append_column(
+        "restricted_terrain_mean_delta_m", pa.array(mean_delta, type=pa.float64())
+    )
+    child_net = float(
+        np.sum(np.asarray(cells["floodplain_deposited_volume_m3"], dtype=np.float64))
+        - np.sum(np.asarray(cells["subgrid_eroded_volume_m3"], dtype=np.float64))
+    )
+    return table, {
+        "parent_budget_residual_m3": float(np.sum(deposited - eroded)) - child_net,
+        "maximum_absolute_parent_mean_delta_m": float(np.max(np.abs(mean_delta), initial=0.0)),
+    }
+
+
+def _maximum_junction_error(profiles: pa.Table) -> float:
+    cell_ids = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    beds = np.asarray(profiles["bed_elevation_m"], dtype=np.float64)
+    order = np.argsort(cell_ids, kind="stable")
+    sorted_ids = cell_ids[order]
+    sorted_beds = beds[order]
+    maximum = 0.0
+    start = 0
+    while start < len(sorted_ids):
+        end = start + 1
+        while end < len(sorted_ids) and sorted_ids[end] == sorted_ids[start]:
+            end += 1
+        maximum = max(
+            maximum, float(np.max(sorted_beds[start:end]) - np.min(sorted_beds[start:end]))
+        )
+        start = end
+    return maximum
+
+
+def _group_sums(
+    target_ids: np.ndarray,
+    source_ids: np.ndarray,
+    values: np.ndarray,
+    *,
+    label: str,
+) -> np.ndarray:
+    totals = np.zeros(len(target_ids), dtype=np.float64)
+    if len(source_ids):
+        rows = _lookup_rows(target_ids, source_ids, label=label)
+        np.add.at(totals, rows, values)
+    return totals
+
+
+def _profile_audit(
+    profiles: pa.Table,
+    reaches: pa.Table,
+    cells: pa.Table,
+    *,
+    radius_m: float,
+) -> dict[str, float | int]:
+    reach_ids = np.asarray(profiles["reach_id"], dtype=np.int32)
+    cell_ids = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    path_order = np.asarray(profiles["path_order"], dtype=np.int32)
+    terrain = np.asarray(profiles["terrain_elevation_m"], dtype=np.float64)
+    bed = np.asarray(profiles["bed_elevation_m"], dtype=np.float64)
+    depth = np.asarray(profiles["incision_depth_m"], dtype=np.float64)
+    length_m = np.asarray(profiles["reach_length_m"], dtype=np.float64)
+    volume_m3 = np.asarray(profiles["eroded_volume_m3"], dtype=np.float64)
+    catalog_reach_ids = np.asarray(reaches["reach_id"], dtype=np.int32)
+    reach_rows = _lookup_rows(catalog_reach_ids, reach_ids, label="bed profile reach")
+    width_m = np.asarray(reaches["channel_width_m"], dtype=np.float64)[reach_rows]
+    expected_volume = width_m * length_m * depth
+
+    fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    profile_cell_rows = _lookup_rows(fine_ids, cell_ids, label="bed profile cell")
+    xyz = _fixed_list_column(cells, "xyz", 3).astype(np.float64)
+    profile_xyz = xyz[profile_cell_rows]
+    sort_order = np.lexsort((path_order, reach_ids))
+    sorted_reaches = reach_ids[sort_order]
+    sorted_paths = path_order[sort_order]
+    edge_mask = (sorted_reaches[1:] == sorted_reaches[:-1]) & (
+        sorted_paths[1:] == sorted_paths[:-1] + 1
+    )
+    edge_sources = sort_order[:-1][edge_mask]
+    edge_targets = sort_order[1:][edge_mask]
+    if len(edge_sources):
+        source_xyz = profile_xyz[edge_sources]
+        target_xyz = profile_xyz[edge_targets]
+        dot = (
+            source_xyz[:, 0] * target_xyz[:, 0]
+            + source_xyz[:, 1] * target_xyz[:, 1]
+            + source_xyz[:, 2] * target_xyz[:, 2]
+        )
+        edge_length_m = np.arccos(np.clip(dot, -1.0, 1.0)) * radius_m
+        if np.any(~np.isfinite(edge_length_m)) or np.any(edge_length_m <= 0.0):
+            raise RuntimeError("published bed profile contains an invalid physical edge")
+        slopes = (bed[edge_sources] - bed[edge_targets]) / edge_length_m
+        minimum_slope = float(np.min(slopes))
+    else:
+        minimum_slope = 0.0
+
+    return {
+        "emitted_physical_edge_count": int(len(edge_sources)),
+        "emitted_minimum_realized_slope": minimum_slope,
+        "maximum_junction_bed_error_m": _maximum_junction_error(profiles),
+        "maximum_bed_above_terrain_error_m": float(
+            np.max(np.maximum(bed - terrain, 0.0), initial=0.0)
+        ),
+        "maximum_profile_depth_relation_error_m": float(
+            np.max(np.abs(depth - (terrain - bed)), initial=0.0)
+        ),
+        "maximum_profile_volume_relation_residual_m3": float(
+            np.max(np.abs(volume_m3 - expected_volume), initial=0.0)
+        ),
+    }
+
+
+def _budget_audit(
+    profiles: pa.Table,
+    reaches: pa.Table,
+    cells: pa.Table,
+    parents: pa.Table,
+) -> dict[str, float]:
+    reach_ids = np.asarray(reaches["reach_id"], dtype=np.int32)
+    profile_reach_ids = np.asarray(profiles["reach_id"], dtype=np.int32)
+    profile_volume = np.asarray(profiles["eroded_volume_m3"], dtype=np.float64)
+    local_erosion = np.asarray(reaches["local_erosion_volume_m3"], dtype=np.float64)
+    profile_by_reach = _group_sums(
+        reach_ids, profile_reach_ids, profile_volume, label="profile erosion reach"
+    )
+
+    fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    profile_cell_ids = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    profile_by_cell = _group_sums(
+        fine_ids, profile_cell_ids, profile_volume, label="profile erosion cell"
+    )
+    cell_eroded = np.asarray(cells["subgrid_eroded_volume_m3"], dtype=np.float64)
+    cell_deposited = np.asarray(cells["floodplain_deposited_volume_m3"], dtype=np.float64)
+    reach_deposited = np.asarray(reaches["floodplain_deposition_volume_m3"], dtype=np.float64)
+
+    upstream_input = np.asarray(reaches["upstream_input_volume_m3"], dtype=np.float64)
+    available = np.asarray(reaches["available_sediment_volume_m3"], dtype=np.float64)
+    transfer = np.asarray(reaches["downstream_transfer_volume_m3"], dtype=np.float64)
+    terminal = np.asarray(reaches["terminal_deposition_volume_m3"], dtype=np.float64)
+    exported = np.asarray(reaches["exported_sediment_volume_m3"], dtype=np.float64)
+    downstream_ids = np.asarray(reaches["downstream_reach_id"], dtype=np.int32)
+    expected_upstream = np.zeros(reaches.num_rows, dtype=np.float64)
+    routed = downstream_ids >= 0
+    if np.any(routed):
+        downstream_rows = _lookup_rows(
+            reach_ids, downstream_ids[routed], label="downstream sediment reach"
+        )
+        np.add.at(expected_upstream, downstream_rows, transfer[routed])
+
+    parent_ids = np.asarray(parents["parent_cell_id"], dtype=np.int32)
+    cell_parent_ids = np.asarray(cells["parent_cell_id"], dtype=np.int32)
+    eroded_by_parent = _group_sums(
+        parent_ids, cell_parent_ids, cell_eroded, label="cell erosion parent"
+    )
+    deposited_by_parent = _group_sums(
+        parent_ids, cell_parent_ids, cell_deposited, label="cell deposition parent"
+    )
+    published_parent_eroded = np.asarray(parents["child_eroded_volume_m3"], dtype=np.float64)
+    published_parent_deposited = np.asarray(parents["child_deposited_volume_m3"], dtype=np.float64)
+
+    total_profile_eroded = float(np.sum(profile_volume))
+    total_cell_deposited = float(np.sum(cell_deposited))
+    independent_sediment_residual = (
+        total_profile_eroded
+        - total_cell_deposited
+        - float(np.sum(terminal))
+        - float(np.sum(exported))
+    )
+    return {
+        "independent_total_eroded_volume_m3": total_profile_eroded,
+        "independent_total_floodplain_deposition_volume_m3": total_cell_deposited,
+        "independent_total_terminal_deposition_volume_m3": float(np.sum(terminal)),
+        "independent_total_exported_sediment_volume_m3": float(np.sum(exported)),
+        "independent_sediment_conservation_residual_m3": independent_sediment_residual,
+        "maximum_reach_local_erosion_residual_m3": float(
+            np.max(np.abs(profile_by_reach - local_erosion), initial=0.0)
+        ),
+        "maximum_cell_erosion_residual_m3": float(
+            np.max(np.abs(profile_by_cell - cell_eroded), initial=0.0)
+        ),
+        "floodplain_deposition_catalog_residual_m3": total_cell_deposited
+        - float(np.sum(reach_deposited)),
+        "maximum_reach_available_residual_m3": float(
+            np.max(np.abs(available - upstream_input - local_erosion), initial=0.0)
+        ),
+        "maximum_reach_output_balance_residual_m3": float(
+            np.max(
+                np.abs(available - reach_deposited - transfer - terminal - exported),
+                initial=0.0,
+            )
+        ),
+        "maximum_downstream_input_residual_m3": float(
+            np.max(np.abs(expected_upstream - upstream_input), initial=0.0)
+        ),
+        "maximum_parent_erosion_residual_m3": float(
+            np.max(np.abs(eroded_by_parent - published_parent_eroded), initial=0.0)
+        ),
+        "maximum_parent_deposition_residual_m3": float(
+            np.max(np.abs(deposited_by_parent - published_parent_deposited), initial=0.0)
+        ),
+    }
+
+
+def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
+    cell_record = result.artifact_records.get("ErodedBasinCellCatalog")
+    profile_record = result.artifact_records.get("ChannelBedProfileCatalog")
+    reach_record = result.artifact_records.get("FluvialRiverReachCatalog")
+    metadata_record = result.artifact_records.get("BasinErosionMetadata")
+    if (
+        cell_record is None
+        or profile_record is None
+        or reach_record is None
+        or metadata_record is None
+        or not isinstance(cell_record.value, pa.Table)
+        or not isinstance(profile_record.value, pa.Table)
+        or not isinstance(reach_record.value, pa.Table)
+    ):
+        return None
+    cells = cell_record.value
+    profiles = profile_record.value
+    reaches = reach_record.value
+    metadata = metadata_record.value
+    fine_resolution = int(metadata["fine_resolution"])
+    display_resolution = min(fine_resolution, 768)
+    placements = np.array([[1, 1], [1, 3], [1, 2], [1, 0], [0, 1], [2, 1]])
+    image = np.full((display_resolution * 3, display_resolution * 4, 3), 18, dtype=np.uint8)
+    face = np.asarray(cells["face"], dtype=np.int32)
+    row = np.asarray(cells["row"], dtype=np.int32)
+    col = np.asarray(cells["col"], dtype=np.int32)
+    elevation = np.asarray(cells["terrain_elevation_after_m"], dtype=np.float64)
+    low, high = np.percentile(elevation, [2.0, 98.0])
+    normalized = np.clip((elevation - low) / max(float(high - low), 1e-6), 0.0, 1.0)
+    colors = np.stack(
+        (52 + 153 * normalized, 80 + 132 * normalized, 51 + 101 * normalized), axis=1
+    ).astype(np.uint8)
+    display_row = np.minimum(row * display_resolution // fine_resolution, display_resolution - 1)
+    display_col = np.minimum(col * display_resolution // fine_resolution, display_resolution - 1)
+    net_row = placements[face, 0] * display_resolution + display_row
+    net_col = placements[face, 1] * display_resolution + display_col
+    image[net_row, net_col] = colors
+
+    incision = np.asarray(cells["maximum_channel_incision_m"], dtype=np.float64)
+    deposition = np.asarray(cells["floodplain_deposited_volume_m3"], dtype=np.float64)
+    positive_incision = incision[incision > 0.0]
+    incision_scale = (
+        float(np.percentile(positive_incision, 95.0)) if len(positive_incision) else 1.0
+    )
+    positive_deposition = deposition[deposition > 0.0]
+    deposition_scale = (
+        float(np.percentile(positive_deposition, 95.0)) if len(positive_deposition) else 1.0
+    )
+    for index in np.flatnonzero((incision > 0.0) | (deposition > 0.0)):
+        target = np.array((118, 77, 50), dtype=np.float32)
+        strength = min(1.0, float(incision[index]) / max(incision_scale, 1e-9))
+        if deposition[index] > 0.0:
+            target = np.array((155, 151, 80), dtype=np.float32)
+            strength = max(
+                strength,
+                min(1.0, float(deposition[index]) / max(deposition_scale, 1e-9)),
+            )
+        alpha = 0.18 + 0.38 * strength
+        image[net_row[index], net_col[index]] = (
+            image[net_row[index], net_col[index]].astype(np.float32) * (1.0 - alpha)
+            + target * alpha
+        ).astype(np.uint8)
+
+    rendered = Image.fromarray(image, mode="RGB")
+    draw = ImageDraw.Draw(rendered)
+    fine_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    for path, reach_kind in zip(
+        reaches["fine_cell_path"].to_pylist(), reaches["reach_kind"].to_pylist(), strict=True
+    ):
+        if reach_kind != "connector":
+            continue
+        rows = _lookup_rows(
+            fine_ids, np.asarray(path, dtype=np.int32), label="connector path visual"
+        )
+        path_face = face[rows]
+        path_row = placements[path_face, 0] * display_resolution + display_row[rows]
+        path_col = placements[path_face, 1] * display_resolution + display_col[rows]
+        segment_start = 0
+        for index in range(1, len(rows) + 1):
+            if index == len(rows) or path_face[index] != path_face[index - 1]:
+                if index - segment_start >= 2:
+                    draw.line(
+                        [
+                            (int(path_col[position]), int(path_row[position]))
+                            for position in range(segment_start, index)
+                        ],
+                        fill=(69, 114, 132),
+                        width=1,
+                    )
+                segment_start = index
+    profile_reaches = np.asarray(profiles["reach_id"], dtype=np.int32)
+    profile_cells = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    profile_orders = np.asarray(profiles["path_order"], dtype=np.int32)
+    for reach_id in np.unique(profile_reaches):
+        mask = profile_reaches == reach_id
+        sequence = np.flatnonzero(mask)[np.argsort(profile_orders[mask])]
+        rows = _lookup_rows(fine_ids, profile_cells[sequence], label="bed profile visual")
+        path_face = face[rows]
+        path_row = placements[path_face, 0] * display_resolution + display_row[rows]
+        path_col = placements[path_face, 1] * display_resolution + display_col[rows]
+        segment_start = 0
+        for index in range(1, len(rows) + 1):
+            split = index == len(rows) or (
+                profile_orders[sequence[index]] != profile_orders[sequence[index - 1]] + 1
+                if index < len(rows)
+                else True
+            )
+            if split:
+                if index - segment_start >= 2:
+                    draw.line(
+                        [
+                            (int(path_col[position]), int(path_row[position]))
+                            for position in range(segment_start, index)
+                        ],
+                        fill=(26, 165, 221),
+                        width=2,
+                    )
+                segment_start = index
+    padding = max(12, display_resolution // 40)
+    left = max(0, int(np.min(net_col)) - padding)
+    upper = max(0, int(np.min(net_row)) - padding)
+    right = min(rendered.width, int(np.max(net_col)) + padding + 1)
+    lower = min(rendered.height, int(np.max(net_row)) + padding + 1)
+    rendered = rendered.crop((left, upper, right, lower))
+    scale = min(1600 / rendered.width, 1000 / rendered.height)
+    if scale > 1.0:
+        rendered = rendered.resize(
+            (max(1, round(rendered.width * scale)), max(1, round(rendered.height * scale))),
+            Image.Resampling.NEAREST,
+        )
+    output = request.output_dir / "eroded_basin.png"
+    rendered.save(output)
+    local_erosion = np.asarray(reaches["local_erosion_volume_m3"], dtype=np.float64)
+    diagnostic_reach = int(
+        np.asarray(reaches["reach_id"], dtype=np.int32)[np.argmax(local_erosion)]
+    )
+    diagnostic_mask = profile_reaches == diagnostic_reach
+    diagnostic_rows = np.flatnonzero(diagnostic_mask)[np.argsort(profile_orders[diagnostic_mask])]
+    if len(diagnostic_rows) >= 2:
+        distances_km = (
+            np.cumsum(np.asarray(profiles["reach_length_m"], dtype=np.float64)[diagnostic_rows])
+            / 1_000.0
+        )
+        terrain_profile = np.asarray(profiles["terrain_elevation_m"], dtype=np.float64)[
+            diagnostic_rows
+        ]
+        bed_profile = np.asarray(profiles["bed_elevation_m"], dtype=np.float64)[diagnostic_rows]
+        chart = Image.new("RGB", (1400, 720), (20, 22, 21))
+        chart_draw = ImageDraw.Draw(chart)
+        left_margin, right_margin = 88, 42
+        top_margin, bottom_margin = 58, 72
+        chart_width = chart.width - left_margin - right_margin
+        chart_height = chart.height - top_margin - bottom_margin
+        elevation_low = float(min(np.min(bed_profile), np.min(terrain_profile)))
+        elevation_high = float(max(np.max(bed_profile), np.max(terrain_profile)))
+        elevation_span = max(elevation_high - elevation_low, 1.0)
+        distance_span = max(float(distances_km[-1] - distances_km[0]), 1e-9)
+
+        def chart_points(values: np.ndarray) -> list[tuple[int, int]]:
+            return [
+                (
+                    round(left_margin + (distance - distances_km[0]) / distance_span * chart_width),
+                    round(top_margin + (elevation_high - value) / elevation_span * chart_height),
+                )
+                for distance, value in zip(distances_km, values, strict=True)
+            ]
+
+        for fraction in np.linspace(0.0, 1.0, 6):
+            y = round(top_margin + fraction * chart_height)
+            chart_draw.line(
+                [(left_margin, y), (left_margin + chart_width, y)],
+                fill=(48, 52, 49),
+                width=1,
+            )
+            value = elevation_high - fraction * elevation_span
+            chart_draw.text((12, y - 7), f"{value:.0f} m", fill=(160, 165, 158))
+        terrain_points = chart_points(terrain_profile)
+        bed_points = chart_points(bed_profile)
+        chart_draw.polygon(terrain_points + list(reversed(bed_points)), fill=(72, 55, 39))
+        chart_draw.line(terrain_points, fill=(216, 178, 101), width=3)
+        chart_draw.line(bed_points, fill=(34, 178, 229), width=3)
+        chart_draw.text(
+            (left_margin, 20),
+            f"Reach {diagnostic_reach}: terrain prior and least-incision bed",
+            fill=(225, 229, 222),
+        )
+        chart_draw.text(
+            (left_margin, chart.height - 42),
+            f"{distances_km[0]:.0f} km",
+            fill=(160, 165, 158),
+        )
+        chart_draw.text(
+            (left_margin + chart_width - 56, chart.height - 42),
+            f"{distances_km[-1]:.0f} km",
+            fill=(160, 165, 158),
+        )
+        chart.save(request.output_dir / "longitudinal_profile.png")
+    return VisualizationResult(
+        output,
+        "ErodedBasinCellCatalog",
+        {
+            "basin_id": metadata["selected_basin_id"],
+            "eroded_volume_km3": metadata["total_eroded_volume_km3"],
+        },
+    )
+
+
+@stage(
+    "basin_erosion",
+    inputs=("basin_refinement", "planet"),
+    outputs=(
+        "ChannelBedProfileCatalog",
+        "FluvialRiverReachCatalog",
+        "ErodedBasinCellCatalog",
+        "BasinErosionParentCatalog",
+        "BasinErosionMetadata",
+    ),
+    version="v1",
+    native_libraries=("fluvial_native",),
+    visualizer=_cube_net_visualizer,
+)
+def basin_erosion_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = BasinErosionConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("basin erosion requires topology: cubed_sphere")
+    refinement = deps["basin_refinement"]
+    refinement_metadata = refinement.artifact_records["BasinRefinementMetadata"].value
+    if refinement_metadata["source_to_sink_ready"] != 1:
+        raise RuntimeError("basin erosion requires a source-to-sink-ready refined reach graph")
+    for gate in (
+        "directed_path_graph_valid",
+        "corridor_cell_capacity_valid",
+        "nested_corridor_support_valid",
+        "process_exclusion_valid",
+    ):
+        if refinement_metadata[gate] != 1:
+            raise RuntimeError(f"basin erosion requires refinement gate {gate}")
+    cells = _artifact_table(refinement, "RefinedBasinCellCatalog")
+    parents = _artifact_table(refinement, "RefinedBasinParentCatalog")
+    reaches = _artifact_table(refinement, "RefinedRiverReachCatalog")
+    memberships = _artifact_table(refinement, "RefinedReachCellCatalog")
+    reach_kind_names = reaches["reach_kind"].to_pylist()
+    reach_kinds = np.ascontiguousarray(
+        [
+            1 if value == "channel" else 2 if value == "connector" else 0
+            for value in reach_kind_names
+        ],
+        dtype=np.uint8,
+    )
+    if np.any(reach_kinds == 0):
+        raise RuntimeError("basin erosion received an unknown reach kind")
+    terminal_kind_names = reaches["terminal_kind"].to_pylist()
+    terminal_kinds = np.ascontiguousarray(
+        [
+            (
+                0
+                if value == "downstream_reach"
+                else 1 if value == "ocean" else 2 if value == "registered_sink" else 255
+            )
+            for value in terminal_kind_names
+        ],
+        dtype=np.uint8,
+    )
+    if np.any(terminal_kinds == 255):
+        raise RuntimeError("basin erosion received an unresolved reach terminal")
+    reach_ids = _column(reaches, "reach_id", np.dtype(np.int32))
+    membership_reach_ids = _column(memberships, "reach_id", np.dtype(np.int32))
+    membership_parent_ids = _column(memberships, "parent_cell_id", np.dtype(np.int32))
+    connector = reach_kinds == 2
+    connector_ids = reach_ids[connector]
+    if np.any(np.isin(membership_reach_ids, connector_ids)):
+        raise RuntimeError("hydrologic connectors must not publish physical cell support")
+    excluded_parent_ids = np.asarray(
+        parents.filter(parents["process_excluded"])["parent_cell_id"], dtype=np.int32
+    )
+    if np.any(np.isin(membership_parent_ids, excluded_parent_ids)):
+        raise RuntimeError("refined reach support enters a process-excluded parent")
+    planet = deps["planet"].artifact_records["PlanetMetadata"].value
+    radius_m = float(planet["planet_radius_earth"]) * EARTH_RADIUS_M
+    controls = {**asdict(config), "planet_radius_m": radius_m}
+    with context.timed("conservative_fluvial_erosion_kernel"):
+        profile_records, reach_records, cell_records, metadata = run_fluvial_erosion(
+            controls=controls,
+            cell_ids=_column(cells, "fine_cell_id", np.dtype(np.int32)),
+            cell_parent_ids=_column(cells, "parent_cell_id", np.dtype(np.int32)),
+            cell_terrain_m=_column(cells, "terrain_elevation_m", np.dtype(np.float32)),
+            cell_areas_km2=_column(cells, "area_km2", np.dtype(np.float64)),
+            cell_xyz=_fixed_list_column(cells, "xyz", 3),
+            reach_ids=reach_ids,
+            downstream_reach_ids=_column(reaches, "downstream_reach_id", np.dtype(np.int32)),
+            reach_kinds=reach_kinds,
+            terminal_kinds=terminal_kinds,
+            channel_width_m=_column(reaches, "channel_width_m", np.dtype(np.float32)),
+            reach_slope=_column(reaches, "slope", np.dtype(np.float32)),
+            membership_reach_ids=membership_reach_ids,
+            membership_cell_ids=_column(memberships, "fine_cell_id", np.dtype(np.int32)),
+            membership_parent_ids=membership_parent_ids,
+            membership_path_order=_column(memberships, "path_order", np.dtype(np.int32)),
+            membership_reach_length_m=_column(memberships, "reach_length_m", np.dtype(np.float64)),
+            membership_channel_fraction=_column(
+                memberships, "channel_fraction", np.dtype(np.float32)
+            ),
+            membership_valley_fraction=_column(
+                memberships, "valley_fraction", np.dtype(np.float32)
+            ),
+            membership_floodplain_fraction=_column(
+                memberships, "floodplain_fraction", np.dtype(np.float32)
+            ),
+        )
+    profiles = _profile_table(profile_records)
+    eroded_reaches = _reach_table(reaches, reach_records)
+    eroded_cells, cell_metadata = _cell_table(cells, cell_records)
+    eroded_parents, parent_metadata = _parent_table(parents, eroded_cells)
+    profile_audit = _profile_audit(profiles, eroded_reaches, eroded_cells, radius_m=radius_m)
+    budget_audit = _budget_audit(profiles, eroded_reaches, eroded_cells, eroded_parents)
+    cell_process = (cell_records["eroded_volume_m3"] != 0.0) | (
+        cell_records["deposited_volume_m3"] != 0.0
+    )
+    process_exclusion_valid = bool(
+        not np.any(np.isin(profile_records["parent_cell_id"], excluded_parent_ids))
+        and not np.any(np.isin(cell_records["parent_cell_id"][cell_process], excluded_parent_ids))
+    )
+    connector_process_valid = bool(
+        np.all(reach_records["has_physical_bed"][connector] == 0)
+        and np.all(reach_records["local_erosion_volume_m3"][connector] == 0.0)
+        and np.all(reach_records["floodplain_deposition_volume_m3"][connector] == 0.0)
+        and not np.any(np.isin(profile_records["reach_id"], connector_ids))
+    )
+    potential_volume_m3 = float(
+        np.sum(np.asarray(memberships["potential_incised_volume_m3"], dtype=np.float64))
+    )
+    total_eroded_m3 = float(budget_audit["independent_total_eroded_volume_m3"])
+    native_catalog_residuals = {
+        "native_total_eroded_catalog_residual_m3": float(metadata["total_eroded_volume_m3"])
+        - total_eroded_m3,
+        "native_floodplain_deposition_catalog_residual_m3": float(
+            metadata["total_floodplain_deposition_volume_m3"]
+        )
+        - float(budget_audit["independent_total_floodplain_deposition_volume_m3"]),
+        "native_terminal_deposition_catalog_residual_m3": float(
+            metadata["total_terminal_deposition_volume_m3"]
+        )
+        - float(budget_audit["independent_total_terminal_deposition_volume_m3"]),
+        "native_export_catalog_residual_m3": float(metadata["total_exported_sediment_volume_m3"])
+        - float(budget_audit["independent_total_exported_sediment_volume_m3"]),
+    }
+    metadata.update(
+        {
+            **asdict(config),
+            **cell_metadata,
+            **parent_metadata,
+            **profile_audit,
+            **budget_audit,
+            **native_catalog_residuals,
+            "selected_basin_id": int(refinement_metadata["selected_basin_id"]),
+            "fine_resolution": int(refinement_metadata["fine_resolution"]),
+            "source_to_sink_ready": 1,
+            "process_exclusion_valid": int(process_exclusion_valid),
+            "connector_process_valid": int(connector_process_valid),
+            "potential_incised_volume_km3": potential_volume_m3 / 1_000_000_000.0,
+            "actual_to_potential_incision_ratio": total_eroded_m3 / max(potential_volume_m3, 1e-12),
+            "total_eroded_volume_km3": total_eroded_m3 / 1_000_000_000.0,
+            "total_floodplain_deposition_volume_km3": float(
+                budget_audit["independent_total_floodplain_deposition_volume_m3"]
+            )
+            / 1_000_000_000.0,
+            "total_terminal_deposition_volume_km3": float(
+                budget_audit["independent_total_terminal_deposition_volume_m3"]
+            )
+            / 1_000_000_000.0,
+            "total_exported_sediment_volume_km3": float(
+                budget_audit["independent_total_exported_sediment_volume_m3"]
+            )
+            / 1_000_000_000.0,
+            "profile_semantics": "least_incision_downstream_monotone_bedrock_envelope",
+            "incision_semantics": "subgrid_channel_volume_with_cell_mean_volume_feedback",
+            "sediment_semantics": "newly_eroded_solid_volume_routed_source_to_sink",
+            "inherited_sediment_load_semantics": "preserved_flux_diagnostic_not_mixed_with_history_volume",
+        }
+    )
+    tolerance_m3 = 1e-8 * max(total_eroded_m3, 1.0)
+    if (
+        metadata["bed_profile_valid"] != 1
+        or profile_audit["maximum_junction_bed_error_m"] > 1e-10
+        or profile_audit["maximum_bed_above_terrain_error_m"] > 1e-10
+        or profile_audit["maximum_profile_depth_relation_error_m"] > 1e-10
+        or profile_audit["emitted_physical_edge_count"] != metadata["physical_edge_count"]
+    ):
+        raise RuntimeError(
+            "fluvial kernel produced an invalid or junction-discontinuous bed profile"
+        )
+    if profile_audit["emitted_minimum_realized_slope"] < config.minimum_bed_slope - 1e-12:
+        raise RuntimeError("fluvial bed profile violates the configured downstream grade")
+    if (
+        metadata["sediment_conservation_valid"] != 1
+        or abs(metadata["sediment_conservation_residual_m3"]) > tolerance_m3
+    ):
+        raise RuntimeError("fluvial sediment routing does not conserve eroded volume")
+    if abs(cell_metadata["cell_mean_volume_relation_residual_m3"]) > tolerance_m3:
+        raise RuntimeError("fluvial cell mean changes do not match physical process volume")
+    if abs(parent_metadata["parent_budget_residual_m3"]) > tolerance_m3:
+        raise RuntimeError("fluvial child process volumes do not restrict to parent budgets")
+    cross_catalog_residuals = (
+        profile_audit["maximum_profile_volume_relation_residual_m3"],
+        budget_audit["independent_sediment_conservation_residual_m3"],
+        budget_audit["maximum_reach_local_erosion_residual_m3"],
+        budget_audit["maximum_cell_erosion_residual_m3"],
+        budget_audit["floodplain_deposition_catalog_residual_m3"],
+        budget_audit["maximum_reach_available_residual_m3"],
+        budget_audit["maximum_reach_output_balance_residual_m3"],
+        budget_audit["maximum_downstream_input_residual_m3"],
+        budget_audit["maximum_parent_erosion_residual_m3"],
+        budget_audit["maximum_parent_deposition_residual_m3"],
+        *native_catalog_residuals.values(),
+    )
+    if any(abs(float(residual)) > tolerance_m3 for residual in cross_catalog_residuals):
+        raise RuntimeError("published fluvial catalogs disagree on process volume or routing")
+    if not process_exclusion_valid:
+        raise RuntimeError("fluvial process volume enters a process-excluded parent")
+    if not connector_process_valid:
+        raise RuntimeError("hydrologic connector acquired physical erosion or deposition")
+    context.logger.log_event(
+        {"type": "basin_erosion_summary", "stage": "basin_erosion", **metadata}
+    )
+    return {
+        "ChannelBedProfileCatalog": profiles,
+        "FluvialRiverReachCatalog": eroded_reaches,
+        "ErodedBasinCellCatalog": eroded_cells,
+        "BasinErosionParentCatalog": eroded_parents,
+        "BasinErosionMetadata": metadata,
+    }
+
+
+__all__ = ["BasinErosionConfig", "basin_erosion_stage"]

--- a/src/map_maker/pipeline/stages/erosion.py
+++ b/src/map_maker/pipeline/stages/erosion.py
@@ -138,8 +138,8 @@ def _log_erosion(context, metadata: Mapping[str, object]) -> None:
 def erosion_stage(context, deps, config_mapping):
     if isinstance(context.topology, CubedSphereGrid):
         raise NotImplementedError(
-            "erosion has not migrated to cubed_sphere; use world_age as the current "
-            "canonical pipeline endpoint"
+            "legacy whole-grid erosion has not migrated to cubed_sphere; use "
+            "basin_erosion for the canonical sparse selected-basin pass"
         )
     config = ErosionConfig.from_mapping(config_mapping)
     height, width = context.topology.shape

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -272,6 +272,7 @@ def main(args: Iterable[str] | None = None) -> int:
             "climate",
             "hydrology",
             "basin_refinement",
+            "basin_erosion",
         ],
         default="topology",
     )
@@ -340,8 +341,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = "climate"
         elif parsed.stage == "hydrology":
             stage_name = "hydrology"
-        else:
+        elif parsed.stage == "basin_refinement":
             stage_name = "basin_refinement"
+        else:
+            stage_name = "basin_erosion"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -366,6 +369,7 @@ def main(args: Iterable[str] | None = None) -> int:
         "climate",
         "hydrology",
         "basin_refinement",
+        "basin_erosion",
     }:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":

--- a/tests/test_basin_erosion.py
+++ b/tests/test_basin_erosion.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline import _fluvial_native as fluvial_native
+from map_maker.pipeline.stages.basin_erosion import BasinErosionConfig
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+        "hydrology",
+        "basin_refinement",
+        "basin_erosion",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(
+    tmp_path: Path,
+    run_id: str,
+    *,
+    root: str = "primary",
+    face_resolution: int = 20,
+    rng_seed: int = 37,
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": face_resolution}],
+            "rng_seed": rng_seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / root / "out"),
+            "cache_dir": str(tmp_path / root / "cache"),
+            "log_dir": str(tmp_path / root / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 10,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+                "basin_refinement": {
+                    "refinement_factor": 4,
+                    "terrain_noise_fraction": 0.4,
+                },
+                "basin_erosion": {
+                    "minimum_bed_slope": 1e-6,
+                    "maximum_deposition_fraction": 0.35,
+                    "deposition_slope_scale": 0.001,
+                    "maximum_deposition_depth_m": 10.0,
+                },
+            },
+        }
+    )
+
+
+def _table(result, name: str) -> pa.Table:
+    value = result.artifact_records[name].value
+    assert isinstance(value, pa.Table)
+    return value
+
+
+def _native_connector_fixture() -> dict[str, object]:
+    return {
+        "controls": {
+            "planet_radius_m": 1_000.0,
+            "minimum_bed_slope": 1e-6,
+            "maximum_deposition_fraction": 0.25,
+            "deposition_slope_scale": 0.001,
+            "maximum_deposition_depth_m": 10.0,
+        },
+        "cell_ids": np.array([10, 11, 12, 13, 14, 99], dtype=np.int32),
+        "cell_parent_ids": np.array([1, 1, 2, 3, 3, 9], dtype=np.int32),
+        "cell_terrain_m": np.array([1000, 1001, 999, 500, 501, 100], dtype=np.float32),
+        "cell_areas_km2": np.ones(6, dtype=np.float64),
+        "cell_xyz": np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.9992, 0.04, 0.0],
+                [0.9968, 0.08, 0.0],
+                [0.9928, 0.12, 0.0],
+                [0.9872, 0.16, 0.0],
+                [0.98, 0.2, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+        "reach_ids": np.array([1, 2, 3], dtype=np.int32),
+        "downstream_reach_ids": np.array([2, 3, -1], dtype=np.int32),
+        "reach_kinds": np.array([1, 2, 1], dtype=np.uint8),
+        "terminal_kinds": np.array([0, 0, 1], dtype=np.uint8),
+        "channel_width_m": np.array([10, 0, 20], dtype=np.float32),
+        "reach_slope": np.array([0.01, 0, 0.001], dtype=np.float32),
+        "membership_reach_ids": np.array([1, 1, 1, 3, 3], dtype=np.int32),
+        "membership_cell_ids": np.array([10, 11, 12, 13, 14], dtype=np.int32),
+        "membership_parent_ids": np.array([1, 1, 2, 3, 3], dtype=np.int32),
+        "membership_path_order": np.array([0, 1, 3, 0, 1], dtype=np.int32),
+        "membership_reach_length_m": np.full(5, 50.0, dtype=np.float64),
+        "membership_channel_fraction": np.full(5, 0.0005, dtype=np.float32),
+        "membership_valley_fraction": np.full(5, 0.01, dtype=np.float32),
+        "membership_floodplain_fraction": np.full(5, 0.005, dtype=np.float32),
+    }
+
+
+def test_basin_erosion_profiles_and_routes_conservatively(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "basin-erosion"), generate_visuals=True)
+    result = engine.run(["basin_erosion"])["basin_erosion"]
+    metadata = result.artifact_records["BasinErosionMetadata"].value
+    profiles = _table(result, "ChannelBedProfileCatalog")
+    reaches = _table(result, "FluvialRiverReachCatalog")
+    cells = _table(result, "ErodedBasinCellCatalog")
+    parents = _table(result, "BasinErosionParentCatalog")
+
+    assert metadata["source_to_sink_ready"] == 1
+    assert metadata["bed_profile_valid"] == 1
+    assert metadata["sediment_conservation_valid"] == 1
+    assert metadata["process_exclusion_valid"] == 1
+    assert metadata["connector_process_valid"] == 1
+    assert metadata["physical_node_count"] > 0
+    assert metadata["profile_record_count"] == profiles.num_rows > 0
+    assert metadata["maximum_junction_bed_error_m"] == 0.0
+    assert metadata["minimum_realized_slope"] >= metadata["minimum_bed_slope"] - 1e-8
+    assert metadata["emitted_minimum_realized_slope"] >= metadata["minimum_bed_slope"] - 1e-12
+    assert metadata["total_eroded_volume_km3"] > 0.0
+
+    terrain = np.asarray(profiles["terrain_elevation_m"], dtype=np.float64)
+    bed = np.asarray(profiles["bed_elevation_m"], dtype=np.float64)
+    depth = np.asarray(profiles["incision_depth_m"], dtype=np.float64)
+    assert np.all(np.isfinite(bed))
+    assert np.all(bed <= terrain + 1e-5)
+    assert np.allclose(depth, terrain - bed, atol=1e-4)
+    width_by_reach = dict(
+        zip(
+            np.asarray(reaches["reach_id"], dtype=np.int32),
+            np.asarray(reaches["channel_width_m"], dtype=np.float64),
+            strict=True,
+        )
+    )
+    expected_volume = sum(
+        width_by_reach[int(reach_id)] * length_m * incision_depth
+        for reach_id, length_m, incision_depth in zip(
+            np.asarray(profiles["reach_id"], dtype=np.int32),
+            np.asarray(profiles["reach_length_m"], dtype=np.float64),
+            depth,
+            strict=True,
+        )
+    )
+    profile_volume = np.sum(np.asarray(profiles["eroded_volume_m3"], dtype=np.float64))
+    assert profile_volume == pytest.approx(expected_volume, rel=1e-7)
+    assert profile_volume == pytest.approx(metadata["total_eroded_volume_m3"], rel=1e-12)
+
+    cell_ids = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    order = np.argsort(cell_ids, kind="stable")
+    sorted_ids = cell_ids[order]
+    sorted_beds = bed[order]
+    starts = np.r_[0, np.flatnonzero(np.diff(sorted_ids)) + 1]
+    ends = np.r_[starts[1:], len(sorted_ids)]
+    for start, end in zip(starts, ends, strict=True):
+        assert np.max(sorted_beds[start:end]) - np.min(sorted_beds[start:end]) <= 1e-5
+
+    connector = np.asarray(reaches["reach_kind"].to_pylist()) == "connector"
+    assert not np.any(np.asarray(reaches["has_physical_bed"])[connector])
+    assert np.all(np.asarray(reaches["local_erosion_volume_m3"])[connector] == 0.0)
+    assert np.all(np.asarray(reaches["floodplain_deposition_volume_m3"])[connector] == 0.0)
+
+    eroded = np.asarray(cells["subgrid_eroded_volume_m3"], dtype=np.float64)
+    deposited = np.asarray(cells["floodplain_deposited_volume_m3"], dtype=np.float64)
+    area_m2 = np.asarray(cells["area_km2"], dtype=np.float64) * 1_000_000.0
+    mean_delta = np.asarray(cells["terrain_mean_delta_m"], dtype=np.float64)
+    assert np.allclose(mean_delta * area_m2, deposited - eroded, rtol=1e-12, atol=1e-5)
+    assert np.sum(eroded) == pytest.approx(metadata["total_eroded_volume_m3"], rel=1e-9)
+    assert np.sum(deposited) == pytest.approx(
+        metadata["total_floodplain_deposition_volume_m3"], rel=1e-9
+    )
+    assert (
+        metadata["total_floodplain_deposition_volume_m3"]
+        + metadata["total_terminal_deposition_volume_m3"]
+        + metadata["total_exported_sediment_volume_m3"]
+    ) == pytest.approx(metadata["total_eroded_volume_m3"], rel=1e-9)
+
+    assert np.sum(np.asarray(parents["child_eroded_volume_m3"])) == pytest.approx(
+        np.sum(eroded), rel=1e-12
+    )
+    assert np.sum(np.asarray(parents["child_deposited_volume_m3"])) == pytest.approx(
+        np.sum(deposited), rel=1e-12
+    )
+    assert (engine.context.config.run_visual_dir() / "basin_erosion" / "eroded_basin.png").is_file()
+    assert (
+        engine.context.config.run_visual_dir() / "basin_erosion" / "longitudinal_profile.png"
+    ).is_file()
+
+
+def test_basin_erosion_is_independently_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "first", root="first")).run(["basin_erosion"])[
+        "basin_erosion"
+    ]
+    second = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["basin_erosion"])[
+        "basin_erosion"
+    ]
+    for artifact in (
+        "ChannelBedProfileCatalog",
+        "FluvialRiverReachCatalog",
+        "ErodedBasinCellCatalog",
+        "BasinErosionParentCatalog",
+    ):
+        assert _table(first, artifact).equals(_table(second, artifact))
+    assert (
+        first.artifact_records["BasinErosionMetadata"].value
+        == second.artifact_records["BasinErosionMetadata"].value
+    )
+
+    cached = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["basin_erosion"])[
+        "basin_erosion"
+    ]
+    assert cached.stats is not None and cached.stats.cache_hit
+
+
+def test_basin_erosion_config_rejects_unknown_and_invalid_controls():
+    with pytest.raises(ValueError, match="Unknown basin erosion controls"):
+        BasinErosionConfig.from_mapping({"magic": 1})
+    with pytest.raises(ValueError, match="maximum_deposition_fraction"):
+        BasinErosionConfig.from_mapping({"maximum_deposition_fraction": 1.1})
+    with pytest.raises(ValueError, match="deposition_slope_scale"):
+        BasinErosionConfig.from_mapping({"deposition_slope_scale": 0.0})
+
+
+def test_native_layout_round_trips_double_precision_profile_fields():
+    record = fluvial_native._ffi.new("BedProfileRecord*")
+    record.reach_id = 17
+    record.fine_cell_id = 23
+    record.bed_elevation_m = 1000.00004
+    record.eroded_volume_m3 = 1234.5
+    view = fluvial_native._ffi.buffer(record, fluvial_native._ffi.sizeof("BedProfileRecord"))
+    parsed = np.frombuffer(view, dtype=fluvial_native.BED_PROFILE_DTYPE, count=1)[0]
+
+    assert parsed["reach_id"] == 17
+    assert parsed["fine_cell_id"] == 23
+    assert parsed["bed_elevation_m"] == pytest.approx(1000.00004, rel=0.0, abs=1e-12)
+    assert parsed["eroded_volume_m3"] == 1234.5
+
+
+def test_native_connector_gap_and_persisted_grade_cross_cffi_boundary():
+    profiles, reaches, cells, metadata = fluvial_native.run_fluvial_erosion(
+        **_native_connector_fixture()
+    )
+
+    assert metadata["connector_reach_count"] == 1
+    assert metadata["physical_component_count"] == 3
+    connector = reaches[reaches["reach_id"] == 2][0]
+    upstream = reaches[reaches["reach_id"] == 1][0]
+    assert connector["has_physical_bed"] == 0
+    assert connector["local_erosion_volume_m3"] == 0.0
+    assert connector["upstream_input_volume_m3"] == upstream["downstream_transfer_volume_m3"]
+    assert connector["downstream_transfer_volume_m3"] == connector["upstream_input_volume_m3"]
+    assert 99 not in set(cells["fine_cell_id"])
+
+    first_reach = profiles[profiles["reach_id"] == 1]
+    first_reach.sort(order="path_order")
+    bed_drop = first_reach["bed_elevation_m"][0] - first_reach["bed_elevation_m"][1]
+    source = _native_connector_fixture()["cell_xyz"][0].astype(np.float64)
+    target = _native_connector_fixture()["cell_xyz"][1].astype(np.float64)
+    length_m = np.arccos(np.clip(np.dot(source, target), -1.0, 1.0)) * 1_000.0
+    assert first_reach["bed_elevation_m"][0] != first_reach["bed_elevation_m"][1]
+    assert bed_drop / length_m >= 1e-6 - 1e-12
+
+
+def test_native_rejects_even_zero_length_connector_membership():
+    fixture = _native_connector_fixture()
+    fixture["membership_reach_ids"] = np.append(fixture["membership_reach_ids"], 2).astype(np.int32)
+    fixture["membership_cell_ids"] = np.append(fixture["membership_cell_ids"], 99).astype(np.int32)
+    fixture["membership_parent_ids"] = np.append(fixture["membership_parent_ids"], 9).astype(
+        np.int32
+    )
+    fixture["membership_path_order"] = np.append(fixture["membership_path_order"], 0).astype(
+        np.int32
+    )
+    fixture["membership_reach_length_m"] = np.append(
+        fixture["membership_reach_length_m"], 0.0
+    ).astype(np.float64)
+    for field in (
+        "membership_channel_fraction",
+        "membership_valley_fraction",
+        "membership_floodplain_fraction",
+    ):
+        fixture[field] = np.append(fixture[field], 0.0).astype(np.float32)
+
+    with pytest.raises(RuntimeError, match="invalid channel/connector physical support"):
+        fluvial_native.run_fluvial_erosion(**fixture)
+
+
+def test_pipeline_fixture_exercises_connectors_and_process_exclusions(tmp_path: Path):
+    engine = ExecutionEngine(
+        _config(
+            tmp_path,
+            "connector-exclusion",
+            face_resolution=16,
+            rng_seed=22,
+        )
+    )
+    results = engine.run(["basin_refinement", "basin_erosion"])
+    refinement = results["basin_refinement"]
+    erosion = results["basin_erosion"]
+    refinement_metadata = refinement.artifact_records["BasinRefinementMetadata"].value
+    reaches = _table(erosion, "FluvialRiverReachCatalog")
+    profiles = _table(erosion, "ChannelBedProfileCatalog")
+    cells = _table(erosion, "ErodedBasinCellCatalog")
+    memberships = _table(refinement, "RefinedReachCellCatalog")
+
+    assert refinement_metadata["connector_reach_count"] > 0
+    assert refinement_metadata["process_excluded_parent_count"] > 0
+    connector_ids = np.asarray(reaches["reach_id"])[
+        np.asarray(reaches["reach_kind"].to_pylist()) == "connector"
+    ]
+    assert not np.any(np.isin(np.asarray(memberships["reach_id"]), connector_ids))
+    assert not np.any(np.isin(np.asarray(profiles["reach_id"]), connector_ids))
+    connector = np.isin(np.asarray(reaches["reach_id"]), connector_ids)
+    assert np.all(
+        np.asarray(reaches["downstream_transfer_volume_m3"])[connector]
+        == np.asarray(reaches["upstream_input_volume_m3"])[connector]
+    )
+
+    excluded = np.asarray(cells["process_excluded"])
+    assert np.any(excluded)
+    assert np.all(np.asarray(cells["subgrid_eroded_volume_m3"])[excluded] == 0.0)
+    assert np.all(np.asarray(cells["floodplain_deposited_volume_m3"])[excluded] == 0.0)
+    assert np.array_equal(
+        np.asarray(cells["terrain_elevation_after_m"])[excluded],
+        np.asarray(cells["terrain_elevation_m"])[excluded],
+    )
+
+
+def test_stage_rejects_cross_catalog_native_inconsistency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = importlib.import_module("map_maker.pipeline.stages.basin_erosion")
+    native_run = module.run_fluvial_erosion
+
+    def inconsistent_native_run(**kwargs):
+        profiles, reaches, cells, metadata = native_run(**kwargs)
+        reaches = reaches.copy()
+        physical = np.flatnonzero(reaches["has_physical_bed"] != 0)
+        reaches["local_erosion_volume_m3"][physical[0]] += max(
+            float(metadata["total_eroded_volume_m3"]) * 0.01, 1.0
+        )
+        return profiles, reaches, cells, metadata
+
+    monkeypatch.setattr(module, "run_fluvial_erosion", inconsistent_native_run)
+    engine = ExecutionEngine(_config(tmp_path, "inconsistent-native"))
+    with pytest.raises(RuntimeError, match="catalogs disagree"):
+        engine.run(["basin_erosion"])

--- a/tests/test_native_loader.py
+++ b/tests/test_native_loader.py
@@ -51,3 +51,6 @@ def test_built_library_exposes_expected_abi_and_fingerprint() -> None:
 
     refinement = native_library_info("refinement_native")
     assert refinement["abi_version"] == 3
+
+    fluvial = native_library_info("fluvial_native")
+    assert fluvial["abi_version"] == 3

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -54,6 +54,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
         "climate_native",
         "elevation_native",
         "erosion_native",
+        "fluvial_native",
         "geology_native",
         "hydrology_native",
         "planet_native",


### PR DESCRIPTION
## Summary

- add an ABI-v3 Rust fluvial kernel for junction-consistent bed profiles and source-to-sink sediment routing
- publish sparse profile, reach, fine-cell, parent, metadata, and diagnostic visual artifacts
- preserve zero-width hydrologic connectors and process-excluded depression support
- independently audit emitted float64 grades and profile/reach/cell/parent/native process budgets
- record the provisional process contract as Decision 025 and update pipeline documentation

## Canonical result

The selected face-2048 basin contains 2,434 physical nodes, 2,421 physical edges, and 37 reaches. It routes 145.53 km3 of conditioning incision into 95.96 km3 of floodplain deposition and 49.57 km3 of ocean export with zero junction error and conservation residuals below tolerance.

This is a structural and conservation milestone, not calibrated fluvial morphology. The current longitudinal diagnostic exposes a maximum 537.11 m subgrid conditioning cut; Hydrology Pass 2 and multi-seed/Earth-derived calibration remain required.

## Validation

- `pytest -q` (108 passed)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `ruff check src tests`
- Black check on all changed Python files
- `cargo fmt --all -- --check`
- `map-maker doctor`
- `uv build -q`
- canonical `basin_erosion` generation with visuals and post-serialization audits
- independent subagent review; all high/medium findings addressed before publication