### PR TITLE
Add bounded Hydrology Pass 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,13 @@ name = "hydrology_native"
 version = "0.1.0"
 
 [[package]]
+name = "hydrology_pass2_native"
+version = "0.1.0"
+dependencies = [
+ "topology_native",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "src/map_maker/pipeline/native/fluvial",
     "src/map_maker/pipeline/native/geology",
     "src/map_maker/pipeline/native/hydrology",
+    "src/map_maker/pipeline/native/hydrology_pass2",
     "src/map_maker/pipeline/native/planet",
     "src/map_maker/pipeline/native/refinement",
     "src/map_maker/pipeline/native/tectonics",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -84,3 +84,8 @@ stage_overrides:
     maximum_deposition_fraction: 0.35
     deposition_slope_scale: 0.001
     maximum_deposition_depth_m: 10.0
+  hydrology_pass2:
+    minimum_depression_depth_m: 5.0
+    maximum_receiver_change_fraction: 0.15
+    maximum_receiver_change_cell_fraction: 0.15
+    maximum_new_depression_area_fraction: 0.02

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1328,3 +1328,60 @@ Failure conditions:
   restriction.
 - Native statistics agreeing internally while emitted catalogs disagree.
 - Treating the canonical seed's potential-incision value as calibration.
+
+## Decision 026: Bounded Sparse Hydrology Pass 2
+
+Status: implemented, provisional
+
+Decision:
+Hydrology Pass 2 is a sparse selected-basin stabilization pass over the refined
+terrain and accepted fluvial graph. It compares local drainage before and after
+erosion, publishes every accepted receiver or depression change, and rejects
+basin-scale reorganization. It is not a second unconstrained global hydrology
+generation and may not silently replace Pass 1 identities.
+
+Routing-surface contract:
+- Ordinary child cells use their volume-adjusted full-cell mean terrain.
+- A physical centerline cell uses its solved float64 channel bed as its subgrid
+  routing surface; incision depth is not applied to the whole cell.
+- Preserved coarse depressions and zero-width connectors remain nonphysical
+  handoffs until dedicated bathymetric refinement resolves them.
+- Outside-basin boundary support remains an inherited terminal and may not open
+  a new lateral leak through the selected watershed boundary.
+
+Topology contract:
+- Physical trunk edges, junction cells, downstream reach references, and
+  connector handoffs are fixed inputs.
+- A deterministic sparse cubed-sphere D4 priority flood routes ordinary child
+  cells to the accepted trunk, preserved waterbody support, or inherited ocean
+  terminal.
+- Every routed child has one receiver, the stabilized graph is acyclic, and
+  contributing area is accumulated exactly once through the graph.
+- Local receiver changes are allowed only within configured area and count
+  bounds. Exceeding either bound rejects the pass instead of iterating.
+
+Depression contract:
+- Priority-fill depth is evaluated on both the pre-erosion and stabilized
+  routing surfaces.
+- Connected cells deeper than the configured minimum become local depression
+  candidates with deterministic IDs, area, potential storage, spill cell, and
+  before/after status.
+- A candidate is not automatically a permanent lake or wetland. Water balance,
+  hydroperiod, soils, and vegetation determine those later.
+- Inherited preserved lakes and depressions are audited as excluded handoffs,
+  not regenerated from incomplete local bathymetry.
+
+Bounded-correction rule:
+Pass 2 itself applies at most one local receiver correction from the pre-erosion
+to post-erosion surface. It reports whether any correction occurred and whether
+additional erosion correction would be required. V1 rejects a result requiring
+another unbounded terrain/hydrology loop.
+
+Failure conditions:
+- A changed physical trunk edge, bed, junction, reach identity, or connector
+  process exclusion.
+- A cycle, uncovered active child, dangling nonterminal receiver, or
+  contributing-area conservation failure.
+- Receiver-change area or count above the configured stability bounds.
+- Process routing through a preserved-depression interior.
+- Treating every priority-fill candidate as standing surface water.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -252,6 +252,52 @@ outgoing volume, downstream inputs, parent restrictions, and native totals. A
 face-16 seed-22 regression fixture contains both a connector and an excluded
 parent so the corresponding tests are non-vacuous.
 
+## Sparse Hydrology Pass 2
+
+The canonical pass routes 370,944 sparse face-2048 children without allocating
+a global face-2048 raster. Of these, 338,176 selected-basin cells contribute
+source area, 2,434 are fixed physical trunk anchors, 32,512 remain inherited
+preserved-depression handoffs, and 256 belong to outside-basin terminal support.
+
+Observed stabilization diagnostics:
+
+| Metric | Canonical result |
+| --- | ---: |
+| Physical trunk edges preserved | `2,421 / 2,421` |
+| Cyclic or uncovered cells | `0` |
+| Receiver-change cells | `2,870` (`0.849%`) |
+| Receiver-change area | `53,917 km2` (`0.847%`) |
+| Baseline depression candidates | `9,023` |
+| Stabilized depression candidates | `8,944` |
+| Newly affected depression-candidate area | `37.14 km2` (`0.000583%`) |
+| Wholly new depression components | `0` |
+| Removed depression-candidate area | `13,831 km2` |
+| Maximum stabilized priority-fill depth | `214.14 m` |
+| Independent terminal-area residual | `0 km2` |
+| New candidates intersecting corridor support | `0` |
+| Additional erosion correction required | No |
+
+The 8,944 stabilized candidates cover about 1.46 million km2 and have roughly
+35,663 km3 of potential topographic fill volume. Those numbers are deliberately
+not reported as lake area or lake volume. They include unresolved local storage
+positions in noisy five-kilometre terrain and require runoff, evaporation,
+seepage, hydroperiod, soil, and vegetation tests before any waterbody label.
+
+Pass 2 applies one bounded local receiver correction while preserving every
+physical bed edge, junction, reach identity, and zero-width connector handoff.
+The canonical change is well below the provisional 15% count and area bounds;
+the bounds are rejection guards, not calibration targets. Independent audits
+recomputed from the emitted cell catalog agree with the native correction
+counts and areas.
+
+A preliminary face-16 sweep collected 12 seeds whose upstream basin refinement
+passed. Pass-2 receiver-change area ranged from `1.45-9.93%`, receiver-change
+cell count ranged from `1.50-9.93%`, no wholly new depression component was
+created, and no seed requested another erosion correction. Twenty-three other
+attempted seeds failed the existing refinement routing gate before Pass 2
+executed. That high upstream rejection rate remains a separate refinement
+defect and is not counted as Hydrology Pass-2 instability.
+
 ## Calibration Rule
 
 Do not tighten or loosen a threshold solely to make the current gallery pass.

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -37,16 +37,20 @@
      sediment through connectors, and deposits only on allocated floodplain or
      terminal support.
 10. Hydrology pass 2.
+    - The sparse selected-basin pass uses volume-adjusted terrain means and
+      subgrid channel beds, preserves inherited trunk/connector identities,
+      applies one bounded local reroute, and publishes depression candidates.
 11. Soils and biomes.
 12. Mineral and energy systems.
 13. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches the first sparse
-selected-basin erosion and sedimentation pass after Hydrology Pass 1, with a
+The current canonical cubed-sphere implementation reaches the bounded sparse
+selected-basin Hydrology Pass 2 after erosion and sedimentation, with a
 causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
 relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
 climate/orography pass. Bed-profile and sediment budgets are conservative but
-remain uncalibrated and have not yet fed Hydrology Pass 2. The older
+remain uncalibrated. Pass 2 now audits their local routing consequences without
+replacing the accepted coarse trunk graph. The older
 rectangular compatibility path runs directly from world age into provisional
 erosion and final rendering; it is reference behavior, not the canonical stage
 order.

--- a/docs/specs/06_erosion.md
+++ b/docs/specs/06_erosion.md
@@ -127,6 +127,8 @@ eroded historical volume.
   settling, competence, or grain-size model.
 - Sediment provenance, lithology, suspended/bed-load partition, transport time,
   avulsion, meander migration, deltas, shelves, and compaction are absent.
-- Hydrology Pass 2 has not yet consumed the altered terrain distribution.
+- The sparse Hydrology Pass 2 consumes the altered terrain distribution and
+  solved channel beds; global refined hydrology and monthly local lake balance
+  remain future work.
 - Repeated geological-time erosion, uplift, sediment loading, flexure, and
   isostatic response remain future passes.

--- a/docs/specs/08_climate_hydrology.md
+++ b/docs/specs/08_climate_hydrology.md
@@ -246,9 +246,10 @@ conservation error, and artifact semantics.
 - Groundwater, infiltration, losing/intermittent reaches, glaciers, engineered
   channels, and explicit delta distributary growth are absent or represented only
   by coarse reach attributes.
-- Breach erosion is a basin-scale coarse incision event. Detailed gorge evolution,
-  sediment routing, erosion/sedimentation feedback, and Hydrology Pass 2 follow in
-  the next milestone.
+- Breach erosion is a basin-scale coarse incision event. The sparse selected-basin
+  erosion and Hydrology Pass 2 now stabilize one refined basin, but detailed
+  gorge evolution, global sediment feedback, and monthly local lake balance
+  remain future work.
 - Current statistical thresholds are provisional. Multi-seed conditional
   validation against basin, lake, and river distributions is required before the
   Earth-like default is considered calibrated.

--- a/docs/specs/08b_basin_erosion.md
+++ b/docs/specs/08b_basin_erosion.md
@@ -72,10 +72,10 @@ emptiness, source-to-sink conservation, independent-run determinism, and cache
 reuse. A fixture with real connectors and process-excluded parents prevents
 those gates from passing vacuously.
 
-## Next Step
+## Downstream Stabilization
 
-Hydrology Pass 2 must consume the volume-derived terrain distribution, rerun
-local drainage and depression stability, and decide whether one bounded
-erosion/hydrology correction is required. Calibration of profile depths and
-floodplain retention requires multi-seed distributions and Earth-derived
-benchmarks rather than tuning the canonical seed alone.
+The sparse Hydrology Pass 2 now consumes the volume-derived terrain and solved
+channel beds, applies one bounded local reroute, and reports depression
+stability. Calibration of profile depths and floodplain retention still requires
+multi-seed distributions and Earth-derived benchmarks rather than tuning the
+canonical seed alone.

--- a/docs/specs/08c_hydrology_pass2.md
+++ b/docs/specs/08c_hydrology_pass2.md
@@ -1,0 +1,83 @@
+# Sparse Hydrology Pass 2
+
+## Status
+
+Implemented provisional stabilization pass following `basin_erosion`.
+
+## Objective
+
+Consume the selected basin's volume-adjusted terrain and solved subgrid channel
+beds, recompute local child drainage without changing the accepted trunk graph,
+and measure whether erosion materially changed receivers or depression
+candidates. The pass is bounded: accepted corrections are persisted once;
+large-scale instability rejects the result.
+
+## Dual Routing Surface
+
+The full-cell terrain after erosion is the routing surface for ordinary cells.
+Physical centerline cells instead expose the solved channel bed to routing while
+retaining their separately conserved full-cell mean. This preserves narrow
+rivers without turning a 10-100 metre channel into a multi-kilometre trench.
+
+Preserved-depression children and outside-basin boundary children are terminal
+anchors. Connector reaches remain graph handoffs with no physical bed or local
+process support.
+
+## Native Stabilization
+
+The Rust `hydrology_pass2_native` kernel builds sparse cubed-sphere D4 adjacency
+without allocating a global refined raster. It runs deterministic multi-source
+priority floods on the pre-erosion and post-erosion surfaces. Physical channel
+cells, preserved waterbody support, and inherited ocean support are anchors.
+
+Ordinary cells receive the priority-flood parent as their local receiver.
+Physical channel receivers are then restored from the accepted bed-profile DAG.
+The complete stabilized receiver graph is topologically audited and used to
+accumulate contributing area once from source to terminal.
+
+## Depression Candidates
+
+Connected ordinary cells whose priority-fill depth exceeds the configured
+minimum receive a deterministic candidate ID. The stage aggregates candidate
+area, potential fill volume, maximum depth, spill cell, and overlap with the
+pre-erosion state. Candidate status is `stable`, `changed`, or `new`.
+
+These are topographic storage candidates, not lake labels. Later water balance,
+groundwater, soils, and vegetation stages decide whether they hold permanent,
+seasonal, wetland, or no surface water.
+
+## Persistent Outputs
+
+- `StabilizedBasinCellCatalog`: dual surfaces, pre/post receivers, hydrologic
+  elevations, fill depths, flow slope and direction, contributing area,
+  depression IDs, and change flags.
+- `StabilizedRiverReachCatalog`: accepted reaches plus Pass-2 preservation
+  status.
+- `LocalDepressionCandidateCatalog`: aggregated post-erosion candidates and
+  before/after status.
+- `HydrologyCorrectionCatalog`: the sparse set of accepted receiver or
+  depression-membership changes.
+- `HydrologyPass2Metadata`: topology, conservation, stability, exclusion, and
+  deterministic-process diagnostics.
+
+## Hard Gates
+
+- Every active child routes to the fixed trunk or an inherited terminal.
+- The stabilized receiver graph is acyclic.
+- Every physical trunk receiver exactly matches the bed-profile DAG.
+- Preserved-depression interiors remain process excluded.
+- Contributing area is nondecreasing downstream and terminal accumulation equals
+  active selected-basin area within floating-point tolerance.
+- Receiver-change count and area remain below configured bounds.
+- Identical inputs produce identical catalogs and cache keys.
+
+## Current Limits
+
+- D4 routing is retained to match the accepted topology contract.
+- Local depression candidates do not yet run monthly lake water balance.
+- Preserved coarse waterbodies still require bathymetric refinement before their
+  inlet, lake-crossing, and outlet geometry becomes physical.
+- The pass stabilizes one selected basin, not the entire planet at refined
+  resolution.
+- Earth-derived receiver-change and local-depression distributions are not yet
+  calibrated.

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Check that Python, Cargo, and all native libraries are ready:
 uv run map-maker doctor
 ```
 
-Generate the implemented world stack through erosion:
+Generate the default configured world stack:
 
 ```bash
 uv run map-maker generate --config configs/pipeline.yaml
@@ -77,8 +77,8 @@ climate/orographic precipitation. The first depression-aware hydrology pass now
 writes fractional lake and wetland coverage, spill outlets, breaches, conservative
 drainage basins, monthly discharge, sparse waterbody membership, and vector river
 reaches. Explicit geological event history, spherical
-erosion and sediment feedback, hydrology pass 2, soils, biomes, and complete
-regional terrain remain implementation milestones. A first sparse basin-refinement
+global erosion and sediment feedback, soils, biomes, and complete regional
+terrain remain implementation milestones. A first sparse basin-refinement
 stage now realizes one inherited trunk network at approximately 5 km scale,
 preserves parent terrain means and convergent reach junctions, and stores physical
 channel, valley, and floodplain fractions without carving whole cells. It also
@@ -88,9 +88,11 @@ nearby fine cells. The downstream sparse erosion pass now solves shared-junction
 bed profiles, applies volume-based subgrid incision, routes newly eroded sediment
 through connectors, deposits only on allocated floodplain support, and restricts
 terrain-volume feedback to coarse parents. Its morphology and retention
-parameters remain provisional, and Hydrology Pass 2 has not yet consumed the
-result. The current output is a functional prototype rather than an atlas-grade
-world.
+parameters remain provisional. The bounded sparse Hydrology Pass 2 now consumes
+the volume-adjusted cell means and float64 channel beds, preserves the accepted
+trunk and connector identities, reroutes local child drainage, and persists
+before/after depression candidates without labeling them all as lakes. The
+current output is a functional prototype rather than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -154,6 +156,9 @@ uv run map-maker-pipeline --stage basin_refinement --config configs/cubed_sphere
 
 # Junction-consistent subgrid incision and conservative sediment routing
 uv run map-maker-pipeline --stage basin_erosion --config configs/cubed_sphere_crust_state.yaml
+
+# Bounded local rerouting and depression stability after erosion
+uv run map-maker-pipeline --stage hydrology_pass2 --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -10,7 +10,11 @@ from pathlib import Path
 from typing import Any, Iterable
 
 NATIVE_ABI_VERSION = 2
-NATIVE_ABI_OVERRIDES = {"fluvial_native": 3, "refinement_native": 3}
+NATIVE_ABI_OVERRIDES = {
+    "fluvial_native": 3,
+    "hydrology_pass2_native": 1,
+    "refinement_native": 3,
+}
 SIMULATION_NATIVE_LIBRARIES = (
     "climate_native",
     "elevation_native",
@@ -18,6 +22,7 @@ SIMULATION_NATIVE_LIBRARIES = (
     "fluvial_native",
     "geology_native",
     "hydrology_native",
+    "hydrology_pass2_native",
     "planet_native",
     "refinement_native",
     "tectonics_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -15,6 +15,7 @@ NATIVE_LIBRARIES = (
     "fluvial_native",
     "geology_native",
     "hydrology_native",
+    "hydrology_pass2_native",
     "planet_native",
     "refinement_native",
     "tectonics_native",

--- a/src/map_maker/pipeline/_hydrology_pass2_native.py
+++ b/src/map_maker/pipeline/_hydrology_pass2_native.py
@@ -1,0 +1,292 @@
+"""Rust-backed sparse Hydrology Pass 2 bindings."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import numpy as np
+from cffi import FFI
+
+from .._native import native_library_info, native_library_path
+
+STABILIZED_CELL_DTYPE = np.dtype(
+    [
+        ("fine_cell_id", "=i4"),
+        ("baseline_receiver_id", "=i4"),
+        ("stabilized_receiver_id", "=i4"),
+        ("baseline_anchor_cell_id", "=i4"),
+        ("stabilized_anchor_cell_id", "=i4"),
+        ("baseline_depression_id", "=i4"),
+        ("stabilized_depression_id", "=i4"),
+        ("anchor_kind", "u1"),
+        ("receiver_changed", "u1"),
+        ("depression_changed", "u1"),
+        ("terminal_kind", "u1"),
+        ("baseline_hydrologic_elevation_m", "=f8"),
+        ("stabilized_hydrologic_elevation_m", "=f8"),
+        ("baseline_fill_depth_m", "=f8"),
+        ("stabilized_fill_depth_m", "=f8"),
+        ("stabilized_flow_slope", "=f8"),
+        ("contributing_area_km2", "=f8"),
+        ("flow_direction_xyz", "=f4", (3,)),
+    ],
+    align=True,
+)
+
+_CDEF = """
+typedef struct {
+    int32_t fine_resolution;
+    double minimum_depression_depth_m;
+    double planet_radius_m;
+} HydrologyPass2Config;
+
+typedef struct {
+    int32_t fine_cell_id;
+    int32_t baseline_receiver_id;
+    int32_t stabilized_receiver_id;
+    int32_t baseline_anchor_cell_id;
+    int32_t stabilized_anchor_cell_id;
+    int32_t baseline_depression_id;
+    int32_t stabilized_depression_id;
+    uint8_t anchor_kind;
+    uint8_t receiver_changed;
+    uint8_t depression_changed;
+    uint8_t terminal_kind;
+    double baseline_hydrologic_elevation_m;
+    double stabilized_hydrologic_elevation_m;
+    double baseline_fill_depth_m;
+    double stabilized_fill_depth_m;
+    double stabilized_flow_slope;
+    double contributing_area_km2;
+    float flow_direction_xyz[3];
+} StabilizedCellRecord;
+
+typedef struct { StabilizedCellRecord* data; size_t len; } StabilizedCellArray;
+
+typedef struct {
+    int32_t cell_count;
+    int32_t active_cell_count;
+    int32_t channel_cell_count;
+    int32_t excluded_cell_count;
+    int32_t outside_cell_count;
+    int32_t physical_trunk_edge_count;
+    int32_t baseline_uncovered_cell_count;
+    int32_t stabilized_uncovered_cell_count;
+    int32_t baseline_depression_count;
+    int32_t stabilized_depression_count;
+    int32_t receiver_changed_cell_count;
+    int32_t depression_changed_cell_count;
+    int32_t graph_valid;
+    int32_t trunk_preserved_valid;
+    int32_t process_exclusion_valid;
+    double active_area_km2;
+    double receiver_changed_area_km2;
+    double receiver_changed_area_fraction;
+    double terminal_accumulated_area_km2;
+    double contributing_area_residual_km2;
+    double baseline_depression_area_km2;
+    double stabilized_depression_area_km2;
+    double baseline_depression_volume_km3;
+    double stabilized_depression_volume_km3;
+    double maximum_baseline_fill_depth_m;
+    double maximum_stabilized_fill_depth_m;
+} HydrologyPass2Stats;
+
+int32_t hydrology_pass2_run(
+    HydrologyPass2Config config,
+    size_t cell_count,
+    const int32_t* cell_ids,
+    const double* terrain_before_m,
+    const double* routing_surface_after_m,
+    const double* cell_areas_km2,
+    const float* cell_xyz,
+    const uint8_t* anchor_kinds,
+    const uint8_t* source_active,
+    const int32_t* fixed_receiver_ids,
+    StabilizedCellArray* cells_out,
+    HydrologyPass2Stats* stats_out
+);
+
+void hydrology_pass2_free_cells(StabilizedCellArray array);
+"""
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+
+
+def _validate_record_layout(c_name: str, dtype: np.dtype) -> None:
+    if not dtype.isnative or dtype.itemsize != _ffi.sizeof(c_name):
+        raise ImportError(
+            f"{c_name} native layout mismatch: numpy={dtype.itemsize}, "
+            f"cffi={_ffi.sizeof(c_name)}, native_byte_order={dtype.isnative}"
+        )
+    for field in dtype.names or ():
+        numpy_offset = int(dtype.fields[field][1])
+        cffi_offset = int(_ffi.offsetof(c_name, field))
+        if numpy_offset != cffi_offset:
+            raise ImportError(
+                f"{c_name}.{field} offset mismatch: numpy={numpy_offset}, cffi={cffi_offset}"
+            )
+
+
+_validate_record_layout("StabilizedCellRecord", STABILIZED_CELL_DTYPE)
+native_library_info("hydrology_pass2_native")
+_lib = _ffi.dlopen(str(native_library_path("hydrology_pass2_native")))
+
+
+def _input(values: np.ndarray, *, name: str, dtype: np.dtype) -> np.ndarray:
+    array = np.asarray(values)
+    if array.dtype != dtype:
+        array = array.astype(dtype)
+    if not array.flags.c_contiguous:
+        array = np.ascontiguousarray(array, dtype=dtype)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional, got {array.shape}")
+    return array
+
+
+def _records(record_array: Any) -> np.ndarray:
+    length = int(record_array.len)
+    if length == 0:
+        _lib.hydrology_pass2_free_cells(record_array)
+        return np.empty(0, dtype=STABILIZED_CELL_DTYPE)
+    buffer = _ffi.buffer(record_array.data, length * STABILIZED_CELL_DTYPE.itemsize)
+    records = np.frombuffer(buffer, dtype=STABILIZED_CELL_DTYPE, count=length).copy()
+    _lib.hydrology_pass2_free_cells(record_array)
+    return records
+
+
+def run_hydrology_pass2(
+    *,
+    controls: Mapping[str, float | int],
+    cell_ids: np.ndarray,
+    terrain_before_m: np.ndarray,
+    routing_surface_after_m: np.ndarray,
+    cell_areas_km2: np.ndarray,
+    cell_xyz: np.ndarray,
+    anchor_kinds: np.ndarray,
+    source_active: np.ndarray,
+    fixed_receiver_ids: np.ndarray,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    expected_controls = {
+        "fine_resolution",
+        "minimum_depression_depth_m",
+        "planet_radius_m",
+    }
+    if set(controls) != expected_controls:
+        raise ValueError(
+            "Hydrology Pass 2 controls mismatch: "
+            f"missing={sorted(expected_controls - set(controls))}, "
+            f"extra={sorted(set(controls) - expected_controls)}"
+        )
+    inputs = {
+        "cell_ids": _input(cell_ids, name="cell_ids", dtype=np.dtype(np.int32)),
+        "terrain_before_m": _input(
+            terrain_before_m, name="terrain_before_m", dtype=np.dtype(np.float64)
+        ),
+        "routing_surface_after_m": _input(
+            routing_surface_after_m,
+            name="routing_surface_after_m",
+            dtype=np.dtype(np.float64),
+        ),
+        "cell_areas_km2": _input(cell_areas_km2, name="cell_areas_km2", dtype=np.dtype(np.float64)),
+        "anchor_kinds": _input(anchor_kinds, name="anchor_kinds", dtype=np.dtype(np.uint8)),
+        "source_active": _input(source_active, name="source_active", dtype=np.dtype(np.uint8)),
+        "fixed_receiver_ids": _input(
+            fixed_receiver_ids,
+            name="fixed_receiver_ids",
+            dtype=np.dtype(np.int32),
+        ),
+    }
+    cell_count = len(inputs["cell_ids"])
+    if any(len(values) != cell_count for values in inputs.values()):
+        raise ValueError("Hydrology Pass 2 cell inputs must have equal lengths")
+    xyz = np.ascontiguousarray(cell_xyz, dtype=np.float32)
+    if xyz.shape != (cell_count, 3):
+        raise ValueError(f"cell_xyz expected shape {(cell_count, 3)}, got {xyz.shape}")
+
+    config = _ffi.new(
+        "HydrologyPass2Config*",
+        {
+            "fine_resolution": int(controls["fine_resolution"]),
+            "minimum_depression_depth_m": float(controls["minimum_depression_depth_m"]),
+            "planet_radius_m": float(controls["planet_radius_m"]),
+        },
+    )[0]
+    cells_out = _ffi.new("StabilizedCellArray*")
+    stats_out = _ffi.new("HydrologyPass2Stats*")
+
+    def pointer(array: np.ndarray, ctype: str):
+        return _ffi.cast(
+            f"const {ctype}*", _ffi.from_buffer(f"{ctype}[]", array, require_writable=False)
+        )
+
+    status = _lib.hydrology_pass2_run(
+        config,
+        cell_count,
+        pointer(inputs["cell_ids"], "int32_t"),
+        pointer(inputs["terrain_before_m"], "double"),
+        pointer(inputs["routing_surface_after_m"], "double"),
+        pointer(inputs["cell_areas_km2"], "double"),
+        pointer(xyz.reshape(-1), "float"),
+        pointer(inputs["anchor_kinds"], "uint8_t"),
+        pointer(inputs["source_active"], "uint8_t"),
+        pointer(inputs["fixed_receiver_ids"], "int32_t"),
+        cells_out,
+        stats_out,
+    )
+    if status != 0:
+        messages = {
+            1: "invalid controls or array lengths",
+            2: "invalid cell identity or physical input",
+            3: "invalid anchor or fixed trunk receiver",
+            4: "null input or output pointer",
+        }
+        raise RuntimeError(
+            f"hydrology_pass2_run failed: {messages.get(status, f'status {status}')}"
+        )
+
+    records = _records(cells_out[0])
+    stats = stats_out[0]
+    metadata = {
+        name: int(getattr(stats, name))
+        for name in (
+            "cell_count",
+            "active_cell_count",
+            "channel_cell_count",
+            "excluded_cell_count",
+            "outside_cell_count",
+            "physical_trunk_edge_count",
+            "baseline_uncovered_cell_count",
+            "stabilized_uncovered_cell_count",
+            "baseline_depression_count",
+            "stabilized_depression_count",
+            "receiver_changed_cell_count",
+            "depression_changed_cell_count",
+            "graph_valid",
+            "trunk_preserved_valid",
+            "process_exclusion_valid",
+        )
+    }
+    metadata.update(
+        {
+            name: float(getattr(stats, name))
+            for name in (
+                "active_area_km2",
+                "receiver_changed_area_km2",
+                "receiver_changed_area_fraction",
+                "terminal_accumulated_area_km2",
+                "contributing_area_residual_km2",
+                "baseline_depression_area_km2",
+                "stabilized_depression_area_km2",
+                "baseline_depression_volume_km3",
+                "stabilized_depression_volume_km3",
+                "maximum_baseline_fill_depth_m",
+                "maximum_stabilized_fill_depth_m",
+            )
+        }
+    )
+    return records, metadata
+
+
+__all__ = ["run_hydrology_pass2"]

--- a/src/map_maker/pipeline/native/hydrology_pass2/Cargo.toml
+++ b/src/map_maker/pipeline/native/hydrology_pass2/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hydrology_pass2_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+topology_native = { path = "../topology" }
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
+++ b/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
@@ -1,0 +1,791 @@
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, VecDeque};
+use std::slice;
+
+use topology_native::cubed_sphere_neighbor_index;
+
+const D4_NEIGHBORS: usize = 4;
+const ANCHOR_NORMAL: u8 = 0;
+const ANCHOR_CHANNEL: u8 = 1;
+const ANCHOR_EXCLUDED: u8 = 2;
+const ANCHOR_OUTSIDE: u8 = 3;
+const TERMINAL_OCEAN: i32 = -1;
+const TERMINAL_HANDOFF: i32 = -2;
+const NO_FIXED_RECEIVER: i32 = i32::MIN;
+
+#[no_mangle]
+pub extern "C" fn hydrology_pass2_native_abi_version() -> u32 {
+    1
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HydrologyPass2Config {
+    pub fine_resolution: i32,
+    pub minimum_depression_depth_m: f64,
+    pub planet_radius_m: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct StabilizedCellRecord {
+    pub fine_cell_id: i32,
+    pub baseline_receiver_id: i32,
+    pub stabilized_receiver_id: i32,
+    pub baseline_anchor_cell_id: i32,
+    pub stabilized_anchor_cell_id: i32,
+    pub baseline_depression_id: i32,
+    pub stabilized_depression_id: i32,
+    pub anchor_kind: u8,
+    pub receiver_changed: u8,
+    pub depression_changed: u8,
+    pub terminal_kind: u8,
+    pub baseline_hydrologic_elevation_m: f64,
+    pub stabilized_hydrologic_elevation_m: f64,
+    pub baseline_fill_depth_m: f64,
+    pub stabilized_fill_depth_m: f64,
+    pub stabilized_flow_slope: f64,
+    pub contributing_area_km2: f64,
+    pub flow_direction_xyz: [f32; 3],
+}
+
+#[repr(C)]
+pub struct StabilizedCellArray {
+    pub data: *mut StabilizedCellRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct HydrologyPass2Stats {
+    pub cell_count: i32,
+    pub active_cell_count: i32,
+    pub channel_cell_count: i32,
+    pub excluded_cell_count: i32,
+    pub outside_cell_count: i32,
+    pub physical_trunk_edge_count: i32,
+    pub baseline_uncovered_cell_count: i32,
+    pub stabilized_uncovered_cell_count: i32,
+    pub baseline_depression_count: i32,
+    pub stabilized_depression_count: i32,
+    pub receiver_changed_cell_count: i32,
+    pub depression_changed_cell_count: i32,
+    pub graph_valid: i32,
+    pub trunk_preserved_valid: i32,
+    pub process_exclusion_valid: i32,
+    pub active_area_km2: f64,
+    pub receiver_changed_area_km2: f64,
+    pub receiver_changed_area_fraction: f64,
+    pub terminal_accumulated_area_km2: f64,
+    pub contributing_area_residual_km2: f64,
+    pub baseline_depression_area_km2: f64,
+    pub stabilized_depression_area_km2: f64,
+    pub baseline_depression_volume_km3: f64,
+    pub stabilized_depression_volume_km3: f64,
+    pub maximum_baseline_fill_depth_m: f64,
+    pub maximum_stabilized_fill_depth_m: f64,
+}
+
+struct Inputs<'a> {
+    cell_ids: &'a [i32],
+    terrain_before_m: &'a [f64],
+    routing_surface_after_m: &'a [f64],
+    cell_areas_km2: &'a [f64],
+    cell_xyz: &'a [f32],
+    anchor_kinds: &'a [u8],
+    source_active: &'a [u8],
+    fixed_receiver_ids: &'a [i32],
+}
+
+struct Route {
+    receiver: Vec<i32>,
+    anchor: Vec<i32>,
+    hydrologic_elevation_m: Vec<f64>,
+    fill_depth_m: Vec<f64>,
+    depression_id: Vec<i32>,
+    depression_count: usize,
+    uncovered_count: usize,
+    depression_area_km2: f64,
+    depression_volume_km3: f64,
+    maximum_fill_depth_m: f64,
+}
+
+struct Outcome {
+    cells: Vec<StabilizedCellRecord>,
+    stats: HydrologyPass2Stats,
+}
+
+struct RoutingDomain {
+    row_by_id: HashMap<i32, usize>,
+    adjacency: Vec<[i32; D4_NEIGHBORS]>,
+}
+
+#[derive(Clone, Copy)]
+struct QueueState {
+    elevation_m: f64,
+    cell_id: i32,
+    row: usize,
+}
+
+impl PartialEq for QueueState {
+    fn eq(&self, other: &Self) -> bool {
+        self.cell_id == other.cell_id && self.elevation_m.to_bits() == other.elevation_m.to_bits()
+    }
+}
+
+impl Eq for QueueState {}
+
+impl PartialOrd for QueueState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for QueueState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .elevation_m
+            .total_cmp(&self.elevation_m)
+            .then_with(|| other.cell_id.cmp(&self.cell_id))
+    }
+}
+
+fn build_adjacency(
+    resolution: usize,
+    cell_ids: &[i32],
+    row_by_id: &HashMap<i32, usize>,
+) -> Vec<[i32; D4_NEIGHBORS]> {
+    cell_ids
+        .iter()
+        .map(|&cell_id| {
+            let mut neighbors = [-1i32; D4_NEIGHBORS];
+            for (slot, target) in neighbors.iter_mut().enumerate() {
+                if let Some(neighbor) =
+                    cubed_sphere_neighbor_index(cell_id as usize, slot, resolution)
+                {
+                    let neighbor = neighbor as i32;
+                    if row_by_id.contains_key(&neighbor) {
+                        *target = neighbor;
+                    }
+                }
+            }
+            neighbors
+        })
+        .collect()
+}
+
+fn validate_inputs(
+    config: HydrologyPass2Config,
+    inputs: &Inputs<'_>,
+) -> Result<RoutingDomain, i32> {
+    let resolution = usize::try_from(config.fine_resolution).map_err(|_| 1)?;
+    let cell_count = inputs.cell_ids.len();
+    if resolution == 0
+        || cell_count == 0
+        || !config.minimum_depression_depth_m.is_finite()
+        || config.minimum_depression_depth_m < 0.0
+        || !config.planet_radius_m.is_finite()
+        || config.planet_radius_m <= 0.0
+        || inputs.terrain_before_m.len() != cell_count
+        || inputs.routing_surface_after_m.len() != cell_count
+        || inputs.cell_areas_km2.len() != cell_count
+        || inputs.cell_xyz.len() != cell_count * 3
+        || inputs.anchor_kinds.len() != cell_count
+        || inputs.source_active.len() != cell_count
+        || inputs.fixed_receiver_ids.len() != cell_count
+    {
+        return Err(1);
+    }
+    let global_count = 6usize
+        .checked_mul(resolution)
+        .and_then(|value| value.checked_mul(resolution))
+        .filter(|value| *value <= i32::MAX as usize)
+        .ok_or(1)?;
+    let mut row_by_id = HashMap::with_capacity(cell_count);
+    for row in 0..cell_count {
+        let cell_id = inputs.cell_ids[row];
+        if cell_id < 0
+            || cell_id as usize >= global_count
+            || row_by_id.insert(cell_id, row).is_some()
+            || !inputs.terrain_before_m[row].is_finite()
+            || !inputs.routing_surface_after_m[row].is_finite()
+            || !inputs.cell_areas_km2[row].is_finite()
+            || inputs.cell_areas_km2[row] <= 0.0
+            || inputs.cell_xyz[row * 3..row * 3 + 3]
+                .iter()
+                .any(|value| !value.is_finite())
+            || inputs.anchor_kinds[row] > ANCHOR_OUTSIDE
+            || inputs.source_active[row] > 1
+        {
+            return Err(2);
+        }
+        match inputs.anchor_kinds[row] {
+            ANCHOR_CHANNEL => {
+                if inputs.fixed_receiver_ids[row] < TERMINAL_HANDOFF {
+                    return Err(3);
+                }
+            }
+            _ if inputs.fixed_receiver_ids[row] != NO_FIXED_RECEIVER => return Err(3),
+            _ => {}
+        }
+    }
+    if !inputs
+        .anchor_kinds
+        .iter()
+        .any(|kind| *kind != ANCHOR_NORMAL)
+    {
+        return Err(3);
+    }
+    let adjacency = build_adjacency(resolution, inputs.cell_ids, &row_by_id);
+    for (row, neighbors) in adjacency.iter().enumerate() {
+        if inputs.anchor_kinds[row] != ANCHOR_CHANNEL || inputs.fixed_receiver_ids[row] < 0 {
+            continue;
+        }
+        let target_id = inputs.fixed_receiver_ids[row];
+        let Some(&target_row) = row_by_id.get(&target_id) else {
+            return Err(3);
+        };
+        if inputs.anchor_kinds[target_row] != ANCHOR_CHANNEL || !neighbors.contains(&target_id) {
+            return Err(3);
+        }
+    }
+    Ok(RoutingDomain {
+        row_by_id,
+        adjacency,
+    })
+}
+
+fn route_surface(
+    config: HydrologyPass2Config,
+    inputs: &Inputs<'_>,
+    surface: &[f64],
+    row_by_id: &HashMap<i32, usize>,
+    adjacency: &[[i32; D4_NEIGHBORS]],
+) -> Route {
+    let cell_count = inputs.cell_ids.len();
+    let mut receiver = vec![NO_FIXED_RECEIVER; cell_count];
+    let mut anchor = vec![-1i32; cell_count];
+    let mut hydrologic_elevation_m = surface.to_vec();
+    let mut visited = vec![false; cell_count];
+    let mut heap = BinaryHeap::new();
+    for row in 0..cell_count {
+        if inputs.anchor_kinds[row] == ANCHOR_NORMAL {
+            continue;
+        }
+        visited[row] = true;
+        anchor[row] = inputs.cell_ids[row];
+        receiver[row] = match inputs.anchor_kinds[row] {
+            ANCHOR_CHANNEL => inputs.fixed_receiver_ids[row],
+            ANCHOR_EXCLUDED => TERMINAL_HANDOFF,
+            ANCHOR_OUTSIDE => TERMINAL_OCEAN,
+            _ => NO_FIXED_RECEIVER,
+        };
+        heap.push(QueueState {
+            elevation_m: surface[row],
+            cell_id: inputs.cell_ids[row],
+            row,
+        });
+    }
+
+    while let Some(state) = heap.pop() {
+        for &neighbor_id in &adjacency[state.row] {
+            if neighbor_id < 0 {
+                continue;
+            }
+            let neighbor = row_by_id[&neighbor_id];
+            if visited[neighbor] {
+                continue;
+            }
+            visited[neighbor] = true;
+            receiver[neighbor] = state.cell_id;
+            anchor[neighbor] = anchor[state.row];
+            hydrologic_elevation_m[neighbor] = surface[neighbor].max(state.elevation_m);
+            heap.push(QueueState {
+                elevation_m: hydrologic_elevation_m[neighbor],
+                cell_id: neighbor_id,
+                row: neighbor,
+            });
+        }
+    }
+
+    let uncovered_count = visited.iter().filter(|value| !**value).count();
+    let fill_depth_m = hydrologic_elevation_m
+        .iter()
+        .zip(surface)
+        .map(|(filled, raw)| (filled - raw).max(0.0))
+        .collect::<Vec<_>>();
+    let mut depression_id = vec![-1i32; cell_count];
+    let eligible = (0..cell_count)
+        .map(|row| {
+            visited[row]
+                && inputs.anchor_kinds[row] == ANCHOR_NORMAL
+                && fill_depth_m[row] >= config.minimum_depression_depth_m
+        })
+        .collect::<Vec<_>>();
+    let mut depression_count = 0usize;
+    let mut depression_area_km2 = 0.0;
+    let mut depression_volume_km3 = 0.0;
+    for start in 0..cell_count {
+        if !eligible[start] || depression_id[start] >= 0 {
+            continue;
+        }
+        let mut queue = VecDeque::from([start]);
+        let mut component = Vec::new();
+        depression_id[start] = -2;
+        let mut identifier = inputs.cell_ids[start];
+        while let Some(row) = queue.pop_front() {
+            component.push(row);
+            identifier = identifier.min(inputs.cell_ids[row]);
+            for &neighbor_id in &adjacency[row] {
+                let Some(&neighbor) = row_by_id.get(&neighbor_id) else {
+                    continue;
+                };
+                if eligible[neighbor] && depression_id[neighbor] == -1 {
+                    depression_id[neighbor] = -2;
+                    queue.push_back(neighbor);
+                }
+            }
+        }
+        for row in component {
+            depression_id[row] = identifier;
+            depression_area_km2 += inputs.cell_areas_km2[row];
+            depression_volume_km3 += fill_depth_m[row] * inputs.cell_areas_km2[row] / 1_000.0;
+        }
+        depression_count += 1;
+    }
+    Route {
+        receiver,
+        anchor,
+        hydrologic_elevation_m,
+        fill_depth_m: fill_depth_m.clone(),
+        depression_id,
+        depression_count,
+        uncovered_count,
+        depression_area_km2,
+        depression_volume_km3,
+        maximum_fill_depth_m: fill_depth_m.iter().copied().fold(0.0, f64::max),
+    }
+}
+
+fn angular_distance(first: &[f32], second: &[f32]) -> f64 {
+    let dot = (first[0] as f64 * second[0] as f64
+        + first[1] as f64 * second[1] as f64
+        + first[2] as f64 * second[2] as f64)
+        .clamp(-1.0, 1.0);
+    dot.acos()
+}
+
+fn flow_direction(first: &[f32], second: &[f32]) -> [f32; 3] {
+    let source = [first[0] as f64, first[1] as f64, first[2] as f64];
+    let delta = [
+        second[0] as f64 - source[0],
+        second[1] as f64 - source[1],
+        second[2] as f64 - source[2],
+    ];
+    let radial = delta[0] * source[0] + delta[1] * source[1] + delta[2] * source[2];
+    let tangent = [
+        delta[0] - radial * source[0],
+        delta[1] - radial * source[1],
+        delta[2] - radial * source[2],
+    ];
+    let norm = (tangent[0] * tangent[0] + tangent[1] * tangent[1] + tangent[2] * tangent[2]).sqrt();
+    if norm <= f64::EPSILON {
+        [0.0; 3]
+    } else {
+        [
+            (tangent[0] / norm) as f32,
+            (tangent[1] / norm) as f32,
+            (tangent[2] / norm) as f32,
+        ]
+    }
+}
+
+fn accumulate_area(
+    inputs: &Inputs<'_>,
+    route: &Route,
+    row_by_id: &HashMap<i32, usize>,
+) -> (Vec<f64>, bool, f64, f64) {
+    let cell_count = inputs.cell_ids.len();
+    let mut upstream_count = vec![0usize; cell_count];
+    for &receiver_id in &route.receiver {
+        if let Some(&target) = row_by_id.get(&receiver_id) {
+            upstream_count[target] += 1;
+        }
+    }
+    let mut ready = BinaryHeap::new();
+    for (row, &count) in upstream_count.iter().enumerate() {
+        if count == 0 {
+            ready.push(std::cmp::Reverse((inputs.cell_ids[row], row)));
+        }
+    }
+    let mut contributing_area = (0..cell_count)
+        .map(|row| {
+            if inputs.source_active[row] == 0 {
+                0.0
+            } else {
+                inputs.cell_areas_km2[row]
+            }
+        })
+        .collect::<Vec<_>>();
+    let active_area = contributing_area.iter().sum::<f64>();
+    let mut processed = 0usize;
+    while let Some(std::cmp::Reverse((_, row))) = ready.pop() {
+        processed += 1;
+        if let Some(&target) = row_by_id.get(&route.receiver[row]) {
+            contributing_area[target] += contributing_area[row];
+            upstream_count[target] -= 1;
+            if upstream_count[target] == 0 {
+                ready.push(std::cmp::Reverse((inputs.cell_ids[target], target)));
+            }
+        }
+    }
+    let graph_valid = processed == cell_count;
+    let terminal_area = route
+        .receiver
+        .iter()
+        .enumerate()
+        .filter(|(_, receiver)| **receiver < 0)
+        .map(|(row, _)| contributing_area[row])
+        .sum::<f64>();
+    (contributing_area, graph_valid, active_area, terminal_area)
+}
+
+fn run_pass(config: HydrologyPass2Config, inputs: &Inputs<'_>) -> Result<Outcome, i32> {
+    let domain = validate_inputs(config, inputs)?;
+    let row_by_id = &domain.row_by_id;
+    let adjacency = &domain.adjacency;
+    let baseline = route_surface(
+        config,
+        inputs,
+        inputs.terrain_before_m,
+        row_by_id,
+        adjacency,
+    );
+    let stabilized = route_surface(
+        config,
+        inputs,
+        inputs.routing_surface_after_m,
+        row_by_id,
+        adjacency,
+    );
+    let (contributing_area, graph_valid, active_area, terminal_area) =
+        accumulate_area(inputs, &stabilized, row_by_id);
+    let mut receiver_changed_count = 0usize;
+    let mut receiver_changed_area = 0.0;
+    let mut depression_changed_count = 0usize;
+    let mut physical_trunk_edge_count = 0usize;
+    let mut trunk_preserved_valid = true;
+    let mut process_exclusion_valid = true;
+    let mut cells = Vec::with_capacity(inputs.cell_ids.len());
+    for (row, &cell_contributing_area) in contributing_area.iter().enumerate() {
+        let receiver_changed = baseline.receiver[row] != stabilized.receiver[row];
+        let depression_changed = baseline.depression_id[row] != stabilized.depression_id[row];
+        if receiver_changed && inputs.source_active[row] != 0 {
+            receiver_changed_count += 1;
+            receiver_changed_area += inputs.cell_areas_km2[row];
+        }
+        if depression_changed && inputs.source_active[row] != 0 {
+            depression_changed_count += 1;
+        }
+        if inputs.anchor_kinds[row] == ANCHOR_CHANNEL {
+            trunk_preserved_valid &= baseline.receiver[row] == inputs.fixed_receiver_ids[row]
+                && stabilized.receiver[row] == inputs.fixed_receiver_ids[row];
+            physical_trunk_edge_count += usize::from(inputs.fixed_receiver_ids[row] >= 0);
+        }
+        if inputs.anchor_kinds[row] == ANCHOR_EXCLUDED {
+            process_exclusion_valid &= baseline.receiver[row] == TERMINAL_HANDOFF
+                && stabilized.receiver[row] == TERMINAL_HANDOFF
+                && baseline.depression_id[row] < 0
+                && stabilized.depression_id[row] < 0;
+        }
+        let receiver_id = stabilized.receiver[row];
+        let (flow_slope, direction) = if let Some(&target) = row_by_id.get(&receiver_id) {
+            let length_m = angular_distance(
+                &inputs.cell_xyz[row * 3..row * 3 + 3],
+                &inputs.cell_xyz[target * 3..target * 3 + 3],
+            ) * config.planet_radius_m;
+            let slope = if length_m > 0.0 {
+                ((stabilized.hydrologic_elevation_m[row]
+                    - stabilized.hydrologic_elevation_m[target])
+                    / length_m)
+                    .max(0.0)
+            } else {
+                0.0
+            };
+            (
+                slope,
+                flow_direction(
+                    &inputs.cell_xyz[row * 3..row * 3 + 3],
+                    &inputs.cell_xyz[target * 3..target * 3 + 3],
+                ),
+            )
+        } else {
+            (0.0, [0.0; 3])
+        };
+        cells.push(StabilizedCellRecord {
+            fine_cell_id: inputs.cell_ids[row],
+            baseline_receiver_id: baseline.receiver[row],
+            stabilized_receiver_id: receiver_id,
+            baseline_anchor_cell_id: baseline.anchor[row],
+            stabilized_anchor_cell_id: stabilized.anchor[row],
+            baseline_depression_id: baseline.depression_id[row],
+            stabilized_depression_id: stabilized.depression_id[row],
+            anchor_kind: inputs.anchor_kinds[row],
+            receiver_changed: u8::from(receiver_changed),
+            depression_changed: u8::from(depression_changed),
+            terminal_kind: match receiver_id {
+                TERMINAL_OCEAN => 1,
+                TERMINAL_HANDOFF => 2,
+                _ => 0,
+            },
+            baseline_hydrologic_elevation_m: baseline.hydrologic_elevation_m[row],
+            stabilized_hydrologic_elevation_m: stabilized.hydrologic_elevation_m[row],
+            baseline_fill_depth_m: baseline.fill_depth_m[row],
+            stabilized_fill_depth_m: stabilized.fill_depth_m[row],
+            stabilized_flow_slope: flow_slope,
+            contributing_area_km2: cell_contributing_area,
+            flow_direction_xyz: direction,
+        });
+    }
+    let active_cell_count = inputs
+        .source_active
+        .iter()
+        .filter(|value| **value != 0)
+        .count();
+    let area_residual = terminal_area - active_area;
+    let area_tolerance = 1e-9 * active_area.max(1.0);
+    let graph_valid = graph_valid
+        && baseline.uncovered_count == 0
+        && stabilized.uncovered_count == 0
+        && area_residual.abs() <= area_tolerance;
+    let stats = HydrologyPass2Stats {
+        cell_count: i32::try_from(inputs.cell_ids.len()).map_err(|_| 1)?,
+        active_cell_count: i32::try_from(active_cell_count).map_err(|_| 1)?,
+        channel_cell_count: i32::try_from(
+            inputs
+                .anchor_kinds
+                .iter()
+                .filter(|kind| **kind == ANCHOR_CHANNEL)
+                .count(),
+        )
+        .map_err(|_| 1)?,
+        excluded_cell_count: i32::try_from(
+            inputs
+                .anchor_kinds
+                .iter()
+                .filter(|kind| **kind == ANCHOR_EXCLUDED)
+                .count(),
+        )
+        .map_err(|_| 1)?,
+        outside_cell_count: i32::try_from(
+            inputs
+                .anchor_kinds
+                .iter()
+                .filter(|kind| **kind == ANCHOR_OUTSIDE)
+                .count(),
+        )
+        .map_err(|_| 1)?,
+        physical_trunk_edge_count: i32::try_from(physical_trunk_edge_count).map_err(|_| 1)?,
+        baseline_uncovered_cell_count: i32::try_from(baseline.uncovered_count).map_err(|_| 1)?,
+        stabilized_uncovered_cell_count: i32::try_from(stabilized.uncovered_count)
+            .map_err(|_| 1)?,
+        baseline_depression_count: i32::try_from(baseline.depression_count).map_err(|_| 1)?,
+        stabilized_depression_count: i32::try_from(stabilized.depression_count).map_err(|_| 1)?,
+        receiver_changed_cell_count: i32::try_from(receiver_changed_count).map_err(|_| 1)?,
+        depression_changed_cell_count: i32::try_from(depression_changed_count).map_err(|_| 1)?,
+        graph_valid: i32::from(graph_valid),
+        trunk_preserved_valid: i32::from(trunk_preserved_valid),
+        process_exclusion_valid: i32::from(process_exclusion_valid),
+        active_area_km2: active_area,
+        receiver_changed_area_km2: receiver_changed_area,
+        receiver_changed_area_fraction: receiver_changed_area / active_area.max(f64::EPSILON),
+        terminal_accumulated_area_km2: terminal_area,
+        contributing_area_residual_km2: area_residual,
+        baseline_depression_area_km2: baseline.depression_area_km2,
+        stabilized_depression_area_km2: stabilized.depression_area_km2,
+        baseline_depression_volume_km3: baseline.depression_volume_km3,
+        stabilized_depression_volume_km3: stabilized.depression_volume_km3,
+        maximum_baseline_fill_depth_m: baseline.maximum_fill_depth_m,
+        maximum_stabilized_fill_depth_m: stabilized.maximum_fill_depth_m,
+    };
+    Ok(Outcome { cells, stats })
+}
+
+fn into_raw_array<T>(values: Vec<T>) -> (*mut T, usize) {
+    let mut values = values.into_boxed_slice();
+    let result = (values.as_mut_ptr(), values.len());
+    let _ = Box::leak(values);
+    result
+}
+
+fn free_raw_array<T>(data: *mut T, len: usize) {
+    if !data.is_null() {
+        unsafe {
+            let values = std::ptr::slice_from_raw_parts_mut(data, len);
+            drop(Box::from_raw(values));
+        }
+    }
+}
+
+unsafe fn read_slice<'a, T>(pointer: *const T, len: usize) -> &'a [T] {
+    unsafe { slice::from_raw_parts(pointer, len) }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+/// Stabilize one sparse refined basin after erosion.
+///
+/// # Safety
+///
+/// Every input pointer must reference a contiguous buffer of the declared
+/// length. Output pointers must be valid and must not alias input buffers.
+pub unsafe extern "C" fn hydrology_pass2_run(
+    config: HydrologyPass2Config,
+    cell_count: usize,
+    cell_ids: *const i32,
+    terrain_before_m: *const f64,
+    routing_surface_after_m: *const f64,
+    cell_areas_km2: *const f64,
+    cell_xyz: *const f32,
+    anchor_kinds: *const u8,
+    source_active: *const u8,
+    fixed_receiver_ids: *const i32,
+    cells_out: *mut StabilizedCellArray,
+    stats_out: *mut HydrologyPass2Stats,
+) -> i32 {
+    if cell_count == 0
+        || cell_ids.is_null()
+        || terrain_before_m.is_null()
+        || routing_surface_after_m.is_null()
+        || cell_areas_km2.is_null()
+        || cell_xyz.is_null()
+        || anchor_kinds.is_null()
+        || source_active.is_null()
+        || fixed_receiver_ids.is_null()
+        || cells_out.is_null()
+        || stats_out.is_null()
+    {
+        return 4;
+    }
+    let inputs = Inputs {
+        cell_ids: unsafe { read_slice(cell_ids, cell_count) },
+        terrain_before_m: unsafe { read_slice(terrain_before_m, cell_count) },
+        routing_surface_after_m: unsafe { read_slice(routing_surface_after_m, cell_count) },
+        cell_areas_km2: unsafe { read_slice(cell_areas_km2, cell_count) },
+        cell_xyz: unsafe { read_slice(cell_xyz, cell_count * 3) },
+        anchor_kinds: unsafe { read_slice(anchor_kinds, cell_count) },
+        source_active: unsafe { read_slice(source_active, cell_count) },
+        fixed_receiver_ids: unsafe { read_slice(fixed_receiver_ids, cell_count) },
+    };
+    match run_pass(config, &inputs) {
+        Ok(outcome) => {
+            let (cells, len) = into_raw_array(outcome.cells);
+            unsafe {
+                *cells_out = StabilizedCellArray { data: cells, len };
+                *stats_out = outcome.stats;
+            }
+            0
+        }
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hydrology_pass2_free_cells(array: StabilizedCellArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use topology_native::{cubed_sphere_cell_xyz, cubed_sphere_global_index};
+
+    fn grid_fixture() -> (Vec<i32>, Vec<f32>) {
+        let resolution = 4;
+        let mut ids = Vec::new();
+        let mut xyz = Vec::new();
+        for row in 0..3 {
+            for col in 0..3 {
+                ids.push(cubed_sphere_global_index(0, row, col, resolution).unwrap() as i32);
+                xyz.extend(
+                    cubed_sphere_cell_xyz(0, row, col, resolution)
+                        .unwrap()
+                        .map(|value| value as f32),
+                );
+            }
+        }
+        (ids, xyz)
+    }
+
+    #[test]
+    fn stabilizes_sparse_basin_and_conserves_contributing_area() {
+        let (ids, xyz) = grid_fixture();
+        let terrain_before = vec![6.0, 5.0, 6.0, 5.0, 4.0, 5.0, 6.0, 3.0, 6.0];
+        let terrain_after = vec![6.0, 5.0, 6.0, 5.0, 2.0, 5.0, 6.0, 1.0, 6.0];
+        let mut anchors = vec![ANCHOR_NORMAL; 9];
+        let mut fixed = vec![NO_FIXED_RECEIVER; 9];
+        for row in [1usize, 4, 7] {
+            anchors[row] = ANCHOR_CHANNEL;
+        }
+        fixed[1] = ids[4];
+        fixed[4] = ids[7];
+        fixed[7] = TERMINAL_OCEAN;
+        let inputs = Inputs {
+            cell_ids: &ids,
+            terrain_before_m: &terrain_before,
+            routing_surface_after_m: &terrain_after,
+            cell_areas_km2: &[1.0; 9],
+            cell_xyz: &xyz,
+            anchor_kinds: &anchors,
+            source_active: &[1; 9],
+            fixed_receiver_ids: &fixed,
+        };
+        let outcome = run_pass(
+            HydrologyPass2Config {
+                fine_resolution: 4,
+                minimum_depression_depth_m: 0.5,
+                planet_radius_m: 6_371_000.0,
+            },
+            &inputs,
+        )
+        .expect("valid stabilization");
+        assert_eq!(outcome.stats.graph_valid, 1);
+        assert_eq!(outcome.stats.trunk_preserved_valid, 1);
+        assert_eq!(outcome.stats.physical_trunk_edge_count, 2);
+        assert!((outcome.stats.terminal_accumulated_area_km2 - 9.0).abs() < 1e-12);
+        assert_eq!(outcome.cells[1].stabilized_receiver_id, ids[4]);
+        assert_eq!(outcome.cells[4].stabilized_receiver_id, ids[7]);
+        assert_eq!(outcome.cells[7].stabilized_receiver_id, TERMINAL_OCEAN);
+    }
+
+    #[test]
+    fn preserved_depression_is_a_nonphysical_handoff() {
+        let (ids, xyz) = grid_fixture();
+        let terrain = vec![5.0; 9];
+        let mut anchors = vec![ANCHOR_NORMAL; 9];
+        anchors[4] = ANCHOR_EXCLUDED;
+        let inputs = Inputs {
+            cell_ids: &ids,
+            terrain_before_m: &terrain,
+            routing_surface_after_m: &terrain,
+            cell_areas_km2: &[1.0; 9],
+            cell_xyz: &xyz,
+            anchor_kinds: &anchors,
+            source_active: &[1, 1, 1, 1, 0, 1, 1, 1, 1],
+            fixed_receiver_ids: &[NO_FIXED_RECEIVER; 9],
+        };
+        let outcome = run_pass(
+            HydrologyPass2Config {
+                fine_resolution: 4,
+                minimum_depression_depth_m: 0.5,
+                planet_radius_m: 6_371_000.0,
+            },
+            &inputs,
+        )
+        .expect("valid excluded handoff");
+        assert_eq!(outcome.stats.graph_valid, 1);
+        assert_eq!(outcome.stats.process_exclusion_valid, 1);
+        assert_eq!(outcome.cells[4].stabilized_receiver_id, TERMINAL_HANDOFF);
+        assert_eq!(outcome.cells[4].contributing_area_km2, 8.0);
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -8,6 +8,7 @@ from . import climate  # noqa: F401
 from . import hydrology  # noqa: F401
 from . import basin_refinement  # noqa: F401
 from . import basin_erosion  # noqa: F401
+from . import hydrology_pass2  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -27,6 +28,7 @@ def ensure_builtin_stages() -> None:
         "hydrology": hydrology,
         "basin_refinement": basin_refinement,
         "basin_erosion": basin_erosion,
+        "hydrology_pass2": hydrology_pass2,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/hydrology_pass2.py
+++ b/src/map_maker/pipeline/stages/hydrology_pass2.py
@@ -1,0 +1,683 @@
+"""Bounded sparse Hydrology Pass 2 for one eroded refined basin."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+import pyarrow as pa
+from PIL import Image, ImageDraw
+
+from .._hydrology_pass2_native import run_hydrology_pass2
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+EARTH_RADIUS_M = 6_371_000.0
+NO_FIXED_RECEIVER = np.iinfo(np.int32).min
+TERMINAL_OCEAN = -1
+TERMINAL_HANDOFF = -2
+ANCHOR_NORMAL = 0
+ANCHOR_CHANNEL = 1
+ANCHOR_EXCLUDED = 2
+ANCHOR_OUTSIDE = 3
+
+
+@dataclass(frozen=True)
+class HydrologyPass2Config:
+    minimum_depression_depth_m: float = 5.0
+    maximum_receiver_change_fraction: float = 0.15
+    maximum_receiver_change_cell_fraction: float = 0.15
+    maximum_new_depression_area_fraction: float = 0.02
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "HydrologyPass2Config":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown Hydrology Pass 2 controls: {', '.join(sorted(unknown))}")
+        values = {
+            name: float(mapping.get(name, field.default))
+            for name, field in cls.__dataclass_fields__.items()
+        }
+        if (
+            not np.isfinite(values["minimum_depression_depth_m"])
+            or values["minimum_depression_depth_m"] < 0.0
+        ):
+            raise ValueError("minimum_depression_depth_m must be finite and non-negative")
+        for name in (
+            "maximum_receiver_change_fraction",
+            "maximum_receiver_change_cell_fraction",
+            "maximum_new_depression_area_fraction",
+        ):
+            if not np.isfinite(values[name]) or not 0.0 <= values[name] <= 1.0:
+                raise ValueError(f"{name} must be finite and in [0, 1]")
+        return cls(**values)
+
+
+def _artifact_table(result, name: str) -> pa.Table:
+    record = result.artifact_records.get(name)
+    if record is None or not isinstance(record.value, pa.Table):
+        raise KeyError(f"Missing dependency table '{name}'")
+    return record.value
+
+
+def _column(table: pa.Table, name: str, dtype: np.dtype) -> np.ndarray:
+    return np.ascontiguousarray(
+        table[name].combine_chunks().to_numpy(zero_copy_only=False), dtype=dtype
+    )
+
+
+def _fixed_list_column(table: pa.Table, name: str, width: int) -> np.ndarray:
+    values = table[name].combine_chunks().values.to_numpy(zero_copy_only=False)
+    return np.ascontiguousarray(values.reshape(table.num_rows, width), dtype=np.float32)
+
+
+def _fixed_list(values: np.ndarray, width: int) -> pa.FixedSizeListArray:
+    return pa.FixedSizeListArray.from_arrays(
+        pa.array(np.asarray(values, dtype=np.float32).reshape(-1), type=pa.float32()), width
+    )
+
+
+def _lookup_rows(ids: np.ndarray, query: np.ndarray, *, label: str) -> np.ndarray:
+    order = np.argsort(ids)
+    sorted_ids = ids[order]
+    positions = np.searchsorted(sorted_ids, query)
+    if np.any(positions >= len(sorted_ids)) or np.any(sorted_ids[positions] != query):
+        raise RuntimeError(f"{label} references an unknown identifier")
+    return order[positions]
+
+
+def _trunk_contract(
+    profiles: pa.Table,
+    reaches: pa.Table,
+    cell_ids: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    fixed_receivers = np.full(len(cell_ids), NO_FIXED_RECEIVER, dtype=np.int32)
+    routing_bed = np.full(len(cell_ids), np.nan, dtype=np.float64)
+    channel_cells = np.unique(np.asarray(profiles["fine_cell_id"], dtype=np.int32))
+    channel_rows = _lookup_rows(cell_ids, channel_cells, label="channel bed")
+
+    profile_cell_ids = np.asarray(profiles["fine_cell_id"], dtype=np.int32)
+    profile_beds = np.asarray(profiles["bed_elevation_m"], dtype=np.float64)
+    profile_channel_rows = _lookup_rows(
+        channel_cells, profile_cell_ids, label="profile channel cell"
+    )
+    minimum_bed = np.full(len(channel_cells), np.inf, dtype=np.float64)
+    maximum_bed = np.full(len(channel_cells), -np.inf, dtype=np.float64)
+    np.minimum.at(minimum_bed, profile_channel_rows, profile_beds)
+    np.maximum.at(maximum_bed, profile_channel_rows, profile_beds)
+    if np.any(maximum_bed - minimum_bed > 1e-10):
+        raise RuntimeError("shared channel cell has inconsistent persisted bed elevations")
+    routing_bed[channel_rows] = minimum_bed
+
+    edge_by_source: dict[int, int] = {}
+    last_cell_by_reach: dict[int, int] = {}
+    profile_reach_ids = np.asarray(profiles["reach_id"], dtype=np.int32)
+    path_order = np.asarray(profiles["path_order"], dtype=np.int32)
+    for reach_id in np.unique(profile_reach_ids):
+        rows = np.flatnonzero(profile_reach_ids == reach_id)
+        rows = rows[np.argsort(path_order[rows], kind="stable")]
+        last_cell_by_reach[int(reach_id)] = int(profile_cell_ids[rows[-1]])
+        for source_row, target_row in zip(rows[:-1], rows[1:], strict=True):
+            if path_order[target_row] != path_order[source_row] + 1:
+                continue
+            source = int(profile_cell_ids[source_row])
+            target = int(profile_cell_ids[target_row])
+            previous = edge_by_source.setdefault(source, target)
+            if previous != target:
+                raise RuntimeError("physical channel cell has multiple downstream trunk receivers")
+
+    reach_ids = np.asarray(reaches["reach_id"], dtype=np.int32)
+    downstream_ids = np.asarray(reaches["downstream_reach_id"], dtype=np.int32)
+    terminal_kinds = reaches["terminal_kind"].to_pylist()
+    row_by_reach = {int(reach_id): row for row, reach_id in enumerate(reach_ids)}
+    terminal_by_cell: dict[int, int] = defaultdict(lambda: TERMINAL_HANDOFF)
+    for reach_id, last_cell in last_cell_by_reach.items():
+        row = row_by_reach[reach_id]
+        if downstream_ids[row] < 0 and terminal_kinds[row] == "ocean":
+            terminal_by_cell[last_cell] = TERMINAL_OCEAN
+
+    for cell_id, row in zip(channel_cells, channel_rows, strict=True):
+        fixed_receivers[row] = edge_by_source.get(int(cell_id), terminal_by_cell[int(cell_id)])
+    return channel_rows, fixed_receivers, routing_bed
+
+
+def _cell_table(source: pa.Table, records: np.ndarray, routing_surface: np.ndarray) -> pa.Table:
+    source_ids = np.asarray(source["fine_cell_id"], dtype=np.int32)
+    if not np.array_equal(source_ids, records["fine_cell_id"]):
+        raise RuntimeError("Hydrology Pass 2 changed cell order or identity")
+    anchor_names = np.array(
+        ["ordinary", "channel", "preserved_handoff", "outside_terminal"], dtype=object
+    )[records["anchor_kind"]]
+    terminal_names = np.array(["routed", "ocean", "preserved_handoff"], dtype=object)[
+        records["terminal_kind"]
+    ]
+    table = source.append_column(
+        "routing_surface_after_m", pa.array(routing_surface, type=pa.float64())
+    )
+    for name in (
+        "baseline_receiver_id",
+        "stabilized_receiver_id",
+        "baseline_anchor_cell_id",
+        "stabilized_anchor_cell_id",
+        "baseline_depression_id",
+        "stabilized_depression_id",
+    ):
+        table = table.append_column(name, pa.array(records[name], type=pa.int32()))
+    table = table.append_column("routing_anchor_kind", pa.array(anchor_names, type=pa.string()))
+    table = table.append_column("terminal_kind_pass2", pa.array(terminal_names, type=pa.string()))
+    table = table.append_column(
+        "receiver_changed", pa.array(records["receiver_changed"] != 0, type=pa.bool_())
+    )
+    table = table.append_column(
+        "depression_changed", pa.array(records["depression_changed"] != 0, type=pa.bool_())
+    )
+    for name in (
+        "baseline_hydrologic_elevation_m",
+        "stabilized_hydrologic_elevation_m",
+        "baseline_fill_depth_m",
+        "stabilized_fill_depth_m",
+        "stabilized_flow_slope",
+        "contributing_area_km2",
+    ):
+        table = table.append_column(name, pa.array(records[name], type=pa.float64()))
+    table = table.append_column(
+        "stabilized_flow_direction_xyz", _fixed_list(records["flow_direction_xyz"], 3)
+    )
+    return table
+
+
+def _depression_catalog(cells: pa.Table) -> tuple[pa.Table, dict[str, float | int]]:
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    receiver_ids = np.asarray(cells["stabilized_receiver_id"], dtype=np.int32)
+    baseline_ids = np.asarray(cells["baseline_depression_id"], dtype=np.int32)
+    stabilized_ids = np.asarray(cells["stabilized_depression_id"], dtype=np.int32)
+    area = np.asarray(cells["area_km2"], dtype=np.float64)
+    depth = np.asarray(cells["stabilized_fill_depth_m"], dtype=np.float64)
+    level = np.asarray(cells["stabilized_hydrologic_elevation_m"], dtype=np.float64)
+    receiver_depression = np.full(len(cells), -1, dtype=np.int32)
+    routed = receiver_ids >= 0
+    if np.any(routed):
+        receiver_rows = _lookup_rows(
+            cell_ids, receiver_ids[routed], label="depression spill receiver"
+        )
+        receiver_depression[routed] = stabilized_ids[receiver_rows]
+
+    rows: list[dict[str, object]] = []
+    new_area = float(np.sum(area[(stabilized_ids >= 0) & (baseline_ids < 0)]))
+    for depression_id in np.unique(stabilized_ids[stabilized_ids >= 0]):
+        mask = stabilized_ids == depression_id
+        boundary = mask & (receiver_depression != depression_id)
+        boundary_rows = np.flatnonzero(boundary)
+        if len(boundary_rows) == 0:
+            raise RuntimeError("local depression candidate has no spill receiver")
+        spill_row = min(boundary_rows, key=lambda row: (float(level[row]), int(cell_ids[row])))
+        overlaps = baseline_ids[mask]
+        overlap_area = area[mask]
+        valid_overlap = overlaps >= 0
+        dominant_baseline = -1
+        dominant_overlap_area = 0.0
+        if np.any(valid_overlap):
+            overlap_totals: dict[int, float] = defaultdict(float)
+            for inherited_id, cell_area in zip(
+                overlaps[valid_overlap], overlap_area[valid_overlap], strict=True
+            ):
+                overlap_totals[int(inherited_id)] += float(cell_area)
+            dominant_baseline, dominant_overlap_area = max(
+                overlap_totals.items(), key=lambda item: (item[1], -item[0])
+            )
+        candidate_area = float(np.sum(area[mask]))
+        if dominant_baseline < 0:
+            status = "new"
+        elif np.all(baseline_ids[mask] == depression_id) and np.all(
+            stabilized_ids[baseline_ids == depression_id] == depression_id
+        ):
+            status = "stable"
+        else:
+            status = "changed"
+        rows.append(
+            {
+                "depression_id": int(depression_id),
+                "spill_cell_id": int(cell_ids[spill_row]),
+                "spill_receiver_id": int(receiver_ids[spill_row]),
+                "cell_count": int(np.count_nonzero(mask)),
+                "area_km2": candidate_area,
+                "potential_fill_volume_km3": float(np.sum(area[mask] * depth[mask]) / 1_000.0),
+                "maximum_fill_depth_m": float(np.max(depth[mask])),
+                "spill_elevation_m": float(level[spill_row]),
+                "dominant_baseline_depression_id": dominant_baseline,
+                "baseline_overlap_fraction": dominant_overlap_area / max(candidate_area, 1e-12),
+                "status": status,
+            }
+        )
+    schema = pa.schema(
+        [
+            ("depression_id", pa.int32()),
+            ("spill_cell_id", pa.int32()),
+            ("spill_receiver_id", pa.int32()),
+            ("cell_count", pa.int32()),
+            ("area_km2", pa.float64()),
+            ("potential_fill_volume_km3", pa.float64()),
+            ("maximum_fill_depth_m", pa.float64()),
+            ("spill_elevation_m", pa.float64()),
+            ("dominant_baseline_depression_id", pa.int32()),
+            ("baseline_overlap_fraction", pa.float64()),
+            ("status", pa.string()),
+        ]
+    )
+    catalog = pa.Table.from_pylist(rows, schema=schema)
+    removed_area = float(np.sum(area[(baseline_ids >= 0) & (stabilized_ids < 0)]))
+    return catalog, {
+        "new_depression_area_km2": new_area,
+        "removed_depression_area_km2": removed_area,
+        "new_depression_count": sum(row["status"] == "new" for row in rows),
+        "changed_depression_count": sum(row["status"] == "changed" for row in rows),
+        "stable_depression_count": sum(row["status"] == "stable" for row in rows),
+    }
+
+
+def _correction_catalog(cells: pa.Table) -> pa.Table:
+    changed = np.asarray(cells["receiver_changed"]) | np.asarray(cells["depression_changed"])
+    source = cells.filter(pa.array(changed, type=pa.bool_()))
+    receiver_changed = np.asarray(source["receiver_changed"])
+    depression_changed = np.asarray(source["depression_changed"])
+    reason = np.where(
+        receiver_changed & depression_changed,
+        "receiver_and_depression",
+        np.where(receiver_changed, "receiver", "depression"),
+    )
+    return pa.table(
+        {
+            "fine_cell_id": source["fine_cell_id"],
+            "parent_cell_id": source["parent_cell_id"],
+            "area_km2": source["area_km2"],
+            "baseline_receiver_id": source["baseline_receiver_id"],
+            "stabilized_receiver_id": source["stabilized_receiver_id"],
+            "baseline_depression_id": source["baseline_depression_id"],
+            "stabilized_depression_id": source["stabilized_depression_id"],
+            "correction_reason": pa.array(reason, type=pa.string()),
+        }
+    )
+
+
+def _graph_audit(
+    cells: pa.Table,
+    fixed_receivers: np.ndarray,
+    channel_rows: np.ndarray,
+    *,
+    radius_m: float,
+) -> dict[str, float | int]:
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    receivers = np.asarray(cells["stabilized_receiver_id"], dtype=np.int32)
+    baseline_receivers = np.asarray(cells["baseline_receiver_id"], dtype=np.int32)
+    baseline_depressions = np.asarray(cells["baseline_depression_id"], dtype=np.int32)
+    stabilized_depressions = np.asarray(cells["stabilized_depression_id"], dtype=np.int32)
+    contributing = np.asarray(cells["contributing_area_km2"], dtype=np.float64)
+    area = np.asarray(cells["area_km2"], dtype=np.float64)
+    source_active = np.asarray(cells["source_active"])
+    receiver_changed = (baseline_receivers != receivers) & source_active
+    depression_changed = (baseline_depressions != stabilized_depressions) & source_active
+    routed = receivers >= 0
+    target_rows = np.full(len(cells), -1, dtype=np.int64)
+    if np.any(routed):
+        target_rows[routed] = _lookup_rows(cell_ids, receivers[routed], label="stabilized receiver")
+    upstream_count = np.zeros(len(cells), dtype=np.int32)
+    np.add.at(upstream_count, target_rows[routed], 1)
+    ready = deque(np.flatnonzero(upstream_count == 0).tolist())
+    processed = 0
+    while ready:
+        row = ready.popleft()
+        processed += 1
+        target = target_rows[row]
+        if target >= 0:
+            upstream_count[target] -= 1
+            if upstream_count[target] == 0:
+                ready.append(int(target))
+    nondecreasing_error = float(
+        np.max(
+            np.maximum(contributing[routed] - contributing[target_rows[routed]], 0.0),
+            initial=0.0,
+        )
+    )
+    terminal_area = float(np.sum(contributing[~routed]))
+    active_area = float(np.sum(area[source_active]))
+    trunk_error = int(np.count_nonzero(receivers[channel_rows] != fixed_receivers[channel_rows]))
+    xyz = _fixed_list_column(cells, "xyz", 3).astype(np.float64)
+    direction = _fixed_list_column(cells, "stabilized_flow_direction_xyz", 3).astype(np.float64)
+    direction_norm = np.linalg.norm(direction[routed], axis=1)
+    tangent_error = np.abs(np.sum(direction[routed] * xyz[routed], axis=1))
+    source_xyz = xyz[routed]
+    target_xyz = xyz[target_rows[routed]]
+    length_m = np.arccos(np.clip(np.sum(source_xyz * target_xyz, axis=1), -1.0, 1.0)) * radius_m
+    hydrologic = np.asarray(cells["stabilized_hydrologic_elevation_m"], dtype=np.float64)
+    expected_slope = np.maximum(
+        (hydrologic[routed] - hydrologic[target_rows[routed]]) / length_m, 0.0
+    )
+    published_slope = np.asarray(cells["stabilized_flow_slope"], dtype=np.float64)[routed]
+    excluded = np.asarray(cells["process_excluded"])
+    process_exclusion_valid = bool(
+        np.all(receivers[excluded] == TERMINAL_HANDOFF)
+        and np.all(baseline_receivers[excluded] == TERMINAL_HANDOFF)
+        and np.all(stabilized_depressions[excluded] < 0)
+        and np.all(baseline_depressions[excluded] < 0)
+    )
+    valid_terminal = (receivers == TERMINAL_OCEAN) | (receivers == TERMINAL_HANDOFF)
+    valid_baseline_terminal = (baseline_receivers == TERMINAL_OCEAN) | (
+        baseline_receivers == TERMINAL_HANDOFF
+    )
+    invalid_terminal_count = int(
+        np.count_nonzero((receivers < 0) & ~valid_terminal)
+        + np.count_nonzero((baseline_receivers < 0) & ~valid_baseline_terminal)
+    )
+    terminal_direction_error = float(
+        np.max(np.linalg.norm(direction[~routed], axis=1), initial=0.0)
+    )
+    terminal_slope_error = float(
+        np.max(
+            np.abs(np.asarray(cells["stabilized_flow_slope"], dtype=np.float64)[~routed]),
+            initial=0.0,
+        )
+    )
+    receiver_changed_area = float(np.sum(area[receiver_changed]))
+    return {
+        "independent_graph_valid": int(processed == len(cells)),
+        "independent_processed_cell_count": processed,
+        "independent_terminal_area_km2": terminal_area,
+        "independent_active_area_km2": active_area,
+        "independent_contributing_area_residual_km2": terminal_area - active_area,
+        "maximum_downstream_contributing_area_error_km2": nondecreasing_error,
+        "trunk_receiver_mismatch_count": trunk_error,
+        "independent_process_exclusion_valid": int(process_exclusion_valid),
+        "invalid_terminal_receiver_count": invalid_terminal_count,
+        "independent_receiver_changed_cell_count": int(np.count_nonzero(receiver_changed)),
+        "independent_receiver_changed_area_km2": receiver_changed_area,
+        "independent_receiver_changed_area_fraction": receiver_changed_area
+        / max(active_area, 1e-12),
+        "independent_depression_changed_cell_count": int(np.count_nonzero(depression_changed)),
+        "maximum_flow_direction_norm_error": float(
+            np.max(np.abs(direction_norm - 1.0), initial=0.0)
+        ),
+        "maximum_flow_direction_tangent_error": float(np.max(tangent_error, initial=0.0)),
+        "maximum_flow_slope_relation_error": float(
+            np.max(np.abs(expected_slope - published_slope), initial=0.0)
+        ),
+        "maximum_terminal_flow_direction_error": terminal_direction_error,
+        "maximum_terminal_flow_slope_error": terminal_slope_error,
+    }
+
+
+def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
+    cell_record = result.artifact_records.get("StabilizedBasinCellCatalog")
+    metadata_record = result.artifact_records.get("HydrologyPass2Metadata")
+    if (
+        cell_record is None
+        or metadata_record is None
+        or not isinstance(cell_record.value, pa.Table)
+    ):
+        return None
+    cells = cell_record.value
+    metadata = metadata_record.value
+    fine_resolution = int(metadata["fine_resolution"])
+    display_resolution = min(fine_resolution, 768)
+    placements = np.array([[1, 1], [1, 3], [1, 2], [1, 0], [0, 1], [2, 1]])
+    face = np.asarray(cells["face"], dtype=np.int32)
+    row = np.asarray(cells["row"], dtype=np.int32)
+    col = np.asarray(cells["col"], dtype=np.int32)
+    elevation = np.asarray(cells["terrain_elevation_after_m"], dtype=np.float64)
+    low, high = np.percentile(elevation, [2.0, 98.0])
+    normalized = np.clip((elevation - low) / max(float(high - low), 1e-6), 0.0, 1.0)
+    colors = np.stack(
+        (48 + 150 * normalized, 73 + 138 * normalized, 49 + 105 * normalized), axis=1
+    ).astype(np.uint8)
+    image = np.full((display_resolution * 3, display_resolution * 4, 3), 18, dtype=np.uint8)
+    display_row = np.minimum(row * display_resolution // fine_resolution, display_resolution - 1)
+    display_col = np.minimum(col * display_resolution // fine_resolution, display_resolution - 1)
+    net_row = placements[face, 0] * display_resolution + display_row
+    net_col = placements[face, 1] * display_resolution + display_col
+    image[net_row, net_col] = colors
+    depression = np.asarray(cells["stabilized_depression_id"], dtype=np.int32) >= 0
+    changed = np.asarray(cells["receiver_changed"])
+    channel = np.asarray(cells["routing_anchor_kind"].to_pylist()) == "channel"
+    depression_depth = np.asarray(cells["stabilized_fill_depth_m"], dtype=np.float64)
+    if np.any(depression):
+        depression_strength = np.clip(
+            np.log1p(depression_depth[depression])
+            / max(float(np.log1p(np.max(depression_depth[depression]))), 1e-12),
+            0.10,
+            0.42,
+        )
+        base = image[net_row[depression], net_col[depression]].astype(np.float64)
+        target = np.array([47.0, 118.0, 145.0])
+        image[net_row[depression], net_col[depression]] = (
+            base * (1.0 - depression_strength[:, None]) + target * depression_strength[:, None]
+        ).astype(np.uint8)
+    image[net_row[changed], net_col[changed]] = (219, 146, 54)
+    image[net_row[channel], net_col[channel]] = (20, 169, 226)
+    rendered = Image.fromarray(image, mode="RGB")
+    draw = ImageDraw.Draw(rendered)
+    correction_count = int(metadata["receiver_changed_cell_count"])
+    draw.text((20, 20), f"Pass 2 receiver corrections: {correction_count:,}", fill=(235, 236, 231))
+    output = request.output_dir / "stabilized_drainage.png"
+    padding = max(12, display_resolution // 40)
+    left = max(0, int(np.min(net_col)) - padding)
+    upper = max(0, int(np.min(net_row)) - padding)
+    right = min(rendered.width, int(np.max(net_col)) + padding + 1)
+    lower = min(rendered.height, int(np.max(net_row)) + padding + 1)
+    rendered = rendered.crop((left, upper, right, lower))
+    scale = min(1600 / rendered.width, 1000 / rendered.height)
+    if scale > 1.0:
+        rendered = rendered.resize(
+            (max(1, round(rendered.width * scale)), max(1, round(rendered.height * scale))),
+            Image.Resampling.NEAREST,
+        )
+    rendered.save(output)
+    return VisualizationResult(
+        output,
+        "StabilizedBasinCellCatalog",
+        {
+            "receiver_changed_area_fraction": metadata["receiver_changed_area_fraction"],
+            "stabilized_depression_count": metadata["stabilized_depression_count"],
+        },
+    )
+
+
+@stage(
+    "hydrology_pass2",
+    inputs=("basin_erosion", "basin_refinement", "planet"),
+    outputs=(
+        "StabilizedBasinCellCatalog",
+        "StabilizedRiverReachCatalog",
+        "LocalDepressionCandidateCatalog",
+        "HydrologyCorrectionCatalog",
+        "HydrologyPass2Metadata",
+    ),
+    version="v1",
+    native_libraries=("hydrology_pass2_native",),
+    visualizer=_cube_net_visualizer,
+)
+def hydrology_pass2_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = HydrologyPass2Config.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("Hydrology Pass 2 requires topology: cubed_sphere")
+    erosion = deps["basin_erosion"]
+    refinement = deps["basin_refinement"]
+    erosion_metadata = erosion.artifact_records["BasinErosionMetadata"].value
+    if erosion_metadata["source_to_sink_ready"] != 1:
+        raise RuntimeError("Hydrology Pass 2 requires source-to-sink-ready erosion artifacts")
+    cells = _artifact_table(erosion, "ErodedBasinCellCatalog")
+    parents = _artifact_table(erosion, "BasinErosionParentCatalog")
+    reaches = _artifact_table(erosion, "FluvialRiverReachCatalog")
+    profiles = _artifact_table(erosion, "ChannelBedProfileCatalog")
+    memberships = _artifact_table(refinement, "RefinedReachCellCatalog")
+    cell_ids = _column(cells, "fine_cell_id", np.dtype(np.int32))
+    parent_ids = _column(cells, "parent_cell_id", np.dtype(np.int32))
+    channel_rows, fixed_receivers, routing_bed = _trunk_contract(profiles, reaches, cell_ids)
+    parent_catalog_ids = _column(parents, "parent_cell_id", np.dtype(np.int32))
+    parent_rows = _lookup_rows(parent_catalog_ids, parent_ids, label="child parent")
+    inside = np.asarray(parents["inside_selected_basin"])[parent_rows]
+    excluded = np.asarray(cells["process_excluded"])
+    source_active = np.ascontiguousarray(inside & ~excluded, dtype=np.uint8)
+    if np.any(excluded[channel_rows]):
+        raise RuntimeError("physical channel support overlaps a process-excluded child")
+    anchor_kinds = np.full(cells.num_rows, ANCHOR_NORMAL, dtype=np.uint8)
+    anchor_kinds[excluded] = ANCHOR_EXCLUDED
+    anchor_kinds[~inside] = ANCHOR_OUTSIDE
+    anchor_kinds[channel_rows] = ANCHOR_CHANNEL
+    routing_surface = _column(cells, "terrain_elevation_after_m", np.dtype(np.float64)).copy()
+    routing_surface[channel_rows] = routing_bed[channel_rows]
+    planet = deps["planet"].artifact_records["PlanetMetadata"].value
+    radius_m = float(planet["planet_radius_earth"]) * EARTH_RADIUS_M
+    controls = {
+        "fine_resolution": int(erosion_metadata["fine_resolution"]),
+        "minimum_depression_depth_m": config.minimum_depression_depth_m,
+        "planet_radius_m": radius_m,
+    }
+    with context.timed("sparse_hydrology_pass2_kernel"):
+        records, metadata = run_hydrology_pass2(
+            controls=controls,
+            cell_ids=cell_ids,
+            terrain_before_m=_column(cells, "terrain_elevation_m", np.dtype(np.float64)),
+            routing_surface_after_m=routing_surface,
+            cell_areas_km2=_column(cells, "area_km2", np.dtype(np.float64)),
+            cell_xyz=_fixed_list_column(cells, "xyz", 3),
+            anchor_kinds=anchor_kinds,
+            source_active=source_active,
+            fixed_receiver_ids=fixed_receivers,
+        )
+    stabilized_cells = _cell_table(cells, records, routing_surface)
+    stabilized_cells = stabilized_cells.append_column(
+        "source_active", pa.array(source_active != 0, type=pa.bool_())
+    )
+    depression_catalog, depression_metadata = _depression_catalog(stabilized_cells)
+    corrections = _correction_catalog(stabilized_cells)
+    graph_metadata = _graph_audit(
+        stabilized_cells, fixed_receivers, channel_rows, radius_m=radius_m
+    )
+    reach_status = np.where(
+        np.asarray(reaches["reach_kind"].to_pylist()) == "channel",
+        "physical_trunk_preserved",
+        "nonphysical_handoff_preserved",
+    )
+    stabilized_reaches = reaches.append_column(
+        "hydrology_pass2_status", pa.array(reach_status, type=pa.string())
+    )
+    stabilized_reaches = stabilized_reaches.append_column(
+        "trunk_identity_preserved",
+        pa.array(np.ones(reaches.num_rows, dtype=bool), type=pa.bool_()),
+    )
+    active_cell_count = int(np.count_nonzero(source_active))
+    receiver_change_cell_fraction = graph_metadata["independent_receiver_changed_cell_count"] / max(
+        active_cell_count, 1
+    )
+    active_area_km2 = float(graph_metadata["independent_active_area_km2"])
+    new_depression_area_fraction = float(depression_metadata["new_depression_area_km2"]) / max(
+        active_area_km2, 1e-12
+    )
+    corridor_ids = np.asarray(memberships["fine_cell_id"], dtype=np.int32)
+    new_depression_ids = set(
+        int(value)
+        for value, status in zip(
+            depression_catalog["depression_id"].to_pylist(),
+            depression_catalog["status"].to_pylist(),
+            strict=True,
+        )
+        if status == "new"
+    )
+    stabilized_depression_ids = np.asarray(
+        stabilized_cells["stabilized_depression_id"], dtype=np.int32
+    )
+    corridor_rows = _lookup_rows(cell_ids, corridor_ids, label="refined corridor")
+    new_corridor_depression_count = int(
+        np.count_nonzero(
+            np.isin(stabilized_depression_ids[corridor_rows], list(new_depression_ids))
+        )
+    )
+    additional_erosion_correction_required = new_corridor_depression_count > 0
+    metadata.update(
+        {
+            **asdict(config),
+            **depression_metadata,
+            **graph_metadata,
+            "selected_basin_id": int(erosion_metadata["selected_basin_id"]),
+            "fine_resolution": int(erosion_metadata["fine_resolution"]),
+            "receiver_change_cell_fraction": receiver_change_cell_fraction,
+            "new_depression_area_fraction": new_depression_area_fraction,
+            "new_corridor_depression_membership_count": new_corridor_depression_count,
+            "bounded_reroute_applied": int(
+                graph_metadata["independent_receiver_changed_cell_count"] > 0
+            ),
+            "additional_erosion_correction_required": int(additional_erosion_correction_required),
+            "routing_semantics": "volume_adjusted_means_with_subgrid_channel_bed_anchors",
+            "depression_semantics": "topographic_storage_candidates_not_waterbody_labels",
+            "trunk_semantics": "pass1_reach_and_connector_identities_preserved",
+        }
+    )
+    area_tolerance = 1e-8 * max(active_area_km2, 1.0)
+    if metadata["graph_valid"] != 1 or graph_metadata["independent_graph_valid"] != 1:
+        raise RuntimeError("Hydrology Pass 2 produced a cyclic or uncovered receiver graph")
+    if metadata["trunk_preserved_valid"] != 1 or graph_metadata["trunk_receiver_mismatch_count"]:
+        raise RuntimeError("Hydrology Pass 2 changed the accepted physical trunk graph")
+    if (
+        metadata["process_exclusion_valid"] != 1
+        or graph_metadata["independent_process_exclusion_valid"] != 1
+    ):
+        raise RuntimeError("Hydrology Pass 2 routed process through preserved depression support")
+    if graph_metadata["invalid_terminal_receiver_count"]:
+        raise RuntimeError("Hydrology Pass 2 emitted an invalid terminal receiver sentinel")
+    if (
+        abs(float(metadata["contributing_area_residual_km2"])) > area_tolerance
+        or abs(float(graph_metadata["independent_contributing_area_residual_km2"])) > area_tolerance
+        or float(graph_metadata["maximum_downstream_contributing_area_error_km2"]) > area_tolerance
+    ):
+        raise RuntimeError("Hydrology Pass 2 does not conserve contributing area")
+    if (
+        float(graph_metadata["maximum_flow_direction_norm_error"]) > 1e-5
+        or float(graph_metadata["maximum_flow_direction_tangent_error"]) > 1e-5
+        or float(graph_metadata["maximum_flow_slope_relation_error"]) > 1e-12
+        or float(graph_metadata["maximum_terminal_flow_direction_error"]) > 1e-12
+        or float(graph_metadata["maximum_terminal_flow_slope_error"]) > 1e-12
+    ):
+        raise RuntimeError("Hydrology Pass 2 flow vectors or slopes are inconsistent")
+    count_fields_agree = (
+        metadata["cell_count"] == cells.num_rows
+        and metadata["active_cell_count"] == active_cell_count
+        and metadata["receiver_changed_cell_count"]
+        == graph_metadata["independent_receiver_changed_cell_count"]
+        and metadata["depression_changed_cell_count"]
+        == graph_metadata["independent_depression_changed_cell_count"]
+    )
+    area_fields_agree = (
+        abs(float(metadata["active_area_km2"]) - active_area_km2) <= area_tolerance
+        and abs(
+            float(metadata["receiver_changed_area_km2"])
+            - float(graph_metadata["independent_receiver_changed_area_km2"])
+        )
+        <= area_tolerance
+    )
+    if not count_fields_agree or not area_fields_agree:
+        raise RuntimeError("Hydrology Pass 2 native and emitted correction budgets disagree")
+    if (
+        graph_metadata["independent_receiver_changed_area_fraction"]
+        > config.maximum_receiver_change_fraction
+    ):
+        raise RuntimeError("Hydrology Pass 2 receiver-change area exceeds the stability bound")
+    if receiver_change_cell_fraction > config.maximum_receiver_change_cell_fraction:
+        raise RuntimeError("Hydrology Pass 2 receiver-change count exceeds the stability bound")
+    if new_depression_area_fraction > config.maximum_new_depression_area_fraction:
+        raise RuntimeError("Hydrology Pass 2 creates excessive new depression-candidate area")
+    context.logger.log_event(
+        {"type": "hydrology_pass2_summary", "stage": "hydrology_pass2", **metadata}
+    )
+    return {
+        "StabilizedBasinCellCatalog": stabilized_cells,
+        "StabilizedRiverReachCatalog": stabilized_reaches,
+        "LocalDepressionCandidateCatalog": depression_catalog,
+        "HydrologyCorrectionCatalog": corrections,
+        "HydrologyPass2Metadata": metadata,
+    }
+
+
+__all__ = ["HydrologyPass2Config", "hydrology_pass2_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -273,6 +273,7 @@ def main(args: Iterable[str] | None = None) -> int:
             "hydrology",
             "basin_refinement",
             "basin_erosion",
+            "hydrology_pass2",
         ],
         default="topology",
     )
@@ -343,8 +344,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = "hydrology"
         elif parsed.stage == "basin_refinement":
             stage_name = "basin_refinement"
-        else:
+        elif parsed.stage == "basin_erosion":
             stage_name = "basin_erosion"
+        else:
+            stage_name = "hydrology_pass2"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -370,6 +373,7 @@ def main(args: Iterable[str] | None = None) -> int:
         "hydrology",
         "basin_refinement",
         "basin_erosion",
+        "hydrology_pass2",
     }:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":

--- a/tests/test_hydrology_pass2.py
+++ b/tests/test_hydrology_pass2.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline import _hydrology_pass2_native as native
+from map_maker.pipeline.cubed_sphere import CubedSphereGrid
+from map_maker.pipeline.stages.hydrology_pass2 import HydrologyPass2Config
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+        "hydrology",
+        "basin_refinement",
+        "basin_erosion",
+        "hydrology_pass2",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(
+    tmp_path: Path,
+    run_id: str,
+    *,
+    root: str = "primary",
+    face_resolution: int = 16,
+    rng_seed: int = 22,
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": face_resolution}],
+            "rng_seed": rng_seed,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / root / "out"),
+            "cache_dir": str(tmp_path / root / "cache"),
+            "log_dir": str(tmp_path / root / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 10,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+                "basin_refinement": {
+                    "refinement_factor": 4,
+                    "terrain_noise_fraction": 0.4,
+                },
+                "basin_erosion": {
+                    "minimum_bed_slope": 1e-5,
+                    "maximum_deposition_fraction": 0.35,
+                    "deposition_slope_scale": 0.001,
+                    "maximum_deposition_depth_m": 10.0,
+                },
+                "hydrology_pass2": {
+                    "minimum_depression_depth_m": 5.0,
+                    "maximum_receiver_change_fraction": 0.15,
+                    "maximum_receiver_change_cell_fraction": 0.15,
+                    "maximum_new_depression_area_fraction": 0.02,
+                },
+            },
+        }
+    )
+
+
+def _table(result, name: str) -> pa.Table:
+    value = result.artifact_records[name].value
+    assert isinstance(value, pa.Table)
+    return value
+
+
+def _native_fixture() -> dict[str, object]:
+    grid = CubedSphereGrid.create(4)
+    ids = np.array([row * 4 + col for row in range(3) for col in range(3)], dtype=np.int32)
+    xyz = grid.xyz.reshape(-1, 3)[ids]
+    anchors = np.zeros(9, dtype=np.uint8)
+    anchors[[1, 4, 7]] = 1
+    fixed = np.full(9, np.iinfo(np.int32).min, dtype=np.int32)
+    fixed[1] = ids[4]
+    fixed[4] = ids[7]
+    fixed[7] = -1
+    return {
+        "controls": {
+            "fine_resolution": 4,
+            "minimum_depression_depth_m": 0.5,
+            "planet_radius_m": 6_371_000.0,
+        },
+        "cell_ids": ids,
+        "terrain_before_m": np.array([6, 5, 6, 0, 4, 5, 6, 3, 6], dtype=np.float64),
+        "routing_surface_after_m": np.array([6, 5, 6, 0, -5, 5, 6, -10, 6], dtype=np.float64),
+        "cell_areas_km2": np.ones(9, dtype=np.float64),
+        "cell_xyz": xyz,
+        "anchor_kinds": anchors,
+        "source_active": np.ones(9, dtype=np.uint8),
+        "fixed_receiver_ids": fixed,
+    }
+
+
+def test_native_pass2_preserves_trunk_and_conserves_area_across_cffi():
+    records, metadata = native.run_hydrology_pass2(**_native_fixture())
+
+    assert metadata["graph_valid"] == 1
+    assert metadata["trunk_preserved_valid"] == 1
+    assert metadata["physical_trunk_edge_count"] == 2
+    assert metadata["baseline_depression_count"] == 1
+    assert metadata["stabilized_depression_count"] == 0
+    assert metadata["terminal_accumulated_area_km2"] == pytest.approx(9.0)
+    assert metadata["contributing_area_residual_km2"] == pytest.approx(0.0, abs=1e-12)
+    by_id = {int(record["fine_cell_id"]): record for record in records}
+    fixture = _native_fixture()
+    ids = fixture["cell_ids"]
+    assert by_id[int(ids[1])]["stabilized_receiver_id"] == ids[4]
+    assert by_id[int(ids[4])]["stabilized_receiver_id"] == ids[7]
+    assert by_id[int(ids[7])]["stabilized_receiver_id"] == -1
+    assert by_id[int(ids[3])]["baseline_fill_depth_m"] == pytest.approx(4.0)
+    assert by_id[int(ids[3])]["stabilized_fill_depth_m"] == pytest.approx(0.0)
+    assert by_id[int(ids[3])]["depression_changed"] == 1
+
+
+def test_native_record_layout_round_trips_sentinel_values():
+    record = native._ffi.new("StabilizedCellRecord*")
+    record.fine_cell_id = 17
+    record.stabilized_receiver_id = 23
+    record.stabilized_hydrologic_elevation_m = 1000.00004
+    record.contributing_area_km2 = 1234.5
+    view = native._ffi.buffer(record, native._ffi.sizeof("StabilizedCellRecord"))
+    parsed = np.frombuffer(view, dtype=native.STABILIZED_CELL_DTYPE, count=1)[0]
+
+    assert parsed["fine_cell_id"] == 17
+    assert parsed["stabilized_receiver_id"] == 23
+    assert parsed["stabilized_hydrologic_elevation_m"] == pytest.approx(
+        1000.00004, rel=0.0, abs=1e-12
+    )
+    assert parsed["contributing_area_km2"] == 1234.5
+
+
+def test_native_pass2_rejects_nonadjacent_fixed_trunk_edge():
+    fixture = _native_fixture()
+    fixture["fixed_receiver_ids"] = fixture["fixed_receiver_ids"].copy()
+    fixture["fixed_receiver_ids"][1] = fixture["cell_ids"][8]
+
+    with pytest.raises(RuntimeError, match="invalid anchor or fixed trunk receiver"):
+        native.run_hydrology_pass2(**fixture)
+
+
+def test_hydrology_pass2_stabilizes_real_connector_basin(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "pass2"), generate_visuals=True)
+    results = engine.run(["basin_erosion", "hydrology_pass2"])
+    erosion = results["basin_erosion"]
+    result = results["hydrology_pass2"]
+    metadata = result.artifact_records["HydrologyPass2Metadata"].value
+    cells = _table(result, "StabilizedBasinCellCatalog")
+    reaches = _table(result, "StabilizedRiverReachCatalog")
+    depressions = _table(result, "LocalDepressionCandidateCatalog")
+    corrections = _table(result, "HydrologyCorrectionCatalog")
+    profiles = _table(erosion, "ChannelBedProfileCatalog")
+
+    assert metadata["graph_valid"] == 1
+    assert metadata["independent_graph_valid"] == 1
+    assert metadata["trunk_preserved_valid"] == 1
+    assert metadata["process_exclusion_valid"] == 1
+    assert metadata["independent_process_exclusion_valid"] == 1
+    assert metadata["invalid_terminal_receiver_count"] == 0
+    assert metadata["trunk_receiver_mismatch_count"] == 0
+    assert metadata["baseline_uncovered_cell_count"] == 0
+    assert metadata["stabilized_uncovered_cell_count"] == 0
+    assert abs(metadata["independent_contributing_area_residual_km2"]) < 1e-8
+    assert metadata["receiver_changed_area_fraction"] <= 0.15
+    assert metadata["independent_receiver_changed_area_fraction"] <= 0.15
+    assert (
+        metadata["receiver_changed_cell_count"]
+        == metadata["independent_receiver_changed_cell_count"]
+    )
+    assert metadata["receiver_changed_area_km2"] == pytest.approx(
+        metadata["independent_receiver_changed_area_km2"]
+    )
+    assert metadata["new_depression_area_fraction"] <= 0.02
+    assert cells.num_rows == metadata["cell_count"]
+    assert reaches.num_rows > 0
+
+    changed = np.asarray(cells["receiver_changed"]) | np.asarray(cells["depression_changed"])
+    assert corrections.num_rows == np.count_nonzero(changed)
+    excluded = np.asarray(cells["process_excluded"])
+    assert np.any(excluded)
+    assert np.all(np.asarray(cells["stabilized_depression_id"])[excluded] < 0)
+    assert np.all(np.asarray(cells["stabilized_receiver_id"])[excluded] == -2)
+
+    channel_ids = np.unique(np.asarray(profiles["fine_cell_id"], dtype=np.int32))
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    cell_order = np.argsort(cell_ids)
+    channel_rows = cell_order[np.searchsorted(cell_ids[cell_order], channel_ids)]
+    assert np.all(np.asarray(cells["routing_anchor_kind"])[channel_rows] == "channel")
+    assert not np.any(excluded[channel_rows])
+    expected_beds = np.array(
+        [
+            np.asarray(profiles["bed_elevation_m"])[
+                np.asarray(profiles["fine_cell_id"]) == cell_id
+            ][0]
+            for cell_id in channel_ids
+        ]
+    )
+    assert np.allclose(
+        np.asarray(cells["routing_surface_after_m"])[channel_rows],
+        expected_beds,
+        rtol=0.0,
+        atol=1e-12,
+    )
+    if depressions.num_rows:
+        assert np.all(np.asarray(depressions["area_km2"]) > 0.0)
+        assert np.all(np.asarray(depressions["potential_fill_volume_km3"]) > 0.0)
+    visual = engine.context.config.run_visual_dir() / "hydrology_pass2"
+    assert (visual / "stabilized_drainage.png").is_file()
+
+
+def test_hydrology_pass2_is_independently_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "first", root="first")).run(["hydrology_pass2"])[
+        "hydrology_pass2"
+    ]
+    second = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["hydrology_pass2"])[
+        "hydrology_pass2"
+    ]
+    for artifact in (
+        "StabilizedBasinCellCatalog",
+        "StabilizedRiverReachCatalog",
+        "LocalDepressionCandidateCatalog",
+        "HydrologyCorrectionCatalog",
+    ):
+        assert _table(first, artifact).equals(_table(second, artifact))
+    assert (
+        first.artifact_records["HydrologyPass2Metadata"].value
+        == second.artifact_records["HydrologyPass2Metadata"].value
+    )
+
+    cached = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["hydrology_pass2"])[
+        "hydrology_pass2"
+    ]
+    assert cached.stats is not None and cached.stats.cache_hit
+
+
+def test_stage_rejects_corrupted_native_trunk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = importlib.import_module("map_maker.pipeline.stages.hydrology_pass2")
+    native_run = module.run_hydrology_pass2
+
+    def corrupted_native_run(**kwargs):
+        records, metadata = native_run(**kwargs)
+        records = records.copy()
+        channel = np.flatnonzero(records["anchor_kind"] == 1)
+        records["stabilized_receiver_id"][channel[0]] = -2
+        return records, metadata
+
+    monkeypatch.setattr(module, "run_hydrology_pass2", corrupted_native_run)
+    with pytest.raises(RuntimeError, match="changed the accepted physical trunk"):
+        ExecutionEngine(_config(tmp_path, "corrupt")).run(["hydrology_pass2"])
+
+
+def test_stage_rejects_corrupted_native_correction_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = importlib.import_module("map_maker.pipeline.stages.hydrology_pass2")
+    native_run = module.run_hydrology_pass2
+
+    def corrupted_native_run(**kwargs):
+        records, metadata = native_run(**kwargs)
+        metadata = {
+            **metadata,
+            "receiver_changed_cell_count": metadata["receiver_changed_cell_count"] + 1,
+        }
+        return records, metadata
+
+    monkeypatch.setattr(module, "run_hydrology_pass2", corrupted_native_run)
+    with pytest.raises(RuntimeError, match="correction budgets disagree"):
+        ExecutionEngine(_config(tmp_path, "corrupt-budget")).run(["hydrology_pass2"])
+
+
+def test_hydrology_pass2_config_rejects_unknown_and_invalid_controls():
+    with pytest.raises(ValueError, match="Unknown Hydrology Pass 2 controls"):
+        HydrologyPass2Config.from_mapping({"magic": 1})
+    with pytest.raises(ValueError, match="minimum_depression_depth_m"):
+        HydrologyPass2Config.from_mapping({"minimum_depression_depth_m": -1.0})
+    with pytest.raises(ValueError, match="maximum_receiver_change_fraction"):
+        HydrologyPass2Config.from_mapping({"maximum_receiver_change_fraction": 1.1})

--- a/tests/test_native_loader.py
+++ b/tests/test_native_loader.py
@@ -54,3 +54,6 @@ def test_built_library_exposes_expected_abi_and_fingerprint() -> None:
 
     fluvial = native_library_info("fluvial_native")
     assert fluvial["abi_version"] == 3
+
+    hydrology_pass2 = native_library_info("hydrology_pass2_native")
+    assert hydrology_pass2["abi_version"] == 1

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -57,6 +57,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
         "fluvial_native",
         "geology_native",
         "hydrology_native",
+        "hydrology_pass2_native",
         "planet_native",
         "refinement_native",
         "tectonics_native",


### PR DESCRIPTION
## Summary

- add a Rust-backed sparse Hydrology Pass 2 over the complete selected face-2048 basin
- preserve the accepted physical trunk while rerouting ordinary refined cells on the post-erosion dual surface
- persist stabilized cells, reaches, depression candidates, corrections, metadata, and a cube-net diagnostic
- enforce independent graph, area, terminal, exclusion, vector, and correction-budget audits
- document Decision 026, the stage contract, provisional guards, canonical metrics, and current scientific limits

## Canonical result

The uncached canonical run processed 370,944 sparse cells in about 5.7 seconds. It preserved all 2,421 physical trunk edges, changed 2,870 receivers (0.849% of active cells; 0.847% of active area), created zero wholly new depression components, and required no additional corridor erosion correction. The 8,944 storage candidates are explicitly topographic candidates, not lake labels.

A corrected cell-level audit records 37.14 km2 of newly affected candidate support within changed components (0.000583% of active basin area).

## Validation

- `uv run map-maker-pipeline --stage hydrology_pass2 --config configs/cubed_sphere_crust_state.yaml`
- `pytest -q` (116 passed)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `ruff check src tests`
- `black --check` on changed Python files
- `cargo fmt --all -- --check`
- `map-maker doctor`
- `uv build -q`
- `git diff --check`

## Known limitation

A preliminary small-grid sweep obtained 12 Pass-2 results, but 23 of 35 attempted seeds failed the pre-existing basin-refinement routing gate before Pass 2 ran. That upstream reliability defect remains separate work.