### PR TITLE
Add refined seasonal surface-water balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "surface_water_native"
+version = "0.1.0"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "src/map_maker/pipeline/native/hydrology_pass2",
     "src/map_maker/pipeline/native/planet",
     "src/map_maker/pipeline/native/refinement",
+    "src/map_maker/pipeline/native/surface_water",
     "src/map_maker/pipeline/native/tectonics",
     "src/map_maker/pipeline/native/topology",
     "src/map_maker/pipeline/native/world_age",

--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -89,3 +89,21 @@ stage_overrides:
     maximum_receiver_change_fraction: 0.15
     maximum_receiver_change_cell_fraction: 0.15
     maximum_new_depression_area_fraction: 0.02
+  surface_water:
+    minimum_solver_iterations: 8
+    maximum_solver_iterations: 64
+    transient_max_months: 3
+    permanent_min_months: 12
+    convergence_tolerance_fraction: 0.000001
+    open_water_evaporation_factor: 1.15
+    seepage_mm_year: 30.0
+    subgrid_relief_scale: 1.0
+    minimum_subgrid_relief_m: 10.0
+    maximum_connected_inundation_fraction: 0.25
+    minimum_wet_area_fraction: 0.01
+    wetland_max_mean_depth_m: 3.0
+    outlet_erosion_score_threshold: 0.30
+    outlet_erosion_depth_scale_m: 200.0
+    minimum_outlet_erosion_discharge_m3s: 0.10
+    maximum_water_balance_relative_error: 0.000000001
+    maximum_area_reconstruction_relative_error: 0.000001

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1366,6 +1366,9 @@ Depression contract:
 - Connected cells deeper than the configured minimum become local depression
   candidates with deterministic IDs, area, potential storage, spill cell, and
   before/after status.
+- On a flat priority-fill component, the persisted spill is the component's
+  final downstream exit in the accepted receiver DAG. This prevents arbitrary
+  equal-level tree tie-breaking from creating self-edges or candidate cycles.
 - A candidate is not automatically a permanent lake or wetland. Water balance,
   hydroperiod, soils, and vegetation determine those later.
 - Inherited preserved lakes and depressions are audited as excluded handoffs,
@@ -1385,3 +1388,65 @@ Failure conditions:
 - Receiver-change area or count above the configured stability bounds.
 - Process routing through a preserved-depression interior.
 - Treating every priority-fill candidate as standing surface water.
+
+## Decision 027: Refined Seasonal Surface-Water Balance
+
+Status: implemented, provisional
+
+Decision:
+New local depression candidates from Hydrology Pass 2 receive a deterministic
+monthly storage balance before any lake or wetland label is accepted. The
+balance runs only on resolved ordinary child cells. Inherited coarse lakes and
+preserved depressions remain excluded handoffs until their bathymetry is
+refined explicitly.
+
+Catchment contract:
+- Parent monthly runoff and evaporation depths are copied to refined children;
+  physical child areas therefore conserve each represented parent's water
+  volume without inventing unsupported fine-scale climate.
+- Every active source child belongs to its first downstream local candidate, if
+  one exists. Direct candidate catchments are disjoint.
+- Candidate spill receivers define an acyclic upstream-to-downstream candidate
+  graph. Monthly overflow is transferred through that graph once; it is not
+  counted as new runoff at the downstream candidate.
+- Candidate-network direct inflow equals evaporation, seepage, terminal
+  overflow, and storage change within floating-point tolerance.
+
+Fractional-water contract:
+- A refined child is still a container, not an atomic water label.
+- Parent relief is scaled to unresolved child relief. A uniform subcell
+  elevation distribution provides deterministic area and volume curves between
+  the local bottom and the Pass-2 spill elevation.
+- Because these candidates were unresolved at the parent scale, a configured
+  connected-basin fraction caps how much low subcell terrain may belong to one
+  local waterbody. Inherited resolved lakes are outside this pass.
+- The monthly balance publishes storage, water area, overflow, evaporation,
+  seepage, and fractional inundation for every participating candidate and
+  child.
+
+Classification contract:
+- `dry_depression`: no material surface-water month.
+- `transient_storage`: short-hydroperiod inundation, or a filled local candidate
+  whose sustained overflow requires outlet-incision feedback before standing
+  water can be accepted.
+- `seasonal_lake`: deeper material inundation that is not present year-round.
+- `permanent_lake`: material water area in every climatological month and mean
+  depth above the wetland threshold.
+- `hydrologic_wetland`: recurrent material inundation whose annual wetted mean
+  depth remains below the wetland threshold.
+- A hydrologic wetland is a surface-water and hydroperiod result, not a final
+  ecological biome. Soil saturation, vegetation, and groundwater may revise it
+  later.
+- Sustained overflow, available head, weak rock, and low sediment accommodation
+  produce an explicit outlet-erosion score. The pre-incision monthly state is
+  retained for conservation auditing, while the accepted class is transient
+  until a later bounded incision/reroute pass resolves the outlet.
+
+Failure conditions:
+- A cyclic candidate graph, overlapping direct catchments, unknown receiver or
+  candidate identity, or process-excluded candidate support.
+- Fractional inundation outside `[0, 1]`, storage above candidate capacity, or a
+  non-finite monthly state.
+- Candidate-network water imbalance above the configured tolerance.
+- Treating provisional land evaporation as calibrated open-water potential
+  evaporation.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -298,6 +298,42 @@ attempted seeds failed the existing refinement routing gate before Pass 2
 executed. That high upstream rejection rate remains a separate refinement
 defect and is not counted as Hydrology Pass-2 instability.
 
+## Refined Seasonal Surface Water
+
+The canonical surface-water pass consumes all 8,944 Pass-2 candidates and
+77,525 candidate-support children. It assigns 320,751 active source children to
+disjoint first-downstream-candidate catchments and solves the periodic monthly
+state of the acyclic candidate graph upstream-to-downstream.
+
+| Metric | Canonical result |
+| --- | ---: |
+| Represented parent runoff volume | `346.298 km3/year` |
+| Candidate-network direct inflow | `281.000 km3/year` |
+| Parent-to-child runoff inheritance error | `0` |
+| Maximum fixed-point iterations | `19` |
+| Potential connected water area at all spills | `365,195 km2` |
+| Pre-adjustment permanent-lake candidates | `8,936` |
+| Outlet-erosion feedback candidates | `3,125` |
+| Pre-incision transient-storage area | `242,636 km2` |
+| Accepted permanent-lake candidates | `5,811` |
+| Hydrologic-wetland candidates | `8` |
+| Accepted standing-water mean area | `120,063 km2` (`1.885%`) |
+| Independent annual water-balance error | `2.49e-15` |
+| Maximum cell-to-candidate area reconstruction error | `5.77e-8` relative |
+
+The first unconstrained audit classified nearly every local candidate as a
+permanent lake and produced about 909,000 km2 of mean water area. That failed
+the realism review. Two structural corrections were made rather than loosening
+a validation bound: local subcell low terrain now has a connected-basin cap,
+and sustained overflow produces explicit outlet-erosion feedback based on head,
+rock strength, sediment accommodation, and discharge.
+
+The 242,636 km2 transient figure is the conservative pre-incision fill/spill
+state, not accepted standing water. `surface_water_ready_for_soils` remains
+false until a bounded outlet-incision and local reroute pass consumes all 3,125
+feedback records. The current class and area distribution is provisional; it
+has not passed a multi-seed Earth-derived lake and wetland calibration.
+
 ## Calibration Rule
 
 Do not tighten or loosen a threshold solely to make the current gallery pass.

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -40,20 +40,24 @@
     - The sparse selected-basin pass uses volume-adjusted terrain means and
       subgrid channel beds, preserves inherited trunk/connector identities,
       applies one bounded local reroute, and publishes depression candidates.
-11. Soils and biomes.
-12. Mineral and energy systems.
-13. Selected-region refinement and map export.
+11. Refined seasonal surface-water balance.
+    - Local candidates receive monthly catchment inflow, fractional inundation,
+      fill/spill propagation, and provisional lake or hydrologic-wetland classes.
+12. Soils and biomes.
+13. Mineral and energy systems.
+14. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches the bounded sparse
-selected-basin Hydrology Pass 2 after erosion and sedimentation, with a
-causal, pre-erosion bedrock surface and separate crustal, orogenic, basin, and
-relief-prior artifacts, persisted monthly orbital forcing, and a first seasonal
-climate/orography pass. Bed-profile and sediment budgets are conservative but
-remain uncalibrated. Pass 2 now audits their local routing consequences without
-replacing the accepted coarse trunk graph. The older
-rectangular compatibility path runs directly from world age into provisional
-erosion and final rendering; it is reference behavior, not the canonical stage
-order.
+The current canonical cubed-sphere implementation reaches the refined seasonal
+surface-water balance after erosion, sedimentation, and bounded Hydrology Pass
+2. It includes a causal, pre-erosion bedrock surface; separate crustal,
+orogenic, basin, and relief-prior artifacts; persisted monthly orbital forcing;
+and a first seasonal climate/orography pass. Bed-profile and sediment budgets
+are conservative but remain uncalibrated. Pass 2 audits their local routing
+consequences without replacing the accepted coarse trunk graph; the
+surface-water stage then solves periodic monthly storage and publishes explicit
+outlet-erosion feedback. The older rectangular compatibility path runs directly
+from world age into provisional erosion and final rendering; it is reference
+behavior, not the canonical stage order.
 
 Legacy pipeline remains callable through `map_maker.legacy.*` but does not participate in this DAG.
 

--- a/docs/specs/06_erosion.md
+++ b/docs/specs/06_erosion.md
@@ -128,7 +128,8 @@ eroded historical volume.
 - Sediment provenance, lithology, suspended/bed-load partition, transport time,
   avulsion, meander migration, deltas, shelves, and compaction are absent.
 - The sparse Hydrology Pass 2 consumes the altered terrain distribution and
-  solved channel beds; global refined hydrology and monthly local lake balance
-  remain future work.
+  solved channel beds, and the surface-water stage now solves monthly local
+  balance. Global refined hydrology and the requested local outlet-incision
+  feedback remain future work.
 - Repeated geological-time erosion, uplift, sediment loading, flexure, and
   isostatic response remain future passes.

--- a/docs/specs/08_climate_hydrology.md
+++ b/docs/specs/08_climate_hydrology.md
@@ -248,8 +248,9 @@ conservation error, and artifact semantics.
   by coarse reach attributes.
 - Breach erosion is a basin-scale coarse incision event. The sparse selected-basin
   erosion and Hydrology Pass 2 now stabilize one refined basin, but detailed
-  gorge evolution, global sediment feedback, and monthly local lake balance
-  remain future work.
+  gorge evolution and global sediment feedback remain future work. The refined
+  surface-water stage now solves monthly local lake balance, but its requested
+  outlet incisions have not yet been applied to terrain or routing.
 - Current statistical thresholds are provisional. Multi-seed conditional
   validation against basin, lake, and river distributions is required before the
   Earth-like default is considered calibrated.

--- a/docs/specs/08c_hydrology_pass2.md
+++ b/docs/specs/08c_hydrology_pass2.md
@@ -74,7 +74,9 @@ seasonal, wetland, or no surface water.
 ## Current Limits
 
 - D4 routing is retained to match the accepted topology contract.
-- Local depression candidates do not yet run monthly lake water balance.
+- The downstream surface-water stage now runs monthly balance for local
+  depression candidates. Outlet-incision feedback from that balance still
+  requires another bounded terrain and routing correction.
 - Preserved coarse waterbodies still require bathymetric refinement before their
   inlet, lake-crossing, and outlet geometry becomes physical.
 - The pass stabilizes one selected basin, not the entire planet at refined

--- a/docs/specs/08d_surface_water_balance.md
+++ b/docs/specs/08d_surface_water_balance.md
@@ -1,0 +1,118 @@
+# Refined Seasonal Surface-Water Balance
+
+## Status
+
+Implemented provisional stage following Hydrology Pass 2.
+
+## Objective
+
+Convert resolved local topographic storage candidates into seasonal
+surface-water states. The stage answers whether a candidate is dry, transient,
+seasonal, permanently inundated, or hydrologically wetland-like while retaining
+fractional cell coverage and a complete monthly water budget.
+
+It does not re-route terrain, alter the accepted river trunk, regenerate
+inherited coarse waterbodies, or claim ecological wetland certainty.
+
+## Inputs
+
+- `hydrology_pass2`: stabilized receiver DAG, local candidate membership,
+  spill elevations, child areas, terrain, and unresolved parent relief.
+- `climate`: monthly runoff potential and provisional evaporation.
+- `geology`: sediment accommodation used to modulate seepage.
+- `basin_refinement`: refinement factor and represented-parent contract.
+
+Monthly parent climate depths are inherited by every child. Multiplication by
+conserved child area preserves represented parent volume exactly.
+
+## Catchments And Candidate Graph
+
+The stabilized cell graph is traversed downstream-to-upstream. A source belongs
+to the first local candidate encountered on its downstream path. This produces
+disjoint direct catchments and excludes water that never encounters a local
+candidate.
+
+Each candidate's spill receiver is followed to the next downstream candidate.
+The resulting candidate DAG is processed upstream-to-downstream each month so
+overflow can fill, spill, or seasonally sustain a downstream system.
+
+## Subcell Hypsometry
+
+Candidate cells use the Pass-2 spill elevation as their maximum water surface.
+Parent relief is reduced by the square root of the refinement factor to retain
+unresolved child-scale relief. A bounded uniform subcell elevation distribution
+then supplies area and volume as functions of water level. A connected-basin
+fraction caps the low subcell area assigned to one unresolved local waterbody;
+the cap does not apply to inherited large lakes, which this stage excludes.
+
+The native kernel precomputes a monotone hypsometric lookup for every candidate.
+Monthly storage is inverted through that curve, producing water level, area,
+depth, and per-cell inundation fractions without turning a five-kilometre child
+into an all-water pixel.
+
+## Monthly Balance
+
+For every climatological month:
+
+1. Add direct catchment runoff and upstream candidate overflow.
+2. Estimate open-water evaporation and geology-modulated seepage over the
+   current inundated area.
+3. Apply losses no greater than available storage.
+4. Retain water up to spill capacity and route excess downstream.
+5. Persist end-of-month storage, area, losses, overflow, and cell fractions.
+
+Because the candidate graph is acyclic, each candidate's climatological annual
+cycle is solved upstream-to-downstream as a bounded periodic-storage fixed
+point. This removes arbitrary transient spin-up years while retaining a strict
+year-boundary convergence check against candidate capacity.
+
+## Outlet-Erosion Feedback
+
+The first monthly solve retains the Pass-2 sill. Candidates with sustained
+overflow are then scored from available head, rock weakness, low sediment
+accommodation, and overflow discharge. A lake-like candidate above the
+configured score and discharge thresholds is published as `transient_storage`
+with a recommended outlet incision. Its monthly fields remain the conservative
+pre-incision fill/spill state; they are not accepted standing-water coverage.
+
+This stage does not silently alter terrain or reroute the accepted graph. A
+future bounded outlet-incision pass consumes the feedback and reruns local
+stabilization.
+
+## Persistent Outputs
+
+- `SurfaceWaterCandidateCatalog`: one row per Pass-2 candidate, pre-adjustment
+  and accepted class, outlet-erosion feedback,
+  catchment, capacity, hydroperiod, annual budget, convergence, and monthly
+  fixed-size-list fields.
+- `SeasonalSurfaceWaterCellCatalog`: one row per candidate child with potential,
+  minimum, mean, maximum, and twelve monthly inundation fractions.
+- `SurfaceWaterMonthlyStateCatalog`: normalized candidate-month rows for direct
+  inspection and surrogate training.
+- `SurfaceWaterMetadata`: class counts and areas, topology, convergence,
+  fractional bounds, climate inheritance, and conservation diagnostics.
+
+## Hard Gates
+
+- Candidate and receiver identities are valid and both cell and candidate
+  graphs are acyclic.
+- Direct catchments are disjoint and include only active source area.
+- Every monthly fraction is finite and in `[0, 1]`; storage is finite and inside
+  candidate capacity.
+- Parent-to-child climate inheritance conserves represented runoff volume.
+- Final-year direct inflow equals evaporation plus seepage plus terminal
+  overflow plus storage change within configured tolerance.
+- Repeated inputs produce byte-identical catalogs and cache keys.
+
+## Current Limits
+
+- Monthly runoff and evaporation are inherited from the coarse parent without
+  local storm, aspect, groundwater, or rain-shadow downscaling.
+- Climate evaporation remains a provisional proxy for open-water potential
+  evaporation and is exposed through a configurable multiplier.
+- Uniform subcell relief is a structural approximation, not surveyed
+  bathymetry.
+- Seepage uses sediment accommodation; explicit soil permeability and aquifers
+  do not yet exist.
+- Hydrologic wetland output is an input to future soils and biomes, not their
+  final classification.

--- a/docs/specs/09_soils_biomes.md
+++ b/docs/specs/09_soils_biomes.md
@@ -1,11 +1,20 @@
-# Stage 8 – Soil Formation & Biome Classification
+# Soil Formation And Biome Classification
+
+## Status
+
+Planned. Execution is blocked while `surface_water_ready_for_soils` is false.
 
 ## Objectives
 - Translate geology + climate into soil properties.
 - Classify land cover/biomes and agricultural suitability.
 
 ## Inputs
-- `Elevation`, `TemperatureMean`, `TemperatureSeasonal`, `PrecipitationMean`, `PrecipitationSeasonal`, `CatchmentMetadata`, `SedimentDepth`.
+- Accepted post-incision terrain and drainage, seasonal temperature and
+  precipitation, sediment depth and lithology, river corridor fractions, and
+  accepted `SurfaceWaterCandidateCatalog` and
+  `SeasonalSurfaceWaterCellCatalog` records.
+- Hydrologic wetlands are evidence for soil and vegetation processes, not final
+  ecological wetland labels.
 - Config:
   - Soil: `weathering_rate`, `organic_input`, `soil_texture_map`, `tile_size`.
   - Biome: `classification_table`, `snowline`, `aridity_thresholds`, `gpu_backend` (optional for large grids).
@@ -43,6 +52,7 @@
 - Tile throughput metrics to diagnose hotspots.
 
 ## Testing
+- Refuse to execute while upstream surface-water outlet corrections are pending.
 - Soil depth non-negative, fertility bounded [0,1].
 - Floodplain/delta enrichment increases fertility near major rivers while conserving total sediment; swamp deltas reduce suitability as expected.
 - Biome classification matches reference cases (e.g., desert climate).

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,10 @@ parameters remain provisional. The bounded sparse Hydrology Pass 2 now consumes
 the volume-adjusted cell means and float64 channel beds, preserves the accepted
 trunk and connector identities, reroutes local child drainage, and persists
 before/after depression candidates without labeling them all as lakes. The
-current output is a functional prototype rather than an atlas-grade world.
+refined seasonal surface-water stage now conserves inherited monthly runoff,
+solves fractional fill/spill states, and separates accepted standing water from
+systems requiring another outlet-incision pass. The current output is a
+functional prototype rather than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
 
@@ -159,6 +162,9 @@ uv run map-maker-pipeline --stage basin_erosion --config configs/cubed_sphere_cr
 
 # Bounded local rerouting and depression stability after erosion
 uv run map-maker-pipeline --stage hydrology_pass2 --config configs/cubed_sphere_crust_state.yaml
+
+# Monthly fractional lakes, wetlands, transient storage, and outlet feedback
+uv run map-maker-pipeline --stage surface_water --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/_native.py
+++ b/src/map_maker/_native.py
@@ -14,6 +14,7 @@ NATIVE_ABI_OVERRIDES = {
     "fluvial_native": 3,
     "hydrology_pass2_native": 1,
     "refinement_native": 3,
+    "surface_water_native": 2,
 }
 SIMULATION_NATIVE_LIBRARIES = (
     "climate_native",
@@ -25,6 +26,7 @@ SIMULATION_NATIVE_LIBRARIES = (
     "hydrology_pass2_native",
     "planet_native",
     "refinement_native",
+    "surface_water_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/native_build.py
+++ b/src/map_maker/native_build.py
@@ -18,6 +18,7 @@ NATIVE_LIBRARIES = (
     "hydrology_pass2_native",
     "planet_native",
     "refinement_native",
+    "surface_water_native",
     "tectonics_native",
     "topology_native",
     "world_age_native",

--- a/src/map_maker/pipeline/_surface_water_native.py
+++ b/src/map_maker/pipeline/_surface_water_native.py
@@ -1,0 +1,461 @@
+"""Rust-backed refined seasonal surface-water balance bindings."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import numpy as np
+from cffi import FFI
+
+from .._native import native_library_info, native_library_path
+
+MONTHS = 12
+
+SURFACE_WATER_CLASSES = {
+    0: "dry_depression",
+    1: "transient_storage",
+    2: "seasonal_lake",
+    3: "permanent_lake",
+    4: "hydrologic_wetland",
+}
+
+CANDIDATE_DTYPE = np.dtype(
+    [
+        ("depression_id", "=i4"),
+        ("downstream_depression_id", "=i4"),
+        ("class_code", "=i4"),
+        ("cell_count", "=i4"),
+        ("catchment_cell_count", "=i4"),
+        ("wet_month_count", "=i4"),
+        ("solver_iterations", "=i4"),
+        ("converged", "=i4"),
+        ("open_outlet", "=i4"),
+        ("catchment_area_km2", "=f8"),
+        ("potential_water_area_km2", "=f8"),
+        ("storage_capacity_km3", "=f8"),
+        ("annual_direct_inflow_km3", "=f8"),
+        ("annual_upstream_inflow_km3", "=f8"),
+        ("annual_total_inflow_km3", "=f8"),
+        ("annual_evaporation_km3", "=f8"),
+        ("annual_seepage_km3", "=f8"),
+        ("annual_overflow_km3", "=f8"),
+        ("annual_terminal_overflow_km3", "=f8"),
+        ("annual_storage_change_km3", "=f8"),
+        ("water_balance_residual_km3", "=f8"),
+        ("hydroperiod_fraction", "=f8"),
+        ("minimum_water_area_km2", "=f8"),
+        ("mean_water_area_km2", "=f8"),
+        ("maximum_water_area_km2", "=f8"),
+        ("mean_wetted_depth_m", "=f8"),
+        ("maximum_mean_depth_m", "=f8"),
+        ("salinity_index", "=f8"),
+        ("monthly_direct_inflow_km3", "=f8", (MONTHS,)),
+        ("monthly_upstream_inflow_km3", "=f8", (MONTHS,)),
+        ("monthly_total_inflow_km3", "=f8", (MONTHS,)),
+        ("monthly_evaporation_km3", "=f8", (MONTHS,)),
+        ("monthly_seepage_km3", "=f8", (MONTHS,)),
+        ("monthly_overflow_km3", "=f8", (MONTHS,)),
+        ("monthly_storage_km3", "=f8", (MONTHS,)),
+        ("monthly_water_area_km2", "=f8", (MONTHS,)),
+    ],
+    align=True,
+)
+
+CELL_DTYPE = np.dtype(
+    [
+        ("fine_cell_id", "=i4"),
+        ("depression_id", "=i4"),
+        ("class_code", "=i4"),
+        ("potential_inundation_fraction", "=f4"),
+        ("minimum_inundation_fraction", "=f4"),
+        ("mean_inundation_fraction", "=f4"),
+        ("maximum_inundation_fraction", "=f4"),
+        ("monthly_inundation_fraction", "=f4", (MONTHS,)),
+    ],
+    align=True,
+)
+
+_CDEF = """
+typedef struct {
+    int32_t refinement_factor;
+    int32_t minimum_solver_iterations;
+    int32_t maximum_solver_iterations;
+    int32_t transient_max_months;
+    int32_t permanent_min_months;
+    double convergence_tolerance_fraction;
+    double open_water_evaporation_factor;
+    double seepage_mm_year;
+    double subgrid_relief_scale;
+    double minimum_subgrid_relief_m;
+    double maximum_connected_inundation_fraction;
+    double minimum_wet_area_fraction;
+    double wetland_max_mean_depth_m;
+} SurfaceWaterConfig;
+
+typedef struct {
+    int32_t depression_id;
+    int32_t downstream_depression_id;
+    int32_t class_code;
+    int32_t cell_count;
+    int32_t catchment_cell_count;
+    int32_t wet_month_count;
+    int32_t solver_iterations;
+    int32_t converged;
+    int32_t open_outlet;
+    double catchment_area_km2;
+    double potential_water_area_km2;
+    double storage_capacity_km3;
+    double annual_direct_inflow_km3;
+    double annual_upstream_inflow_km3;
+    double annual_total_inflow_km3;
+    double annual_evaporation_km3;
+    double annual_seepage_km3;
+    double annual_overflow_km3;
+    double annual_terminal_overflow_km3;
+    double annual_storage_change_km3;
+    double water_balance_residual_km3;
+    double hydroperiod_fraction;
+    double minimum_water_area_km2;
+    double mean_water_area_km2;
+    double maximum_water_area_km2;
+    double mean_wetted_depth_m;
+    double maximum_mean_depth_m;
+    double salinity_index;
+    double monthly_direct_inflow_km3[12];
+    double monthly_upstream_inflow_km3[12];
+    double monthly_total_inflow_km3[12];
+    double monthly_evaporation_km3[12];
+    double monthly_seepage_km3[12];
+    double monthly_overflow_km3[12];
+    double monthly_storage_km3[12];
+    double monthly_water_area_km2[12];
+} SurfaceWaterCandidateRecord;
+typedef struct { SurfaceWaterCandidateRecord* data; size_t len; } SurfaceWaterCandidateArray;
+
+typedef struct {
+    int32_t fine_cell_id;
+    int32_t depression_id;
+    int32_t class_code;
+    float potential_inundation_fraction;
+    float minimum_inundation_fraction;
+    float mean_inundation_fraction;
+    float maximum_inundation_fraction;
+    float monthly_inundation_fraction[12];
+} SurfaceWaterCellRecord;
+typedef struct { SurfaceWaterCellRecord* data; size_t len; } SurfaceWaterCellArray;
+
+typedef struct {
+    int32_t cell_count;
+    int32_t candidate_count;
+    int32_t candidate_cell_count;
+    int32_t owned_source_cell_count;
+    int32_t dry_count;
+    int32_t transient_count;
+    int32_t seasonal_lake_count;
+    int32_t permanent_lake_count;
+    int32_t hydrologic_wetland_count;
+    int32_t graph_valid;
+    int32_t convergence_valid;
+    int32_t fraction_valid;
+    int32_t storage_valid;
+    int32_t direct_catchment_valid;
+    int32_t maximum_solver_iterations_used;
+    double active_source_area_km2;
+    double owned_catchment_area_km2;
+    double potential_water_area_km2;
+    double storage_capacity_km3;
+    double annual_direct_inflow_km3;
+    double annual_evaporation_km3;
+    double annual_seepage_km3;
+    double annual_terminal_overflow_km3;
+    double annual_storage_change_km3;
+    double water_balance_residual_km3;
+    double water_balance_relative_error;
+    double minimum_inundation_fraction;
+    double maximum_inundation_fraction;
+    double dry_mean_water_area_km2;
+    double transient_mean_water_area_km2;
+    double seasonal_lake_mean_water_area_km2;
+    double permanent_lake_mean_water_area_km2;
+    double hydrologic_wetland_mean_water_area_km2;
+} SurfaceWaterStats;
+
+int32_t surface_water_run(
+    SurfaceWaterConfig config,
+    size_t cell_count,
+    size_t candidate_count,
+    const int32_t* cell_ids,
+    const int32_t* receiver_ids,
+    const int32_t* depression_ids,
+    const uint8_t* source_active,
+    const double* area_km2,
+    const double* terrain_elevation_m,
+    const double* hydrologic_elevation_m,
+    const float* parent_relief_m,
+    const float* monthly_runoff_mm,
+    const float* monthly_evaporation_mm,
+    const float* sediment_accommodation,
+    const int32_t* candidate_ids,
+    const int32_t* spill_receiver_ids,
+    SurfaceWaterCandidateArray* candidates_out,
+    SurfaceWaterCellArray* cells_out,
+    SurfaceWaterStats* stats_out
+);
+void surface_water_free_candidates(SurfaceWaterCandidateArray array);
+void surface_water_free_cells(SurfaceWaterCellArray array);
+size_t surface_water_native_struct_size(uint32_t kind);
+"""
+
+_ffi = FFI()
+_ffi.cdef(_CDEF)
+
+
+def _validate_layout(c_name: str, dtype: np.dtype) -> None:
+    if not dtype.isnative or dtype.itemsize != _ffi.sizeof(c_name):
+        raise ImportError(
+            f"{c_name} native layout mismatch: numpy={dtype.itemsize}, "
+            f"cffi={_ffi.sizeof(c_name)}, native_byte_order={dtype.isnative}"
+        )
+    for field in dtype.names or ():
+        numpy_offset = int(dtype.fields[field][1])
+        cffi_offset = int(_ffi.offsetof(c_name, field))
+        if numpy_offset != cffi_offset:
+            raise ImportError(
+                f"{c_name}.{field} offset mismatch: numpy={numpy_offset}, cffi={cffi_offset}"
+            )
+
+
+_validate_layout("SurfaceWaterCandidateRecord", CANDIDATE_DTYPE)
+_validate_layout("SurfaceWaterCellRecord", CELL_DTYPE)
+native_library_info("surface_water_native")
+_lib = _ffi.dlopen(str(native_library_path("surface_water_native")))
+for _kind, _c_name in enumerate(
+    (
+        "SurfaceWaterConfig",
+        "SurfaceWaterCandidateRecord",
+        "SurfaceWaterCellRecord",
+        "SurfaceWaterStats",
+    )
+):
+    _native_size = int(_lib.surface_water_native_struct_size(_kind))
+    _declared_size = int(_ffi.sizeof(_c_name))
+    if _native_size != _declared_size:
+        raise ImportError(
+            f"{_c_name} Rust/CFFI size mismatch: native={_native_size}, " f"cffi={_declared_size}"
+        )
+
+
+def _input(values: np.ndarray, *, name: str, dtype: np.dtype, dimensions: int = 1) -> np.ndarray:
+    array = np.asarray(values)
+    if array.dtype != dtype or not array.flags.c_contiguous:
+        array = np.ascontiguousarray(array, dtype=dtype)
+    if array.ndim != dimensions:
+        raise ValueError(f"{name} must be {dimensions}-dimensional, got {array.shape}")
+    return array
+
+
+def _records(record_array: Any, dtype: np.dtype, free) -> np.ndarray:
+    length = int(record_array.len)
+    if length == 0:
+        free(record_array)
+        return np.empty(0, dtype=dtype)
+    buffer = _ffi.buffer(record_array.data, length * dtype.itemsize)
+    records = np.frombuffer(buffer, dtype=dtype, count=length).copy()
+    free(record_array)
+    return records
+
+
+def run_surface_water_balance(
+    *,
+    controls: Mapping[str, float | int],
+    cell_ids: np.ndarray,
+    receiver_ids: np.ndarray,
+    depression_ids: np.ndarray,
+    source_active: np.ndarray,
+    area_km2: np.ndarray,
+    terrain_elevation_m: np.ndarray,
+    hydrologic_elevation_m: np.ndarray,
+    parent_relief_m: np.ndarray,
+    monthly_runoff_mm: np.ndarray,
+    monthly_evaporation_mm: np.ndarray,
+    sediment_accommodation: np.ndarray,
+    candidate_ids: np.ndarray,
+    spill_receiver_ids: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, dict[str, Any]]:
+    control_names = {
+        "refinement_factor",
+        "minimum_solver_iterations",
+        "maximum_solver_iterations",
+        "transient_max_months",
+        "permanent_min_months",
+        "convergence_tolerance_fraction",
+        "open_water_evaporation_factor",
+        "seepage_mm_year",
+        "subgrid_relief_scale",
+        "minimum_subgrid_relief_m",
+        "maximum_connected_inundation_fraction",
+        "minimum_wet_area_fraction",
+        "wetland_max_mean_depth_m",
+    }
+    if set(controls) != control_names:
+        raise ValueError(
+            "Surface-water controls mismatch: "
+            f"missing={sorted(control_names - set(controls))}, "
+            f"extra={sorted(set(controls) - control_names)}"
+        )
+    inputs = {
+        "cell_ids": _input(cell_ids, name="cell_ids", dtype=np.dtype(np.int32)),
+        "receiver_ids": _input(receiver_ids, name="receiver_ids", dtype=np.dtype(np.int32)),
+        "depression_ids": _input(depression_ids, name="depression_ids", dtype=np.dtype(np.int32)),
+        "source_active": _input(source_active, name="source_active", dtype=np.dtype(np.uint8)),
+        "area_km2": _input(area_km2, name="area_km2", dtype=np.dtype(np.float64)),
+        "terrain_elevation_m": _input(
+            terrain_elevation_m, name="terrain_elevation_m", dtype=np.dtype(np.float64)
+        ),
+        "hydrologic_elevation_m": _input(
+            hydrologic_elevation_m,
+            name="hydrologic_elevation_m",
+            dtype=np.dtype(np.float64),
+        ),
+        "parent_relief_m": _input(
+            parent_relief_m, name="parent_relief_m", dtype=np.dtype(np.float32)
+        ),
+        "sediment_accommodation": _input(
+            sediment_accommodation,
+            name="sediment_accommodation",
+            dtype=np.dtype(np.float32),
+        ),
+    }
+    cell_count = len(inputs["cell_ids"])
+    if any(len(values) != cell_count for values in inputs.values()):
+        raise ValueError("Surface-water cell inputs must have equal lengths")
+    runoff = _input(
+        monthly_runoff_mm,
+        name="monthly_runoff_mm",
+        dtype=np.dtype(np.float32),
+        dimensions=2,
+    )
+    evaporation = _input(
+        monthly_evaporation_mm,
+        name="monthly_evaporation_mm",
+        dtype=np.dtype(np.float32),
+        dimensions=2,
+    )
+    if runoff.shape != (MONTHS, cell_count) or evaporation.shape != (MONTHS, cell_count):
+        raise ValueError(
+            "Surface-water monthly inputs must have shape "
+            f"{(MONTHS, cell_count)}, got runoff={runoff.shape}, evaporation={evaporation.shape}"
+        )
+    candidates = _input(candidate_ids, name="candidate_ids", dtype=np.dtype(np.int32))
+    spill_receivers = _input(
+        spill_receiver_ids, name="spill_receiver_ids", dtype=np.dtype(np.int32)
+    )
+    if len(candidates) == 0 or len(candidates) != len(spill_receivers):
+        raise ValueError("Surface-water candidate inputs must be non-empty and equal length")
+
+    config = _ffi.new(
+        "SurfaceWaterConfig*",
+        {
+            name: (
+                int(controls[name])
+                if name
+                in {
+                    "refinement_factor",
+                    "minimum_solver_iterations",
+                    "maximum_solver_iterations",
+                    "transient_max_months",
+                    "permanent_min_months",
+                }
+                else float(controls[name])
+            )
+            for name in control_names
+        },
+    )[0]
+    candidates_out = _ffi.new("SurfaceWaterCandidateArray*")
+    cells_out = _ffi.new("SurfaceWaterCellArray*")
+    stats_out = _ffi.new("SurfaceWaterStats*")
+
+    def pointer(array: np.ndarray, ctype: str):
+        return _ffi.cast(
+            f"const {ctype}*", _ffi.from_buffer(f"{ctype}[]", array, require_writable=False)
+        )
+
+    status = _lib.surface_water_run(
+        config,
+        cell_count,
+        len(candidates),
+        pointer(inputs["cell_ids"], "int32_t"),
+        pointer(inputs["receiver_ids"], "int32_t"),
+        pointer(inputs["depression_ids"], "int32_t"),
+        pointer(inputs["source_active"], "uint8_t"),
+        pointer(inputs["area_km2"], "double"),
+        pointer(inputs["terrain_elevation_m"], "double"),
+        pointer(inputs["hydrologic_elevation_m"], "double"),
+        pointer(inputs["parent_relief_m"], "float"),
+        pointer(runoff.reshape(-1), "float"),
+        pointer(evaporation.reshape(-1), "float"),
+        pointer(inputs["sediment_accommodation"], "float"),
+        pointer(candidates, "int32_t"),
+        pointer(spill_receivers, "int32_t"),
+        candidates_out,
+        cells_out,
+        stats_out,
+    )
+    if status != 0:
+        messages = {
+            1: "invalid controls or array lengths",
+            2: "invalid cell identity or physical input",
+            3: "invalid candidate identity or hypsometry",
+            4: "cyclic cell or candidate graph",
+            5: "null input or output pointer",
+        }
+        raise RuntimeError(f"surface_water_run failed: {messages.get(status, f'status {status}')}")
+
+    candidate_records = _records(
+        candidates_out[0], CANDIDATE_DTYPE, _lib.surface_water_free_candidates
+    )
+    cell_records = _records(cells_out[0], CELL_DTYPE, _lib.surface_water_free_cells)
+    stats = stats_out[0]
+    integer_names = (
+        "cell_count",
+        "candidate_count",
+        "candidate_cell_count",
+        "owned_source_cell_count",
+        "dry_count",
+        "transient_count",
+        "seasonal_lake_count",
+        "permanent_lake_count",
+        "hydrologic_wetland_count",
+        "graph_valid",
+        "convergence_valid",
+        "fraction_valid",
+        "storage_valid",
+        "direct_catchment_valid",
+        "maximum_solver_iterations_used",
+    )
+    float_names = (
+        "active_source_area_km2",
+        "owned_catchment_area_km2",
+        "potential_water_area_km2",
+        "storage_capacity_km3",
+        "annual_direct_inflow_km3",
+        "annual_evaporation_km3",
+        "annual_seepage_km3",
+        "annual_terminal_overflow_km3",
+        "annual_storage_change_km3",
+        "water_balance_residual_km3",
+        "water_balance_relative_error",
+        "minimum_inundation_fraction",
+        "maximum_inundation_fraction",
+        "dry_mean_water_area_km2",
+        "transient_mean_water_area_km2",
+        "seasonal_lake_mean_water_area_km2",
+        "permanent_lake_mean_water_area_km2",
+        "hydrologic_wetland_mean_water_area_km2",
+    )
+    metadata = {name: int(getattr(stats, name)) for name in integer_names}
+    metadata.update({name: float(getattr(stats, name)) for name in float_names})
+    return candidate_records, cell_records, metadata
+
+
+__all__ = ["SURFACE_WATER_CLASSES", "run_surface_water_balance"]

--- a/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
+++ b/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
@@ -183,7 +183,7 @@ fn validate_inputs(
     if resolution == 0
         || cell_count == 0
         || !config.minimum_depression_depth_m.is_finite()
-        || config.minimum_depression_depth_m < 0.0
+        || config.minimum_depression_depth_m <= 0.0
         || !config.planet_radius_m.is_finite()
         || config.planet_radius_m <= 0.0
         || inputs.terrain_before_m.len() != cell_count

--- a/src/map_maker/pipeline/native/surface_water/Cargo.toml
+++ b/src/map_maker/pipeline/native/surface_water/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "surface_water_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/map_maker/pipeline/native/surface_water/src/lib.rs
+++ b/src/map_maker/pipeline/native/surface_water/src/lib.rs
@@ -1,0 +1,1303 @@
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+use std::mem;
+use std::slice;
+
+const MONTHS: usize = 12;
+const HYPSOMETRY_BINS: usize = 65;
+
+const CLASS_DRY: i32 = 0;
+const CLASS_TRANSIENT: i32 = 1;
+const CLASS_SEASONAL_LAKE: i32 = 2;
+const CLASS_PERMANENT_LAKE: i32 = 3;
+const CLASS_HYDROLOGIC_WETLAND: i32 = 4;
+
+#[no_mangle]
+pub extern "C" fn surface_water_native_abi_version() -> u32 {
+    2
+}
+
+#[no_mangle]
+pub extern "C" fn surface_water_native_struct_size(kind: u32) -> usize {
+    match kind {
+        0 => mem::size_of::<SurfaceWaterConfig>(),
+        1 => mem::size_of::<SurfaceWaterCandidateRecord>(),
+        2 => mem::size_of::<SurfaceWaterCellRecord>(),
+        3 => mem::size_of::<SurfaceWaterStats>(),
+        _ => 0,
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SurfaceWaterConfig {
+    pub refinement_factor: i32,
+    pub minimum_solver_iterations: i32,
+    pub maximum_solver_iterations: i32,
+    pub transient_max_months: i32,
+    pub permanent_min_months: i32,
+    pub convergence_tolerance_fraction: f64,
+    pub open_water_evaporation_factor: f64,
+    pub seepage_mm_year: f64,
+    pub subgrid_relief_scale: f64,
+    pub minimum_subgrid_relief_m: f64,
+    pub maximum_connected_inundation_fraction: f64,
+    pub minimum_wet_area_fraction: f64,
+    pub wetland_max_mean_depth_m: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct SurfaceWaterCandidateRecord {
+    pub depression_id: i32,
+    pub downstream_depression_id: i32,
+    pub class_code: i32,
+    pub cell_count: i32,
+    pub catchment_cell_count: i32,
+    pub wet_month_count: i32,
+    pub solver_iterations: i32,
+    pub converged: i32,
+    pub open_outlet: i32,
+    pub catchment_area_km2: f64,
+    pub potential_water_area_km2: f64,
+    pub storage_capacity_km3: f64,
+    pub annual_direct_inflow_km3: f64,
+    pub annual_upstream_inflow_km3: f64,
+    pub annual_total_inflow_km3: f64,
+    pub annual_evaporation_km3: f64,
+    pub annual_seepage_km3: f64,
+    pub annual_overflow_km3: f64,
+    pub annual_terminal_overflow_km3: f64,
+    pub annual_storage_change_km3: f64,
+    pub water_balance_residual_km3: f64,
+    pub hydroperiod_fraction: f64,
+    pub minimum_water_area_km2: f64,
+    pub mean_water_area_km2: f64,
+    pub maximum_water_area_km2: f64,
+    pub mean_wetted_depth_m: f64,
+    pub maximum_mean_depth_m: f64,
+    pub salinity_index: f64,
+    pub monthly_direct_inflow_km3: [f64; MONTHS],
+    pub monthly_upstream_inflow_km3: [f64; MONTHS],
+    pub monthly_total_inflow_km3: [f64; MONTHS],
+    pub monthly_evaporation_km3: [f64; MONTHS],
+    pub monthly_seepage_km3: [f64; MONTHS],
+    pub monthly_overflow_km3: [f64; MONTHS],
+    pub monthly_storage_km3: [f64; MONTHS],
+    pub monthly_water_area_km2: [f64; MONTHS],
+}
+
+#[repr(C)]
+pub struct SurfaceWaterCandidateArray {
+    pub data: *mut SurfaceWaterCandidateRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct SurfaceWaterCellRecord {
+    pub fine_cell_id: i32,
+    pub depression_id: i32,
+    pub class_code: i32,
+    pub potential_inundation_fraction: f32,
+    pub minimum_inundation_fraction: f32,
+    pub mean_inundation_fraction: f32,
+    pub maximum_inundation_fraction: f32,
+    pub monthly_inundation_fraction: [f32; MONTHS],
+}
+
+#[repr(C)]
+pub struct SurfaceWaterCellArray {
+    pub data: *mut SurfaceWaterCellRecord,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct SurfaceWaterStats {
+    pub cell_count: i32,
+    pub candidate_count: i32,
+    pub candidate_cell_count: i32,
+    pub owned_source_cell_count: i32,
+    pub dry_count: i32,
+    pub transient_count: i32,
+    pub seasonal_lake_count: i32,
+    pub permanent_lake_count: i32,
+    pub hydrologic_wetland_count: i32,
+    pub graph_valid: i32,
+    pub convergence_valid: i32,
+    pub fraction_valid: i32,
+    pub storage_valid: i32,
+    pub direct_catchment_valid: i32,
+    pub maximum_solver_iterations_used: i32,
+    pub active_source_area_km2: f64,
+    pub owned_catchment_area_km2: f64,
+    pub potential_water_area_km2: f64,
+    pub storage_capacity_km3: f64,
+    pub annual_direct_inflow_km3: f64,
+    pub annual_evaporation_km3: f64,
+    pub annual_seepage_km3: f64,
+    pub annual_terminal_overflow_km3: f64,
+    pub annual_storage_change_km3: f64,
+    pub water_balance_residual_km3: f64,
+    pub water_balance_relative_error: f64,
+    pub minimum_inundation_fraction: f64,
+    pub maximum_inundation_fraction: f64,
+    pub dry_mean_water_area_km2: f64,
+    pub transient_mean_water_area_km2: f64,
+    pub seasonal_lake_mean_water_area_km2: f64,
+    pub permanent_lake_mean_water_area_km2: f64,
+    pub hydrologic_wetland_mean_water_area_km2: f64,
+}
+
+struct Inputs<'a> {
+    cell_ids: &'a [i32],
+    receiver_ids: &'a [i32],
+    depression_ids: &'a [i32],
+    source_active: &'a [u8],
+    area_km2: &'a [f64],
+    terrain_elevation_m: &'a [f64],
+    hydrologic_elevation_m: &'a [f64],
+    parent_relief_m: &'a [f32],
+    monthly_runoff_mm: &'a [f32],
+    monthly_evaporation_mm: &'a [f32],
+    sediment_accommodation: &'a [f32],
+    candidate_ids: &'a [i32],
+    spill_receiver_ids: &'a [i32],
+}
+
+struct RoutingDomain {
+    candidate_by_id: HashMap<i32, usize>,
+    owner: Vec<i32>,
+    downstream: Vec<i32>,
+    candidate_order: Vec<usize>,
+}
+
+struct Hypsometry {
+    bottom_m: f64,
+    cap_m: f64,
+    volume_km3: [f64; HYPSOMETRY_BINS],
+    area_km2: [f64; HYPSOMETRY_BINS],
+    evaporation_area: [[f64; MONTHS]; HYPSOMETRY_BINS],
+    seepage_area_km2: [f64; HYPSOMETRY_BINS],
+    potential_fraction_by_member: Vec<f32>,
+}
+
+struct CandidateState {
+    members: Vec<usize>,
+    hypsometry: Hypsometry,
+    direct_inflow_km3: [f64; MONTHS],
+    catchment_cell_count: usize,
+    catchment_area_km2: f64,
+    monthly_upstream_inflow_km3: [f64; MONTHS],
+    monthly_total_inflow_km3: [f64; MONTHS],
+    monthly_evaporation_km3: [f64; MONTHS],
+    monthly_seepage_km3: [f64; MONTHS],
+    monthly_overflow_km3: [f64; MONTHS],
+    monthly_storage_km3: [f64; MONTHS],
+    monthly_water_area_km2: [f64; MONTHS],
+    periodic_start_storage_km3: f64,
+    solver_iterations: usize,
+}
+
+struct Outcome {
+    candidates: Vec<SurfaceWaterCandidateRecord>,
+    cells: Vec<SurfaceWaterCellRecord>,
+    stats: SurfaceWaterStats,
+}
+
+fn validate_config(config: SurfaceWaterConfig) -> Result<(), i32> {
+    if config.refinement_factor < 2
+        || config.refinement_factor > 32
+        || config.refinement_factor & (config.refinement_factor - 1) != 0
+        || config.minimum_solver_iterations < 1
+        || config.maximum_solver_iterations < config.minimum_solver_iterations
+        || config.maximum_solver_iterations > 256
+        || !(0..=11).contains(&config.transient_max_months)
+        || config.permanent_min_months != MONTHS as i32
+        || config.transient_max_months >= config.permanent_min_months
+    {
+        return Err(1);
+    }
+    for value in [
+        config.convergence_tolerance_fraction,
+        config.open_water_evaporation_factor,
+        config.seepage_mm_year,
+        config.subgrid_relief_scale,
+        config.minimum_subgrid_relief_m,
+        config.maximum_connected_inundation_fraction,
+        config.minimum_wet_area_fraction,
+        config.wetland_max_mean_depth_m,
+    ] {
+        if !value.is_finite() || value < 0.0 {
+            return Err(1);
+        }
+    }
+    if config.convergence_tolerance_fraction <= 0.0
+        || config.open_water_evaporation_factor > 10.0
+        || config.seepage_mm_year > 10_000.0
+        || config.subgrid_relief_scale <= 0.0
+        || config.minimum_subgrid_relief_m <= 0.0
+        || config.maximum_connected_inundation_fraction <= 0.0
+        || config.maximum_connected_inundation_fraction > 1.0
+        || config.minimum_wet_area_fraction <= 0.0
+        || config.minimum_wet_area_fraction > 1.0
+        || config.wetland_max_mean_depth_m <= 0.0
+    {
+        return Err(1);
+    }
+    Ok(())
+}
+
+fn validate_inputs(config: SurfaceWaterConfig, inputs: &Inputs<'_>) -> Result<RoutingDomain, i32> {
+    validate_config(config)?;
+    let cell_count = inputs.cell_ids.len();
+    let candidate_count = inputs.candidate_ids.len();
+    if cell_count == 0
+        || candidate_count == 0
+        || inputs.receiver_ids.len() != cell_count
+        || inputs.depression_ids.len() != cell_count
+        || inputs.source_active.len() != cell_count
+        || inputs.area_km2.len() != cell_count
+        || inputs.terrain_elevation_m.len() != cell_count
+        || inputs.hydrologic_elevation_m.len() != cell_count
+        || inputs.parent_relief_m.len() != cell_count
+        || inputs.monthly_runoff_mm.len() != cell_count * MONTHS
+        || inputs.monthly_evaporation_mm.len() != cell_count * MONTHS
+        || inputs.sediment_accommodation.len() != cell_count
+        || inputs.spill_receiver_ids.len() != candidate_count
+    {
+        return Err(1);
+    }
+
+    let mut row_by_cell_id = HashMap::with_capacity(cell_count);
+    for row in 0..cell_count {
+        if inputs.cell_ids[row] < 0
+            || row_by_cell_id.insert(inputs.cell_ids[row], row).is_some()
+            || inputs.receiver_ids[row] < -2
+            || inputs.source_active[row] > 1
+            || !inputs.area_km2[row].is_finite()
+            || inputs.area_km2[row] <= 0.0
+            || !inputs.terrain_elevation_m[row].is_finite()
+            || !inputs.hydrologic_elevation_m[row].is_finite()
+            || !inputs.parent_relief_m[row].is_finite()
+            || inputs.parent_relief_m[row] < 0.0
+            || !inputs.sediment_accommodation[row].is_finite()
+            || !(0.0..=1.0).contains(&inputs.sediment_accommodation[row])
+        {
+            return Err(2);
+        }
+        for month in 0..MONTHS {
+            let runoff = inputs.monthly_runoff_mm[month * cell_count + row];
+            let evaporation = inputs.monthly_evaporation_mm[month * cell_count + row];
+            if !runoff.is_finite() || runoff < 0.0 || !evaporation.is_finite() || evaporation < 0.0
+            {
+                return Err(2);
+            }
+        }
+    }
+    for &receiver in inputs.receiver_ids {
+        if receiver >= 0 && !row_by_cell_id.contains_key(&receiver) {
+            return Err(2);
+        }
+    }
+
+    let mut candidate_by_id = HashMap::with_capacity(candidate_count);
+    for (index, &candidate_id) in inputs.candidate_ids.iter().enumerate() {
+        if candidate_id < 0 || candidate_by_id.insert(candidate_id, index).is_some() {
+            return Err(3);
+        }
+        let spill_receiver = inputs.spill_receiver_ids[index];
+        if spill_receiver < -2
+            || (spill_receiver >= 0 && !row_by_cell_id.contains_key(&spill_receiver))
+        {
+            return Err(3);
+        }
+    }
+    let mut membership_count = vec![0usize; candidate_count];
+    for row in 0..cell_count {
+        let depression_id = inputs.depression_ids[row];
+        if depression_id < 0 {
+            continue;
+        }
+        let Some(&candidate) = candidate_by_id.get(&depression_id) else {
+            return Err(3);
+        };
+        if inputs.source_active[row] == 0
+            || inputs.hydrologic_elevation_m[row] <= inputs.terrain_elevation_m[row]
+        {
+            return Err(3);
+        }
+        membership_count[candidate] += 1;
+    }
+    if membership_count.contains(&0) {
+        return Err(3);
+    }
+
+    let mut upstream_count = vec![0usize; cell_count];
+    for &receiver in inputs.receiver_ids {
+        if receiver >= 0 {
+            upstream_count[row_by_cell_id[&receiver]] += 1;
+        }
+    }
+    let mut ready = BinaryHeap::new();
+    for (row, &count) in upstream_count.iter().enumerate() {
+        if count == 0 {
+            ready.push(Reverse((inputs.cell_ids[row], row)));
+        }
+    }
+    let mut cell_order = Vec::with_capacity(cell_count);
+    while let Some(Reverse((_, row))) = ready.pop() {
+        cell_order.push(row);
+        let receiver = inputs.receiver_ids[row];
+        if receiver >= 0 {
+            let target = row_by_cell_id[&receiver];
+            upstream_count[target] -= 1;
+            if upstream_count[target] == 0 {
+                ready.push(Reverse((inputs.cell_ids[target], target)));
+            }
+        }
+    }
+    if cell_order.len() != cell_count {
+        return Err(4);
+    }
+
+    let mut owner = vec![-1i32; cell_count];
+    for &row in cell_order.iter().rev() {
+        let depression_id = inputs.depression_ids[row];
+        if depression_id >= 0 {
+            owner[row] = candidate_by_id[&depression_id] as i32;
+        } else if inputs.receiver_ids[row] >= 0 {
+            owner[row] = owner[row_by_cell_id[&inputs.receiver_ids[row]]];
+        }
+    }
+
+    let mut downstream = vec![-1i32; candidate_count];
+    let mut candidate_upstream_count = vec![0usize; candidate_count];
+    for candidate in 0..candidate_count {
+        let spill_receiver = inputs.spill_receiver_ids[candidate];
+        if spill_receiver >= 0 {
+            downstream[candidate] = owner[row_by_cell_id[&spill_receiver]];
+        }
+        if downstream[candidate] == candidate as i32 {
+            return Err(4);
+        }
+        if downstream[candidate] >= 0 {
+            candidate_upstream_count[downstream[candidate] as usize] += 1;
+        }
+    }
+    let mut candidate_ready = BinaryHeap::new();
+    for (candidate, &count) in candidate_upstream_count.iter().enumerate() {
+        if count == 0 {
+            candidate_ready.push(Reverse((inputs.candidate_ids[candidate], candidate)));
+        }
+    }
+    let mut candidate_order = Vec::with_capacity(candidate_count);
+    while let Some(Reverse((_, candidate))) = candidate_ready.pop() {
+        candidate_order.push(candidate);
+        let target = downstream[candidate];
+        if target >= 0 {
+            let target = target as usize;
+            candidate_upstream_count[target] -= 1;
+            if candidate_upstream_count[target] == 0 {
+                candidate_ready.push(Reverse((inputs.candidate_ids[target], target)));
+            }
+        }
+    }
+    if candidate_order.len() != candidate_count {
+        return Err(4);
+    }
+
+    Ok(RoutingDomain {
+        candidate_by_id,
+        owner,
+        downstream,
+        candidate_order,
+    })
+}
+
+fn inundation(mean_m: f64, span_m: f64, surface_m: f64, maximum_fraction: f64) -> (f64, f64) {
+    let bottom_m = mean_m - 0.5 * span_m;
+    let height_m = (surface_m - bottom_m).clamp(0.0, span_m);
+    let fraction = (height_m / span_m).min(maximum_fraction);
+    let equivalent_depth_m = (fraction * height_m - 0.5 * span_m * fraction * fraction).max(0.0);
+    (fraction, equivalent_depth_m)
+}
+
+fn build_hypsometry(
+    config: SurfaceWaterConfig,
+    inputs: &Inputs<'_>,
+    members: &[usize],
+) -> Result<Hypsometry, i32> {
+    let relief_divisor = (config.refinement_factor as f64).sqrt();
+    let spans = members
+        .iter()
+        .map(|&row| {
+            (inputs.parent_relief_m[row] as f64 / relief_divisor * config.subgrid_relief_scale)
+                .max(config.minimum_subgrid_relief_m)
+        })
+        .collect::<Vec<_>>();
+    let cap_m = inputs.hydrologic_elevation_m[members[0]];
+    if members
+        .iter()
+        .any(|&row| (inputs.hydrologic_elevation_m[row] - cap_m).abs() > 1e-6)
+    {
+        return Err(3);
+    }
+    let bottom_m = members
+        .iter()
+        .zip(&spans)
+        .map(|(&row, &span)| inputs.terrain_elevation_m[row] - 0.5 * span)
+        .fold(cap_m, f64::min);
+    if cap_m <= bottom_m {
+        return Err(3);
+    }
+
+    let mut volume_km3 = [0.0; HYPSOMETRY_BINS];
+    let mut area_km2 = [0.0; HYPSOMETRY_BINS];
+    let mut evaporation_area = [[0.0; MONTHS]; HYPSOMETRY_BINS];
+    let mut seepage_area_km2 = [0.0; HYPSOMETRY_BINS];
+    for bin in 0..HYPSOMETRY_BINS {
+        let fraction = bin as f64 / (HYPSOMETRY_BINS - 1) as f64;
+        let level_m = bottom_m + fraction * (cap_m - bottom_m);
+        for (member_index, &row) in members.iter().enumerate() {
+            let (cell_fraction, equivalent_depth_m) = inundation(
+                inputs.terrain_elevation_m[row],
+                spans[member_index],
+                level_m,
+                config.maximum_connected_inundation_fraction,
+            );
+            let covered_area = cell_fraction * inputs.area_km2[row];
+            area_km2[bin] += covered_area;
+            volume_km3[bin] += equivalent_depth_m * inputs.area_km2[row] / 1_000.0;
+            let seepage_factor = 1.0 - 0.65 * inputs.sediment_accommodation[row] as f64;
+            seepage_area_km2[bin] += covered_area * seepage_factor;
+            for (month, value) in evaporation_area[bin].iter_mut().enumerate() {
+                *value += covered_area
+                    * inputs.monthly_evaporation_mm[month * inputs.cell_ids.len() + row] as f64;
+            }
+        }
+    }
+    if volume_km3[HYPSOMETRY_BINS - 1] <= 0.0
+        || area_km2[HYPSOMETRY_BINS - 1] <= 0.0
+        || volume_km3.windows(2).any(|pair| pair[1] < pair[0])
+        || area_km2.windows(2).any(|pair| pair[1] < pair[0])
+    {
+        return Err(3);
+    }
+    let potential_fraction_by_member = members
+        .iter()
+        .enumerate()
+        .map(|(member_index, &row)| {
+            inundation(
+                inputs.terrain_elevation_m[row],
+                spans[member_index],
+                cap_m,
+                config.maximum_connected_inundation_fraction,
+            )
+            .0 as f32
+        })
+        .collect();
+    Ok(Hypsometry {
+        bottom_m,
+        cap_m,
+        volume_km3,
+        area_km2,
+        evaporation_area,
+        seepage_area_km2,
+        potential_fraction_by_member,
+    })
+}
+
+fn curve_position(curve: &Hypsometry, storage_km3: f64) -> (usize, f64) {
+    let capacity = curve.volume_km3[HYPSOMETRY_BINS - 1];
+    let storage = storage_km3.clamp(0.0, capacity);
+    let upper = curve
+        .volume_km3
+        .partition_point(|value| *value < storage)
+        .clamp(1, HYPSOMETRY_BINS - 1);
+    let lower = upper - 1;
+    let width = curve.volume_km3[upper] - curve.volume_km3[lower];
+    let fraction = if width <= f64::EPSILON {
+        0.0
+    } else {
+        (storage - curve.volume_km3[lower]) / width
+    };
+    (lower, fraction.clamp(0.0, 1.0))
+}
+
+fn interpolate(values: &[f64; HYPSOMETRY_BINS], lower: usize, fraction: f64) -> f64 {
+    values[lower] + fraction * (values[lower + 1] - values[lower])
+}
+
+fn curve_properties(curve: &Hypsometry, storage_km3: f64, month: usize) -> (f64, f64, f64) {
+    if storage_km3 <= 0.0 {
+        return (0.0, 0.0, 0.0);
+    }
+    let (lower, fraction) = curve_position(curve, storage_km3);
+    let evaporation_area = curve.evaporation_area[lower][month]
+        + fraction
+            * (curve.evaporation_area[lower + 1][month] - curve.evaporation_area[lower][month]);
+    (
+        interpolate(&curve.area_km2, lower, fraction),
+        evaporation_area,
+        interpolate(&curve.seepage_area_km2, lower, fraction),
+    )
+}
+
+fn curve_level(curve: &Hypsometry, storage_km3: f64) -> f64 {
+    if storage_km3 <= 0.0 {
+        return curve.bottom_m;
+    }
+    let (lower, fraction) = curve_position(curve, storage_km3);
+    let lower_fraction = lower as f64 / (HYPSOMETRY_BINS - 1) as f64;
+    let upper_fraction = (lower + 1) as f64 / (HYPSOMETRY_BINS - 1) as f64;
+    curve.bottom_m
+        + (lower_fraction + fraction * (upper_fraction - lower_fraction))
+            * (curve.cap_m - curve.bottom_m)
+}
+
+fn refresh_exact_monthly_areas(
+    config: SurfaceWaterConfig,
+    inputs: &Inputs<'_>,
+    states: &mut [CandidateState],
+) {
+    let relief_divisor = (config.refinement_factor as f64).sqrt();
+    for state in states {
+        for month in 0..MONTHS {
+            let level = curve_level(&state.hypsometry, state.monthly_storage_km3[month]);
+            state.monthly_water_area_km2[month] = state
+                .members
+                .iter()
+                .map(|&row| {
+                    let span = (inputs.parent_relief_m[row] as f64 / relief_divisor
+                        * config.subgrid_relief_scale)
+                        .max(config.minimum_subgrid_relief_m);
+                    inundation(
+                        inputs.terrain_elevation_m[row],
+                        span,
+                        level,
+                        config.maximum_connected_inundation_fraction,
+                    )
+                    .0 * inputs.area_km2[row]
+                })
+                .sum();
+        }
+    }
+}
+
+fn initialize_states(
+    config: SurfaceWaterConfig,
+    inputs: &Inputs<'_>,
+    domain: &RoutingDomain,
+) -> Result<Vec<CandidateState>, i32> {
+    let candidate_count = inputs.candidate_ids.len();
+    let mut members = vec![Vec::new(); candidate_count];
+    for (row, &depression_id) in inputs.depression_ids.iter().enumerate() {
+        if depression_id >= 0 {
+            members[domain.candidate_by_id[&depression_id]].push(row);
+        }
+    }
+    let mut states = Vec::with_capacity(candidate_count);
+    for candidate_members in members {
+        let hypsometry = build_hypsometry(config, inputs, &candidate_members)?;
+        states.push(CandidateState {
+            members: candidate_members,
+            hypsometry,
+            direct_inflow_km3: [0.0; MONTHS],
+            catchment_cell_count: 0,
+            catchment_area_km2: 0.0,
+            monthly_upstream_inflow_km3: [0.0; MONTHS],
+            monthly_total_inflow_km3: [0.0; MONTHS],
+            monthly_evaporation_km3: [0.0; MONTHS],
+            monthly_seepage_km3: [0.0; MONTHS],
+            monthly_overflow_km3: [0.0; MONTHS],
+            monthly_storage_km3: [0.0; MONTHS],
+            monthly_water_area_km2: [0.0; MONTHS],
+            periodic_start_storage_km3: 0.0,
+            solver_iterations: 0,
+        });
+    }
+
+    for row in 0..inputs.cell_ids.len() {
+        if inputs.source_active[row] == 0 || domain.owner[row] < 0 {
+            continue;
+        }
+        let candidate = domain.owner[row] as usize;
+        states[candidate].catchment_cell_count += 1;
+        states[candidate].catchment_area_km2 += inputs.area_km2[row];
+        for month in 0..MONTHS {
+            states[candidate].direct_inflow_km3[month] +=
+                inputs.monthly_runoff_mm[month * inputs.cell_ids.len() + row] as f64
+                    * inputs.area_km2[row]
+                    / 1_000_000.0;
+        }
+    }
+
+    Ok(states)
+}
+
+fn simulate_candidate_year(
+    config: SurfaceWaterConfig,
+    state: &mut CandidateState,
+    upstream_inflow: &[f64; MONTHS],
+    initial_storage_km3: f64,
+    persist: bool,
+) -> f64 {
+    if persist {
+        state.periodic_start_storage_km3 = initial_storage_km3;
+        state.monthly_upstream_inflow_km3 = [0.0; MONTHS];
+        state.monthly_total_inflow_km3 = [0.0; MONTHS];
+        state.monthly_evaporation_km3 = [0.0; MONTHS];
+        state.monthly_seepage_km3 = [0.0; MONTHS];
+        state.monthly_overflow_km3 = [0.0; MONTHS];
+        state.monthly_storage_km3 = [0.0; MONTHS];
+        state.monthly_water_area_km2 = [0.0; MONTHS];
+    }
+    let mut storage_km3 = initial_storage_km3;
+    for (month, &upstream) in upstream_inflow.iter().enumerate() {
+        let direct = state.direct_inflow_km3[month];
+        let total_inflow = direct + upstream;
+        let available = storage_km3 + total_inflow;
+        let capacity = state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1];
+        let provisional_storage = available.min(capacity);
+        let loss_storage = 0.5 * (storage_km3 + provisional_storage);
+        let (_, evaporation_area, seepage_area) =
+            curve_properties(&state.hypsometry, loss_storage, month);
+        let mut evaporation = evaporation_area * config.open_water_evaporation_factor / 1_000_000.0;
+        let mut seepage = seepage_area * config.seepage_mm_year / MONTHS as f64 / 1_000_000.0;
+        let demanded_loss = evaporation + seepage;
+        if demanded_loss > available && demanded_loss > 0.0 {
+            let scale = available / demanded_loss;
+            evaporation *= scale;
+            seepage *= scale;
+        }
+        let remaining = (available - evaporation - seepage).max(0.0);
+        let overflow = (remaining - capacity).max(0.0);
+        storage_km3 = remaining.min(capacity);
+        if persist {
+            let (water_area, _, _) = curve_properties(&state.hypsometry, storage_km3, month);
+            state.monthly_upstream_inflow_km3[month] = upstream;
+            state.monthly_total_inflow_km3[month] = total_inflow;
+            state.monthly_evaporation_km3[month] = evaporation;
+            state.monthly_seepage_km3[month] = seepage;
+            state.monthly_overflow_km3[month] = overflow;
+            state.monthly_storage_km3[month] = storage_km3;
+            state.monthly_water_area_km2[month] = water_area;
+        }
+    }
+    storage_km3
+}
+
+fn solve_periodic_states(
+    config: SurfaceWaterConfig,
+    states: &mut [CandidateState],
+    downstream: &[i32],
+    candidate_order: &[usize],
+) -> bool {
+    let mut upstream_inflow = vec![[0.0f64; MONTHS]; states.len()];
+    let mut all_converged = true;
+    for &candidate in candidate_order {
+        let state = &mut states[candidate];
+        let capacity = state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1];
+        let tolerance = config.convergence_tolerance_fraction * capacity.max(1e-12);
+        let low_end =
+            simulate_candidate_year(config, state, &upstream_inflow[candidate], 0.0, false);
+        let high_end =
+            simulate_candidate_year(config, state, &upstream_inflow[candidate], capacity, false);
+        let initial_storage = if low_end.abs() <= tolerance {
+            0.0
+        } else if (high_end - capacity).abs() <= tolerance {
+            capacity
+        } else {
+            let mut low = 0.0;
+            let mut high = capacity;
+            let mut solution = 0.5 * capacity;
+            for iteration in 1..=config.maximum_solver_iterations as usize {
+                let midpoint = 0.5 * (low + high);
+                let end = simulate_candidate_year(
+                    config,
+                    state,
+                    &upstream_inflow[candidate],
+                    midpoint,
+                    false,
+                );
+                let residual = end - midpoint;
+                solution = midpoint;
+                state.solver_iterations = iteration;
+                if iteration >= config.minimum_solver_iterations as usize
+                    && residual.abs() <= tolerance
+                {
+                    break;
+                }
+                if residual > 0.0 {
+                    low = midpoint;
+                } else {
+                    high = midpoint;
+                }
+            }
+            solution
+        };
+        if state.solver_iterations == 0 {
+            state.solver_iterations = 1;
+        }
+        let final_storage = simulate_candidate_year(
+            config,
+            state,
+            &upstream_inflow[candidate],
+            initial_storage,
+            true,
+        );
+        let residual = final_storage - initial_storage;
+        if residual.abs() > tolerance {
+            all_converged = false;
+        }
+        let target = downstream[candidate];
+        if target >= 0 {
+            for (target_inflow, overflow) in upstream_inflow[target as usize]
+                .iter_mut()
+                .zip(state.monthly_overflow_km3)
+            {
+                *target_inflow += overflow;
+            }
+        }
+    }
+    all_converged
+}
+
+fn classify_candidate(config: SurfaceWaterConfig, state: &CandidateState) -> (i32, usize) {
+    let potential_area = state.hypsometry.area_km2[HYPSOMETRY_BINS - 1];
+    let wet_month_count = state
+        .monthly_water_area_km2
+        .iter()
+        .filter(|area| **area / potential_area.max(1e-12) >= config.minimum_wet_area_fraction)
+        .count();
+    let total_area = state.monthly_water_area_km2.iter().sum::<f64>();
+    let mean_depth_m = if total_area > 0.0 {
+        state.monthly_storage_km3.iter().sum::<f64>() * 1_000.0 / total_area
+    } else {
+        0.0
+    };
+    let class_code = if wet_month_count == 0 {
+        CLASS_DRY
+    } else if wet_month_count <= config.transient_max_months as usize {
+        CLASS_TRANSIENT
+    } else if mean_depth_m <= config.wetland_max_mean_depth_m {
+        CLASS_HYDROLOGIC_WETLAND
+    } else if wet_month_count >= config.permanent_min_months as usize {
+        CLASS_PERMANENT_LAKE
+    } else {
+        CLASS_SEASONAL_LAKE
+    };
+    (class_code, wet_month_count)
+}
+
+fn run_balance(config: SurfaceWaterConfig, inputs: &Inputs<'_>) -> Result<Outcome, i32> {
+    let domain = validate_inputs(config, inputs)?;
+    let mut states = initialize_states(config, inputs, &domain)?;
+    let convergence_valid = solve_periodic_states(
+        config,
+        &mut states,
+        &domain.downstream,
+        &domain.candidate_order,
+    );
+    refresh_exact_monthly_areas(config, inputs, &mut states);
+
+    let mut candidates = Vec::with_capacity(states.len());
+    let mut class_counts = [0usize; 5];
+    let mut class_areas = [0.0f64; 5];
+    let mut annual_direct_total = 0.0;
+    let mut annual_evaporation_total = 0.0;
+    let mut annual_seepage_total = 0.0;
+    let mut annual_terminal_overflow_total = 0.0;
+    let mut annual_storage_change_total = 0.0;
+    for (candidate, state) in states.iter().enumerate() {
+        let (class_code, wet_month_count) = classify_candidate(config, state);
+        class_counts[class_code as usize] += 1;
+        let annual_direct = state.direct_inflow_km3.iter().sum::<f64>();
+        let annual_upstream = state.monthly_upstream_inflow_km3.iter().sum::<f64>();
+        let annual_total = state.monthly_total_inflow_km3.iter().sum::<f64>();
+        let annual_evaporation = state.monthly_evaporation_km3.iter().sum::<f64>();
+        let annual_seepage = state.monthly_seepage_km3.iter().sum::<f64>();
+        let annual_overflow = state.monthly_overflow_km3.iter().sum::<f64>();
+        let annual_terminal_overflow = if domain.downstream[candidate] < 0 {
+            annual_overflow
+        } else {
+            0.0
+        };
+        let annual_storage_change =
+            state.monthly_storage_km3[MONTHS - 1] - state.periodic_start_storage_km3;
+        let residual = annual_total
+            - annual_evaporation
+            - annual_seepage
+            - annual_overflow
+            - annual_storage_change;
+        let minimum_area = state
+            .monthly_water_area_km2
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let maximum_area = state
+            .monthly_water_area_km2
+            .iter()
+            .copied()
+            .fold(0.0, f64::max);
+        let mean_area = state.monthly_water_area_km2.iter().sum::<f64>() / MONTHS as f64;
+        class_areas[class_code as usize] += mean_area;
+        let total_monthly_area = state.monthly_water_area_km2.iter().sum::<f64>();
+        let mean_wetted_depth = if total_monthly_area > 0.0 {
+            state.monthly_storage_km3.iter().sum::<f64>() * 1_000.0 / total_monthly_area
+        } else {
+            0.0
+        };
+        let maximum_mean_depth = (0..MONTHS)
+            .map(|month| {
+                if state.monthly_water_area_km2[month] > 0.0 {
+                    state.monthly_storage_km3[month] * 1_000.0 / state.monthly_water_area_km2[month]
+                } else {
+                    0.0
+                }
+            })
+            .fold(0.0, f64::max);
+        let converged = (annual_storage_change.abs()
+            / state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1].max(1e-12))
+            <= config.convergence_tolerance_fraction;
+        candidates.push(SurfaceWaterCandidateRecord {
+            depression_id: inputs.candidate_ids[candidate],
+            downstream_depression_id: if domain.downstream[candidate] >= 0 {
+                inputs.candidate_ids[domain.downstream[candidate] as usize]
+            } else {
+                -1
+            },
+            class_code,
+            cell_count: state.members.len() as i32,
+            catchment_cell_count: state.catchment_cell_count as i32,
+            wet_month_count: wet_month_count as i32,
+            solver_iterations: state.solver_iterations as i32,
+            converged: i32::from(converged),
+            open_outlet: i32::from(annual_overflow > 1e-12),
+            catchment_area_km2: state.catchment_area_km2,
+            potential_water_area_km2: state.hypsometry.area_km2[HYPSOMETRY_BINS - 1],
+            storage_capacity_km3: state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1],
+            annual_direct_inflow_km3: annual_direct,
+            annual_upstream_inflow_km3: annual_upstream,
+            annual_total_inflow_km3: annual_total,
+            annual_evaporation_km3: annual_evaporation,
+            annual_seepage_km3: annual_seepage,
+            annual_overflow_km3: annual_overflow,
+            annual_terminal_overflow_km3: annual_terminal_overflow,
+            annual_storage_change_km3: annual_storage_change,
+            water_balance_residual_km3: residual,
+            hydroperiod_fraction: wet_month_count as f64 / MONTHS as f64,
+            minimum_water_area_km2: minimum_area,
+            mean_water_area_km2: mean_area,
+            maximum_water_area_km2: maximum_area,
+            mean_wetted_depth_m: mean_wetted_depth,
+            maximum_mean_depth_m: maximum_mean_depth,
+            salinity_index: ((annual_evaporation + annual_seepage) / annual_total.max(1e-12))
+                .clamp(0.0, 10.0),
+            monthly_direct_inflow_km3: state.direct_inflow_km3,
+            monthly_upstream_inflow_km3: state.monthly_upstream_inflow_km3,
+            monthly_total_inflow_km3: state.monthly_total_inflow_km3,
+            monthly_evaporation_km3: state.monthly_evaporation_km3,
+            monthly_seepage_km3: state.monthly_seepage_km3,
+            monthly_overflow_km3: state.monthly_overflow_km3,
+            monthly_storage_km3: state.monthly_storage_km3,
+            monthly_water_area_km2: state.monthly_water_area_km2,
+        });
+        annual_direct_total += annual_direct;
+        annual_evaporation_total += annual_evaporation;
+        annual_seepage_total += annual_seepage;
+        annual_terminal_overflow_total += annual_terminal_overflow;
+        annual_storage_change_total += annual_storage_change;
+    }
+
+    let mut cells = Vec::new();
+    let relief_divisor = (config.refinement_factor as f64).sqrt();
+    let mut minimum_fraction = 1.0f64;
+    let mut maximum_fraction = 0.0f64;
+    let mut fraction_valid = true;
+    for (candidate, state) in states.iter().enumerate() {
+        let class_code = candidates[candidate].class_code;
+        for (member_index, &row) in state.members.iter().enumerate() {
+            let span = (inputs.parent_relief_m[row] as f64 / relief_divisor
+                * config.subgrid_relief_scale)
+                .max(config.minimum_subgrid_relief_m);
+            let mut monthly = [0.0f32; MONTHS];
+            for (month, value) in monthly.iter_mut().enumerate() {
+                let level = curve_level(&state.hypsometry, state.monthly_storage_km3[month]);
+                *value = inundation(
+                    inputs.terrain_elevation_m[row],
+                    span,
+                    level,
+                    config.maximum_connected_inundation_fraction,
+                )
+                .0 as f32;
+                minimum_fraction = minimum_fraction.min(*value as f64);
+                maximum_fraction = maximum_fraction.max(*value as f64);
+                fraction_valid &= value.is_finite() && (0.0..=1.0).contains(value);
+            }
+            let minimum = monthly.iter().copied().fold(f32::INFINITY, f32::min);
+            let maximum = monthly.iter().copied().fold(0.0f32, f32::max);
+            let mean =
+                monthly.iter().map(|value| *value as f64).sum::<f64>() as f32 / MONTHS as f32;
+            cells.push(SurfaceWaterCellRecord {
+                fine_cell_id: inputs.cell_ids[row],
+                depression_id: inputs.candidate_ids[candidate],
+                class_code,
+                potential_inundation_fraction: state.hypsometry.potential_fraction_by_member
+                    [member_index],
+                minimum_inundation_fraction: minimum,
+                mean_inundation_fraction: mean,
+                maximum_inundation_fraction: maximum,
+                monthly_inundation_fraction: monthly,
+            });
+        }
+    }
+    cells.sort_by_key(|record| record.fine_cell_id);
+
+    let active_source_area = (0..inputs.cell_ids.len())
+        .filter(|&row| inputs.source_active[row] != 0)
+        .map(|row| inputs.area_km2[row])
+        .sum::<f64>();
+    let owned_source_cell_count = (0..inputs.cell_ids.len())
+        .filter(|&row| inputs.source_active[row] != 0 && domain.owner[row] >= 0)
+        .count();
+    let owned_catchment_area = states
+        .iter()
+        .map(|state| state.catchment_area_km2)
+        .sum::<f64>();
+    let potential_water_area = states
+        .iter()
+        .map(|state| state.hypsometry.area_km2[HYPSOMETRY_BINS - 1])
+        .sum::<f64>();
+    let storage_capacity = states
+        .iter()
+        .map(|state| state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1])
+        .sum::<f64>();
+    let residual = annual_direct_total
+        - annual_evaporation_total
+        - annual_seepage_total
+        - annual_terminal_overflow_total
+        - annual_storage_change_total;
+    let scale = annual_direct_total
+        .max(annual_evaporation_total + annual_seepage_total + annual_terminal_overflow_total)
+        .max(1e-12);
+    let storage_valid = states.iter().all(|state| {
+        let capacity = state.hypsometry.volume_km3[HYPSOMETRY_BINS - 1];
+        state.monthly_storage_km3.iter().all(|storage| {
+            storage.is_finite() && *storage >= -1e-12 && *storage <= capacity + 1e-12
+        })
+    });
+    let stats = SurfaceWaterStats {
+        cell_count: inputs.cell_ids.len() as i32,
+        candidate_count: states.len() as i32,
+        candidate_cell_count: cells.len() as i32,
+        owned_source_cell_count: owned_source_cell_count as i32,
+        dry_count: class_counts[CLASS_DRY as usize] as i32,
+        transient_count: class_counts[CLASS_TRANSIENT as usize] as i32,
+        seasonal_lake_count: class_counts[CLASS_SEASONAL_LAKE as usize] as i32,
+        permanent_lake_count: class_counts[CLASS_PERMANENT_LAKE as usize] as i32,
+        hydrologic_wetland_count: class_counts[CLASS_HYDROLOGIC_WETLAND as usize] as i32,
+        graph_valid: 1,
+        convergence_valid: i32::from(convergence_valid),
+        fraction_valid: i32::from(fraction_valid),
+        storage_valid: i32::from(storage_valid),
+        direct_catchment_valid: i32::from(
+            states
+                .iter()
+                .map(|state| state.catchment_cell_count)
+                .sum::<usize>()
+                == owned_source_cell_count,
+        ),
+        maximum_solver_iterations_used: states
+            .iter()
+            .map(|state| state.solver_iterations)
+            .max()
+            .unwrap_or(0) as i32,
+        active_source_area_km2: active_source_area,
+        owned_catchment_area_km2: owned_catchment_area,
+        potential_water_area_km2: potential_water_area,
+        storage_capacity_km3: storage_capacity,
+        annual_direct_inflow_km3: annual_direct_total,
+        annual_evaporation_km3: annual_evaporation_total,
+        annual_seepage_km3: annual_seepage_total,
+        annual_terminal_overflow_km3: annual_terminal_overflow_total,
+        annual_storage_change_km3: annual_storage_change_total,
+        water_balance_residual_km3: residual,
+        water_balance_relative_error: residual.abs() / scale,
+        minimum_inundation_fraction: minimum_fraction,
+        maximum_inundation_fraction: maximum_fraction,
+        dry_mean_water_area_km2: class_areas[CLASS_DRY as usize],
+        transient_mean_water_area_km2: class_areas[CLASS_TRANSIENT as usize],
+        seasonal_lake_mean_water_area_km2: class_areas[CLASS_SEASONAL_LAKE as usize],
+        permanent_lake_mean_water_area_km2: class_areas[CLASS_PERMANENT_LAKE as usize],
+        hydrologic_wetland_mean_water_area_km2: class_areas[CLASS_HYDROLOGIC_WETLAND as usize],
+    };
+    Ok(Outcome {
+        candidates,
+        cells,
+        stats,
+    })
+}
+
+fn into_raw_array<T>(values: Vec<T>) -> (*mut T, usize) {
+    let mut values = values.into_boxed_slice();
+    let result = (values.as_mut_ptr(), values.len());
+    let _ = Box::leak(values);
+    result
+}
+
+fn free_raw_array<T>(data: *mut T, len: usize) {
+    if !data.is_null() {
+        unsafe {
+            let values = std::ptr::slice_from_raw_parts_mut(data, len);
+            drop(Box::from_raw(values));
+        }
+    }
+}
+
+unsafe fn read_slice<'a, T>(pointer: *const T, len: usize) -> &'a [T] {
+    unsafe { slice::from_raw_parts(pointer, len) }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+/// Run the refined monthly surface-water balance.
+///
+/// # Safety
+///
+/// Every input pointer must reference a contiguous buffer of the declared
+/// length. Output pointers must be valid and may not alias input buffers.
+pub unsafe extern "C" fn surface_water_run(
+    config: SurfaceWaterConfig,
+    cell_count: usize,
+    candidate_count: usize,
+    cell_ids: *const i32,
+    receiver_ids: *const i32,
+    depression_ids: *const i32,
+    source_active: *const u8,
+    area_km2: *const f64,
+    terrain_elevation_m: *const f64,
+    hydrologic_elevation_m: *const f64,
+    parent_relief_m: *const f32,
+    monthly_runoff_mm: *const f32,
+    monthly_evaporation_mm: *const f32,
+    sediment_accommodation: *const f32,
+    candidate_ids: *const i32,
+    spill_receiver_ids: *const i32,
+    candidates_out: *mut SurfaceWaterCandidateArray,
+    cells_out: *mut SurfaceWaterCellArray,
+    stats_out: *mut SurfaceWaterStats,
+) -> i32 {
+    if cell_count == 0
+        || candidate_count == 0
+        || cell_ids.is_null()
+        || receiver_ids.is_null()
+        || depression_ids.is_null()
+        || source_active.is_null()
+        || area_km2.is_null()
+        || terrain_elevation_m.is_null()
+        || hydrologic_elevation_m.is_null()
+        || parent_relief_m.is_null()
+        || monthly_runoff_mm.is_null()
+        || monthly_evaporation_mm.is_null()
+        || sediment_accommodation.is_null()
+        || candidate_ids.is_null()
+        || spill_receiver_ids.is_null()
+        || candidates_out.is_null()
+        || cells_out.is_null()
+        || stats_out.is_null()
+    {
+        return 5;
+    }
+    let inputs = Inputs {
+        cell_ids: unsafe { read_slice(cell_ids, cell_count) },
+        receiver_ids: unsafe { read_slice(receiver_ids, cell_count) },
+        depression_ids: unsafe { read_slice(depression_ids, cell_count) },
+        source_active: unsafe { read_slice(source_active, cell_count) },
+        area_km2: unsafe { read_slice(area_km2, cell_count) },
+        terrain_elevation_m: unsafe { read_slice(terrain_elevation_m, cell_count) },
+        hydrologic_elevation_m: unsafe { read_slice(hydrologic_elevation_m, cell_count) },
+        parent_relief_m: unsafe { read_slice(parent_relief_m, cell_count) },
+        monthly_runoff_mm: unsafe { read_slice(monthly_runoff_mm, cell_count * MONTHS) },
+        monthly_evaporation_mm: unsafe { read_slice(monthly_evaporation_mm, cell_count * MONTHS) },
+        sediment_accommodation: unsafe { read_slice(sediment_accommodation, cell_count) },
+        candidate_ids: unsafe { read_slice(candidate_ids, candidate_count) },
+        spill_receiver_ids: unsafe { read_slice(spill_receiver_ids, candidate_count) },
+    };
+    match run_balance(config, &inputs) {
+        Ok(outcome) => {
+            let (candidate_data, candidate_len) = into_raw_array(outcome.candidates);
+            let (cell_data, cell_len) = into_raw_array(outcome.cells);
+            unsafe {
+                *candidates_out = SurfaceWaterCandidateArray {
+                    data: candidate_data,
+                    len: candidate_len,
+                };
+                *cells_out = SurfaceWaterCellArray {
+                    data: cell_data,
+                    len: cell_len,
+                };
+                *stats_out = outcome.stats;
+            }
+            0
+        }
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn surface_water_free_candidates(array: SurfaceWaterCandidateArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[no_mangle]
+pub extern "C" fn surface_water_free_cells(array: SurfaceWaterCellArray) {
+    free_raw_array(array.data, array.len);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> SurfaceWaterConfig {
+        SurfaceWaterConfig {
+            refinement_factor: 4,
+            minimum_solver_iterations: 4,
+            maximum_solver_iterations: 64,
+            transient_max_months: 3,
+            permanent_min_months: 12,
+            convergence_tolerance_fraction: 1e-8,
+            open_water_evaporation_factor: 1.0,
+            seepage_mm_year: 0.0,
+            subgrid_relief_scale: 1.0,
+            minimum_subgrid_relief_m: 10.0,
+            maximum_connected_inundation_fraction: 1.0,
+            minimum_wet_area_fraction: 0.01,
+            wetland_max_mean_depth_m: 3.0,
+        }
+    }
+
+    #[test]
+    fn rejects_ambiguous_classification_thresholds() {
+        let mut invalid_wet_area = config();
+        invalid_wet_area.minimum_wet_area_fraction = 0.0;
+        assert_eq!(validate_config(invalid_wet_area), Err(1));
+
+        let mut invalid_permanence = config();
+        invalid_permanence.permanent_min_months = 11;
+        assert_eq!(validate_config(invalid_permanence), Err(1));
+    }
+
+    #[test]
+    fn exported_struct_sizes_match_rust_layouts() {
+        assert_eq!(
+            surface_water_native_struct_size(0),
+            mem::size_of::<SurfaceWaterConfig>()
+        );
+        assert_eq!(
+            surface_water_native_struct_size(1),
+            mem::size_of::<SurfaceWaterCandidateRecord>()
+        );
+        assert_eq!(
+            surface_water_native_struct_size(2),
+            mem::size_of::<SurfaceWaterCellRecord>()
+        );
+        assert_eq!(
+            surface_water_native_struct_size(3),
+            mem::size_of::<SurfaceWaterStats>()
+        );
+        assert_eq!(surface_water_native_struct_size(99), 0);
+    }
+
+    #[test]
+    fn wet_candidate_fills_spills_and_conserves_water() {
+        let cell_ids = [0, 1, 2];
+        let receiver_ids = [1, 2, -1];
+        let depression_ids = [-1, 1, -1];
+        let runoff = [100.0f32; MONTHS * 3];
+        let evaporation = [0.0f32; MONTHS * 3];
+        let inputs = Inputs {
+            cell_ids: &cell_ids,
+            receiver_ids: &receiver_ids,
+            depression_ids: &depression_ids,
+            source_active: &[1, 1, 1],
+            area_km2: &[1.0; 3],
+            terrain_elevation_m: &[2.0, -10.0, 2.0],
+            hydrologic_elevation_m: &[2.0, 0.0, 2.0],
+            parent_relief_m: &[20.0; 3],
+            monthly_runoff_mm: &runoff,
+            monthly_evaporation_mm: &evaporation,
+            sediment_accommodation: &[0.5; 3],
+            candidate_ids: &[1],
+            spill_receiver_ids: &[2],
+        };
+        let outcome = run_balance(config(), &inputs).expect("valid balance");
+        assert_eq!(outcome.stats.graph_valid, 1);
+        assert_eq!(outcome.stats.convergence_valid, 1);
+        assert_eq!(outcome.candidates[0].class_code, CLASS_PERMANENT_LAKE);
+        assert!(outcome.candidates[0].annual_overflow_km3 > 0.0);
+        assert!(outcome.stats.water_balance_relative_error < 1e-12);
+        assert_eq!(outcome.cells.len(), 1);
+        assert!(outcome.cells[0].mean_inundation_fraction > 0.0);
+    }
+
+    #[test]
+    fn candidate_without_runoff_is_dry() {
+        let cell_ids = [0, 1];
+        let receiver_ids = [1, -1];
+        let depression_ids = [5, -1];
+        let runoff = [0.0f32; MONTHS * 2];
+        let evaporation = [100.0f32; MONTHS * 2];
+        let inputs = Inputs {
+            cell_ids: &cell_ids,
+            receiver_ids: &receiver_ids,
+            depression_ids: &depression_ids,
+            source_active: &[1, 1],
+            area_km2: &[1.0; 2],
+            terrain_elevation_m: &[-5.0, 2.0],
+            hydrologic_elevation_m: &[0.0, 2.0],
+            parent_relief_m: &[20.0; 2],
+            monthly_runoff_mm: &runoff,
+            monthly_evaporation_mm: &evaporation,
+            sediment_accommodation: &[0.0; 2],
+            candidate_ids: &[5],
+            spill_receiver_ids: &[1],
+        };
+        let outcome = run_balance(config(), &inputs).expect("valid dry balance");
+        assert_eq!(outcome.candidates[0].class_code, CLASS_DRY);
+        assert_eq!(outcome.candidates[0].mean_water_area_km2, 0.0);
+    }
+
+    #[test]
+    fn upstream_overflow_enters_downstream_candidate_once() {
+        let cell_ids = [0, 1, 2, 3, 4];
+        let receiver_ids = [1, 2, 3, 4, -1];
+        let depression_ids = [-1, 11, -1, 33, -1];
+        let mut runoff = [0.0f32; MONTHS * 5];
+        for month in 0..MONTHS {
+            runoff[month * 5] = 1_000.0;
+        }
+        let evaporation = [0.0f32; MONTHS * 5];
+        let inputs = Inputs {
+            cell_ids: &cell_ids,
+            receiver_ids: &receiver_ids,
+            depression_ids: &depression_ids,
+            source_active: &[1; 5],
+            area_km2: &[1.0; 5],
+            terrain_elevation_m: &[2.0, -10.0, 2.0, -10.0, 2.0],
+            hydrologic_elevation_m: &[2.0, 0.0, 2.0, 0.0, 2.0],
+            parent_relief_m: &[20.0; 5],
+            monthly_runoff_mm: &runoff,
+            monthly_evaporation_mm: &evaporation,
+            sediment_accommodation: &[0.5; 5],
+            candidate_ids: &[11, 33],
+            spill_receiver_ids: &[2, 4],
+        };
+        let outcome = run_balance(config(), &inputs).expect("valid candidate chain");
+        assert_eq!(outcome.candidates[0].downstream_depression_id, 33);
+        assert!(outcome.candidates[1].annual_upstream_inflow_km3 > 0.0);
+        assert!(outcome.stats.water_balance_relative_error < 1e-12);
+    }
+}

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -9,6 +9,7 @@ from . import hydrology  # noqa: F401
 from . import basin_refinement  # noqa: F401
 from . import basin_erosion  # noqa: F401
 from . import hydrology_pass2  # noqa: F401
+from . import surface_water  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -29,6 +30,7 @@ def ensure_builtin_stages() -> None:
         "basin_refinement": basin_refinement,
         "basin_erosion": basin_erosion,
         "hydrology_pass2": hydrology_pass2,
+        "surface_water": surface_water,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/hydrology_pass2.py
+++ b/src/map_maker/pipeline/stages/hydrology_pass2.py
@@ -44,9 +44,9 @@ class HydrologyPass2Config:
         }
         if (
             not np.isfinite(values["minimum_depression_depth_m"])
-            or values["minimum_depression_depth_m"] < 0.0
+            or values["minimum_depression_depth_m"] <= 0.0
         ):
-            raise ValueError("minimum_depression_depth_m must be finite and non-negative")
+            raise ValueError("minimum_depression_depth_m must be finite and positive")
         for name in (
             "maximum_receiver_change_fraction",
             "maximum_receiver_change_cell_fraction",
@@ -200,11 +200,28 @@ def _depression_catalog(cells: pa.Table) -> tuple[pa.Table, dict[str, float | in
     level = np.asarray(cells["stabilized_hydrologic_elevation_m"], dtype=np.float64)
     receiver_depression = np.full(len(cells), -1, dtype=np.int32)
     routed = receiver_ids >= 0
+    target_rows = np.full(len(cells), -1, dtype=np.int64)
     if np.any(routed):
-        receiver_rows = _lookup_rows(
+        target_rows[routed] = _lookup_rows(
             cell_ids, receiver_ids[routed], label="depression spill receiver"
         )
-        receiver_depression[routed] = stabilized_ids[receiver_rows]
+        receiver_depression[routed] = stabilized_ids[target_rows[routed]]
+    upstream_count = np.zeros(len(cells), dtype=np.int32)
+    np.add.at(upstream_count, target_rows[routed], 1)
+    ready = deque(np.flatnonzero(upstream_count == 0).tolist())
+    downstream_rank = np.full(len(cells), -1, dtype=np.int64)
+    processed = 0
+    while ready:
+        row = ready.popleft()
+        downstream_rank[row] = processed
+        processed += 1
+        target = target_rows[row]
+        if target >= 0:
+            upstream_count[target] -= 1
+            if upstream_count[target] == 0:
+                ready.append(int(target))
+    if processed != len(cells):
+        raise RuntimeError("local depression candidates use a cyclic receiver graph")
 
     rows: list[dict[str, object]] = []
     new_area = float(np.sum(area[(stabilized_ids >= 0) & (baseline_ids < 0)]))
@@ -214,7 +231,12 @@ def _depression_catalog(cells: pa.Table) -> tuple[pa.Table, dict[str, float | in
         boundary_rows = np.flatnonzero(boundary)
         if len(boundary_rows) == 0:
             raise RuntimeError("local depression candidate has no spill receiver")
-        spill_row = min(boundary_rows, key=lambda row: (float(level[row]), int(cell_ids[row])))
+        if float(np.ptp(level[mask])) > 1e-6:
+            raise RuntimeError("local depression candidate does not have a level spill surface")
+        spill_row = max(
+            boundary_rows,
+            key=lambda row: (int(downstream_rank[row]), -int(cell_ids[row])),
+        )
         overlaps = baseline_ids[mask]
         overlap_area = area[mask]
         valid_overlap = overlaps >= 0
@@ -494,7 +516,7 @@ def _cube_net_visualizer(result, request: VisualizationRequest) -> Visualization
         "HydrologyCorrectionCatalog",
         "HydrologyPass2Metadata",
     ),
-    version="v1",
+    version="v2",
     native_libraries=("hydrology_pass2_native",),
     visualizer=_cube_net_visualizer,
 )

--- a/src/map_maker/pipeline/stages/surface_water.py
+++ b/src/map_maker/pipeline/stages/surface_water.py
@@ -1,0 +1,905 @@
+"""Monthly fractional surface-water balance over refined local depressions."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+import pyarrow as pa
+from PIL import Image
+
+from .._surface_water_native import SURFACE_WATER_CLASSES, run_surface_water_balance
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+
+MONTHS = 12
+
+
+@dataclass(frozen=True)
+class SurfaceWaterConfig:
+    minimum_solver_iterations: int = 8
+    maximum_solver_iterations: int = 64
+    transient_max_months: int = 3
+    permanent_min_months: int = 12
+    convergence_tolerance_fraction: float = 1e-6
+    open_water_evaporation_factor: float = 1.15
+    seepage_mm_year: float = 30.0
+    subgrid_relief_scale: float = 1.0
+    minimum_subgrid_relief_m: float = 10.0
+    maximum_connected_inundation_fraction: float = 0.25
+    minimum_wet_area_fraction: float = 0.01
+    wetland_max_mean_depth_m: float = 3.0
+    outlet_erosion_score_threshold: float = 0.30
+    outlet_erosion_depth_scale_m: float = 200.0
+    minimum_outlet_erosion_discharge_m3s: float = 0.10
+    maximum_water_balance_relative_error: float = 1e-9
+    maximum_area_reconstruction_relative_error: float = 1e-6
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "SurfaceWaterConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown surface-water controls: {', '.join(sorted(unknown))}")
+        integer_names = {
+            "minimum_solver_iterations",
+            "maximum_solver_iterations",
+            "transient_max_months",
+            "permanent_min_months",
+        }
+        values = {
+            name: (
+                int(mapping.get(name, field.default))
+                if name in integer_names
+                else float(mapping.get(name, field.default))
+            )
+            for name, field in cls.__dataclass_fields__.items()
+        }
+        config = cls(**values)
+        if not 1 <= config.minimum_solver_iterations <= config.maximum_solver_iterations <= 256:
+            raise ValueError(
+                "surface-water solver iterations must satisfy 1 <= minimum <= maximum <= 256"
+            )
+        if not 0 <= config.transient_max_months < config.permanent_min_months == MONTHS:
+            raise ValueError(
+                "surface-water month thresholds must satisfy 0 <= transient < permanent == 12"
+            )
+        bounds = {
+            "convergence_tolerance_fraction": (1e-12, 0.1),
+            "open_water_evaporation_factor": (0.0, 10.0),
+            "seepage_mm_year": (0.0, 10_000.0),
+            "subgrid_relief_scale": (0.01, 10.0),
+            "minimum_subgrid_relief_m": (0.1, 1_000.0),
+            "maximum_connected_inundation_fraction": (0.01, 1.0),
+            "wetland_max_mean_depth_m": (0.1, 100.0),
+            "outlet_erosion_score_threshold": (0.0, 1.0),
+            "outlet_erosion_depth_scale_m": (1.0, 5_000.0),
+            "minimum_outlet_erosion_discharge_m3s": (0.0, 100_000.0),
+            "maximum_water_balance_relative_error": (1e-14, 0.01),
+            "maximum_area_reconstruction_relative_error": (1e-12, 0.01),
+        }
+        for name, (minimum, maximum) in bounds.items():
+            value = getattr(config, name)
+            if not np.isfinite(value) or not minimum <= value <= maximum:
+                raise ValueError(f"{name} must be finite and in [{minimum}, {maximum}]")
+        if (
+            not np.isfinite(config.minimum_wet_area_fraction)
+            or not 0.0 < config.minimum_wet_area_fraction <= 1.0
+        ):
+            raise ValueError("minimum_wet_area_fraction must be finite and in (0, 1]")
+        return config
+
+
+def _artifact_table(result, name: str) -> pa.Table:
+    record = result.artifact_records.get(name)
+    if record is None or not isinstance(record.value, pa.Table):
+        raise KeyError(f"Missing dependency table '{name}'")
+    return record.value
+
+
+def _artifact_array(result, name: str) -> np.ndarray:
+    record = result.artifact_records.get(name)
+    if record is None or record.value is None:
+        raise KeyError(f"Missing dependency artifact '{name}'")
+    value = record.value
+    return np.asarray(value.array() if hasattr(value, "array") else value)
+
+
+def _column(table: pa.Table, name: str, dtype: np.dtype) -> np.ndarray:
+    return np.ascontiguousarray(
+        table[name].combine_chunks().to_numpy(zero_copy_only=False), dtype=dtype
+    )
+
+
+def _lookup_rows(ids: np.ndarray, query: np.ndarray, *, label: str) -> np.ndarray:
+    order = np.argsort(ids)
+    sorted_ids = ids[order]
+    positions = np.searchsorted(sorted_ids, query)
+    if np.any(positions >= len(sorted_ids)) or np.any(sorted_ids[positions] != query):
+        raise RuntimeError(f"{label} references an unknown identifier")
+    return order[positions]
+
+
+def _fixed_list(values: np.ndarray, value_type: pa.DataType) -> pa.FixedSizeListArray:
+    values = np.asarray(values)
+    return pa.FixedSizeListArray.from_arrays(
+        pa.array(values.reshape(-1), type=value_type), values.shape[1]
+    )
+
+
+def _candidate_table(
+    source: pa.Table,
+    records: np.ndarray,
+    final_class_codes: np.ndarray,
+    erosion_score: np.ndarray,
+    erosion_required: np.ndarray,
+    recommended_incision_m: np.ndarray,
+    classification_reason: np.ndarray,
+) -> pa.Table:
+    source_ids = np.asarray(source["depression_id"], dtype=np.int32)
+    if not np.array_equal(source_ids, records["depression_id"]):
+        raise RuntimeError("surface-water kernel changed candidate order or identity")
+    pre_adjustment_classes = np.array(
+        [SURFACE_WATER_CLASSES[int(code)] for code in records["class_code"]], dtype=object
+    )
+    classes = np.array(
+        [SURFACE_WATER_CLASSES[int(code)] for code in final_class_codes], dtype=object
+    )
+    table = source
+    integer_fields = (
+        "downstream_depression_id",
+        "catchment_cell_count",
+        "wet_month_count",
+        "solver_iterations",
+    )
+    for name in integer_fields:
+        table = table.append_column(name, pa.array(records[name], type=pa.int32()))
+    table = table.append_column(
+        "pre_adjustment_class_code", pa.array(records["class_code"], type=pa.int32())
+    )
+    table = table.append_column(
+        "pre_adjustment_surface_water_class",
+        pa.array(pre_adjustment_classes, type=pa.string()),
+    )
+    table = table.append_column("class_code", pa.array(final_class_codes, type=pa.int32()))
+    table = table.append_column("surface_water_class", pa.array(classes, type=pa.string()))
+    table = table.append_column(
+        "classification_reason", pa.array(classification_reason, type=pa.string())
+    )
+    table = table.append_column("converged", pa.array(records["converged"] != 0, type=pa.bool_()))
+    table = table.append_column(
+        "open_outlet", pa.array(records["open_outlet"] != 0, type=pa.bool_())
+    )
+    table = table.append_column(
+        "outlet_erosion_required", pa.array(erosion_required, type=pa.bool_())
+    )
+    table = table.append_column("outlet_erosion_score", pa.array(erosion_score, type=pa.float64()))
+    table = table.append_column(
+        "recommended_outlet_incision_m",
+        pa.array(recommended_incision_m, type=pa.float64()),
+    )
+    scalar_fields = (
+        "catchment_area_km2",
+        "potential_water_area_km2",
+        "storage_capacity_km3",
+        "annual_direct_inflow_km3",
+        "annual_upstream_inflow_km3",
+        "annual_total_inflow_km3",
+        "annual_evaporation_km3",
+        "annual_seepage_km3",
+        "annual_overflow_km3",
+        "annual_terminal_overflow_km3",
+        "annual_storage_change_km3",
+        "water_balance_residual_km3",
+        "hydroperiod_fraction",
+        "minimum_water_area_km2",
+        "mean_water_area_km2",
+        "maximum_water_area_km2",
+        "mean_wetted_depth_m",
+        "maximum_mean_depth_m",
+        "salinity_index",
+    )
+    for name in scalar_fields:
+        table = table.append_column(name, pa.array(records[name], type=pa.float64()))
+    monthly_fields = (
+        "monthly_direct_inflow_km3",
+        "monthly_upstream_inflow_km3",
+        "monthly_total_inflow_km3",
+        "monthly_evaporation_km3",
+        "monthly_seepage_km3",
+        "monthly_overflow_km3",
+        "monthly_storage_km3",
+        "monthly_water_area_km2",
+    )
+    for name in monthly_fields:
+        table = table.append_column(name, _fixed_list(records[name], pa.float64()))
+    return table
+
+
+def _cell_table(
+    records: np.ndarray, candidate_ids: np.ndarray, final_class_codes: np.ndarray
+) -> pa.Table:
+    candidate_rows = _lookup_rows(
+        candidate_ids, records["depression_id"], label="surface-water cell candidate"
+    )
+    cell_class_codes = final_class_codes[candidate_rows]
+    classes = np.array(
+        [SURFACE_WATER_CLASSES[int(code)] for code in cell_class_codes], dtype=object
+    )
+    return pa.table(
+        {
+            "fine_cell_id": pa.array(records["fine_cell_id"], type=pa.int32()),
+            "depression_id": pa.array(records["depression_id"], type=pa.int32()),
+            "pre_adjustment_class_code": pa.array(records["class_code"], type=pa.int32()),
+            "class_code": pa.array(cell_class_codes, type=pa.int32()),
+            "surface_water_class": pa.array(classes, type=pa.string()),
+            "potential_inundation_fraction": pa.array(
+                records["potential_inundation_fraction"], type=pa.float32()
+            ),
+            "minimum_inundation_fraction": pa.array(
+                records["minimum_inundation_fraction"], type=pa.float32()
+            ),
+            "mean_inundation_fraction": pa.array(
+                records["mean_inundation_fraction"], type=pa.float32()
+            ),
+            "maximum_inundation_fraction": pa.array(
+                records["maximum_inundation_fraction"], type=pa.float32()
+            ),
+            "monthly_inundation_fraction": _fixed_list(
+                records["monthly_inundation_fraction"], pa.float32()
+            ),
+        }
+    )
+
+
+def _monthly_table(records: np.ndarray) -> pa.Table:
+    return pa.table(
+        {
+            "depression_id": pa.array(np.repeat(records["depression_id"], MONTHS), type=pa.int32()),
+            "month": pa.array(
+                np.tile(np.arange(1, MONTHS + 1, dtype=np.int8), len(records)), type=pa.int8()
+            ),
+            "direct_inflow_km3": pa.array(
+                records["monthly_direct_inflow_km3"].reshape(-1), type=pa.float64()
+            ),
+            "upstream_inflow_km3": pa.array(
+                records["monthly_upstream_inflow_km3"].reshape(-1), type=pa.float64()
+            ),
+            "total_inflow_km3": pa.array(
+                records["monthly_total_inflow_km3"].reshape(-1), type=pa.float64()
+            ),
+            "evaporation_km3": pa.array(
+                records["monthly_evaporation_km3"].reshape(-1), type=pa.float64()
+            ),
+            "seepage_km3": pa.array(records["monthly_seepage_km3"].reshape(-1), type=pa.float64()),
+            "overflow_km3": pa.array(
+                records["monthly_overflow_km3"].reshape(-1), type=pa.float64()
+            ),
+            "storage_km3": pa.array(records["monthly_storage_km3"].reshape(-1), type=pa.float64()),
+            "water_area_km2": pa.array(
+                records["monthly_water_area_km2"].reshape(-1), type=pa.float64()
+            ),
+        }
+    )
+
+
+def _outlet_erosion_feedback(
+    config: SurfaceWaterConfig,
+    cells: pa.Table,
+    candidates: pa.Table,
+    candidate_records: np.ndarray,
+    cell_records: np.ndarray,
+    rock_strength: np.ndarray,
+    accommodation: np.ndarray,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    dict[str, object],
+    np.ndarray,
+]:
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    source_rows = _lookup_rows(
+        cell_ids, cell_records["fine_cell_id"], label="surface-water feedback cell"
+    )
+    candidate_ids = np.asarray(candidates["depression_id"], dtype=np.int32)
+    candidate_rows = _lookup_rows(
+        candidate_ids,
+        cell_records["depression_id"],
+        label="surface-water feedback candidate",
+    )
+    covered_area = np.asarray(cells["area_km2"], dtype=np.float64)[source_rows] * cell_records[
+        "potential_inundation_fraction"
+    ].astype(np.float64)
+    support_area = np.zeros(len(candidates), dtype=np.float64)
+    rock_total = np.zeros(len(candidates), dtype=np.float64)
+    accommodation_total = np.zeros(len(candidates), dtype=np.float64)
+    np.add.at(support_area, candidate_rows, covered_area)
+    np.add.at(rock_total, candidate_rows, covered_area * rock_strength[source_rows])
+    np.add.at(
+        accommodation_total,
+        candidate_rows,
+        covered_area * accommodation[source_rows],
+    )
+    mean_rock = rock_total / np.maximum(support_area, 1e-12)
+    mean_accommodation = accommodation_total / np.maximum(support_area, 1e-12)
+    maximum_head_m = np.asarray(candidates["maximum_fill_depth_m"], dtype=np.float64)
+    annual_overflow_km3 = candidate_records["annual_overflow_km3"]
+    mean_overflow_m3s = annual_overflow_km3 * 1e9 / (365.2422 * 86_400.0)
+    depth_score = np.clip(maximum_head_m / config.outlet_erosion_depth_scale_m, 0.0, 1.0)
+    discharge_score = np.clip(np.log1p(mean_overflow_m3s) / 6.0, 0.0, 1.0)
+    erosion_score = (
+        0.35 * depth_score
+        + 0.30 * (1.0 - mean_rock)
+        + 0.15 * (1.0 - mean_accommodation)
+        + 0.20 * discharge_score
+    )
+    pre_adjustment_codes = candidate_records["class_code"]
+    lake_like = (pre_adjustment_codes == 2) | (pre_adjustment_codes == 3)
+    erosion_required = (
+        lake_like
+        & (mean_overflow_m3s > 0.0)
+        & (mean_overflow_m3s >= config.minimum_outlet_erosion_discharge_m3s)
+        & (erosion_score >= config.outlet_erosion_score_threshold)
+    )
+    final_class_codes = pre_adjustment_codes.copy()
+    final_class_codes[erosion_required] = 1
+    recommended_incision_m = np.where(
+        erosion_required,
+        maximum_head_m * np.clip(0.20 + erosion_score, 0.0, 0.75),
+        0.0,
+    )
+    reasons = np.select(
+        [
+            erosion_required,
+            pre_adjustment_codes == 0,
+            pre_adjustment_codes == 1,
+            pre_adjustment_codes == 2,
+            pre_adjustment_codes == 3,
+            pre_adjustment_codes == 4,
+        ],
+        [
+            "outlet_erosion_feedback",
+            "no_material_water",
+            "short_hydroperiod",
+            "seasonal_hydroperiod",
+            "year_round_inundation",
+            "shallow_recurrent_inundation",
+        ],
+        default="unclassified",
+    )
+    mean_area = candidate_records["mean_water_area_km2"]
+    feedback_metadata: dict[str, object] = {
+        "outlet_erosion_required_count": int(np.count_nonzero(erosion_required)),
+        "outlet_erosion_required_mean_water_area_km2": float(np.sum(mean_area[erosion_required])),
+        "maximum_outlet_erosion_score": float(np.max(erosion_score)),
+        "maximum_recommended_outlet_incision_m": float(np.max(recommended_incision_m)),
+        "outlet_erosion_score_semantics": ("head_weak_rock_low_accommodation_sustained_overflow"),
+        "pre_adjustment_water_area_semantics": (
+            "monthly_fill_spill_state_before_required_outlet_incision"
+        ),
+        "classification_reasons": sorted(set(str(value) for value in reasons)),
+    }
+    return (
+        final_class_codes,
+        erosion_score,
+        erosion_required,
+        recommended_incision_m,
+        feedback_metadata,
+        reasons,
+    )
+
+
+def _catchment_audit(
+    cells: pa.Table,
+    candidates: pa.Table,
+    monthly_runoff_mm: np.ndarray,
+) -> dict[str, float | int]:
+    cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    receiver_ids = np.asarray(cells["stabilized_receiver_id"], dtype=np.int32)
+    depression_ids = np.asarray(cells["stabilized_depression_id"], dtype=np.int32)
+    source_active = np.asarray(cells["source_active"])
+    area = np.asarray(cells["area_km2"], dtype=np.float64)
+    candidate_ids = np.asarray(candidates["depression_id"], dtype=np.int32)
+    candidate_by_id = {int(value): index for index, value in enumerate(candidate_ids)}
+    routed = receiver_ids >= 0
+    target_rows = np.full(len(cells), -1, dtype=np.int64)
+    if np.any(routed):
+        target_rows[routed] = _lookup_rows(cell_ids, receiver_ids[routed], label="receiver")
+    upstream_count = np.zeros(len(cells), dtype=np.int32)
+    np.add.at(upstream_count, target_rows[routed], 1)
+    ready = deque(np.flatnonzero(upstream_count == 0).tolist())
+    order: list[int] = []
+    while ready:
+        row = ready.popleft()
+        order.append(row)
+        target = target_rows[row]
+        if target >= 0:
+            upstream_count[target] -= 1
+            if upstream_count[target] == 0:
+                ready.append(int(target))
+    if len(order) != len(cells):
+        raise RuntimeError("surface-water audit found a cyclic stabilized cell graph")
+    owner = np.full(len(cells), -1, dtype=np.int32)
+    for row in reversed(order):
+        depression_id = int(depression_ids[row])
+        if depression_id >= 0:
+            owner[row] = candidate_by_id[depression_id]
+        elif target_rows[row] >= 0:
+            owner[row] = owner[target_rows[row]]
+
+    direct = np.zeros((len(candidates), MONTHS), dtype=np.float64)
+    owned = source_active & (owner >= 0)
+    for month in range(MONTHS):
+        np.add.at(
+            direct[:, month],
+            owner[owned],
+            monthly_runoff_mm[month, owned] * area[owned] / 1_000_000.0,
+        )
+    catchment_area = np.zeros(len(candidates), dtype=np.float64)
+    catchment_count = np.zeros(len(candidates), dtype=np.int32)
+    np.add.at(catchment_area, owner[owned], area[owned])
+    np.add.at(catchment_count, owner[owned], 1)
+
+    spill_receivers = np.asarray(candidates["spill_receiver_id"], dtype=np.int32)
+    downstream = np.full(len(candidates), -1, dtype=np.int32)
+    routed_spills = spill_receivers >= 0
+    if np.any(routed_spills):
+        spill_rows = _lookup_rows(
+            cell_ids, spill_receivers[routed_spills], label="candidate spill receiver"
+        )
+        downstream[routed_spills] = owner[spill_rows]
+    published_downstream_ids = np.asarray(candidates["downstream_depression_id"], dtype=np.int32)
+    expected_downstream_ids = np.where(
+        downstream >= 0, candidate_ids[np.maximum(downstream, 0)], -1
+    )
+    published_direct = np.asarray(
+        candidates["monthly_direct_inflow_km3"].combine_chunks().values
+    ).reshape(len(candidates), MONTHS)
+    published_overflow = np.asarray(
+        candidates["monthly_overflow_km3"].combine_chunks().values
+    ).reshape(len(candidates), MONTHS)
+    published_upstream = np.asarray(
+        candidates["monthly_upstream_inflow_km3"].combine_chunks().values
+    ).reshape(len(candidates), MONTHS)
+    expected_upstream = np.zeros((len(candidates), MONTHS), dtype=np.float64)
+    for source_row, target_row in enumerate(downstream):
+        if target_row >= 0:
+            expected_upstream[target_row] += published_overflow[source_row]
+    return {
+        "independent_cell_graph_valid": 1,
+        "independent_owned_source_cell_count": int(np.count_nonzero(owned)),
+        "independent_owned_catchment_area_km2": float(np.sum(area[owned])),
+        "maximum_direct_inflow_error_km3": float(np.max(np.abs(direct - published_direct))),
+        "maximum_upstream_inflow_error_km3": float(
+            np.max(np.abs(expected_upstream - published_upstream))
+        ),
+        "maximum_catchment_area_error_km2": float(
+            np.max(
+                np.abs(
+                    catchment_area - np.asarray(candidates["catchment_area_km2"], dtype=np.float64)
+                )
+            )
+        ),
+        "maximum_catchment_cell_count_error": int(
+            np.max(
+                np.abs(
+                    catchment_count - np.asarray(candidates["catchment_cell_count"], dtype=np.int32)
+                )
+            )
+        ),
+        "downstream_candidate_mismatch_count": int(
+            np.count_nonzero(expected_downstream_ids != published_downstream_ids)
+        ),
+    }
+
+
+def _area_audit(
+    cells: pa.Table,
+    candidates: pa.Table,
+    water_cells: pa.Table,
+) -> dict[str, float]:
+    source_cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
+    water_cell_ids = np.asarray(water_cells["fine_cell_id"], dtype=np.int32)
+    source_rows = _lookup_rows(source_cell_ids, water_cell_ids, label="surface-water cell")
+    cell_area = np.asarray(cells["area_km2"], dtype=np.float64)[source_rows]
+    candidate_ids = np.asarray(candidates["depression_id"], dtype=np.int32)
+    water_depression_ids = np.asarray(water_cells["depression_id"], dtype=np.int32)
+    candidate_rows = _lookup_rows(
+        candidate_ids, water_depression_ids, label="surface-water candidate"
+    )
+    fractions = np.asarray(
+        water_cells["monthly_inundation_fraction"].combine_chunks().values,
+        dtype=np.float32,
+    ).reshape(len(water_cells), MONTHS)
+    reconstructed = np.zeros((len(candidates), MONTHS), dtype=np.float64)
+    for month in range(MONTHS):
+        np.add.at(reconstructed[:, month], candidate_rows, fractions[:, month] * cell_area)
+    published = np.asarray(
+        candidates["monthly_water_area_km2"].combine_chunks().values, dtype=np.float64
+    ).reshape(len(candidates), MONTHS)
+    absolute_error = np.abs(reconstructed - published)
+    relative_error = absolute_error / np.maximum(published, 1.0)
+    return {
+        "maximum_area_reconstruction_error_km2": float(np.max(absolute_error)),
+        "maximum_area_reconstruction_relative_error": float(np.max(relative_error)),
+    }
+
+
+def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
+    candidate_record = result.artifact_records.get("SurfaceWaterCandidateCatalog")
+    cell_record = result.artifact_records.get("SeasonalSurfaceWaterCellCatalog")
+    metadata_record = result.artifact_records.get("SurfaceWaterMetadata")
+    if (
+        candidate_record is None
+        or cell_record is None
+        or metadata_record is None
+        or not isinstance(candidate_record.value, pa.Table)
+        or not isinstance(cell_record.value, pa.Table)
+    ):
+        return None
+    candidates = candidate_record.value
+    water_cells = cell_record.value
+    metadata = metadata_record.value
+    fine_resolution = int(metadata["fine_resolution"])
+    display_resolution = min(fine_resolution, 768)
+    placements = np.array([[1, 1], [1, 3], [1, 2], [1, 0], [0, 1], [2, 1]])
+
+    cell_ids = np.asarray(water_cells["fine_cell_id"], dtype=np.int64)
+    face_size = fine_resolution * fine_resolution
+    face = cell_ids // face_size
+    within = cell_ids % face_size
+    row = within // fine_resolution
+    col = within % fine_resolution
+    display_row = np.minimum(row * display_resolution // fine_resolution, display_resolution - 1)
+    display_col = np.minimum(col * display_resolution // fine_resolution, display_resolution - 1)
+    net_row = placements[face, 0] * display_resolution + display_row
+    net_col = placements[face, 1] * display_resolution + display_col
+
+    image = np.full((display_resolution * 3, display_resolution * 4, 3), 17, dtype=np.uint8)
+    class_code = np.asarray(water_cells["class_code"], dtype=np.int32)
+    mean_fraction = np.asarray(water_cells["mean_inundation_fraction"], dtype=np.float32)
+    colors = np.array(
+        [
+            [111, 88, 56],
+            [94, 159, 183],
+            [31, 132, 196],
+            [15, 83, 156],
+            [62, 145, 91],
+        ],
+        dtype=np.float64,
+    )[class_code]
+    strength = np.where(class_code == 0, 0.30, 0.45 + 0.55 * mean_fraction)[:, None]
+    background = np.array([53.0, 65.0, 48.0])
+    blended = background * (1.0 - strength) + colors * strength
+    image[net_row, net_col] = blended.astype(np.uint8)
+
+    rendered = Image.fromarray(image, mode="RGB")
+    padding = max(12, display_resolution // 40)
+    rendered = rendered.crop(
+        (
+            max(0, int(np.min(net_col)) - padding),
+            max(0, int(np.min(net_row)) - padding),
+            min(rendered.width, int(np.max(net_col)) + padding + 1),
+            min(rendered.height, int(np.max(net_row)) + padding + 1),
+        )
+    )
+    scale = min(1600 / rendered.width, 1000 / rendered.height)
+    if scale > 1.0:
+        rendered = rendered.resize(
+            (max(1, round(rendered.width * scale)), max(1, round(rendered.height * scale))),
+            Image.Resampling.NEAREST,
+        )
+    output = request.output_dir / "seasonal_surface_water.png"
+    rendered.save(output)
+    return VisualizationResult(
+        output,
+        "SurfaceWaterCandidateCatalog",
+        {
+            "class_counts": {
+                name: int(np.count_nonzero(np.asarray(candidates["surface_water_class"]) == name))
+                for name in SURFACE_WATER_CLASSES.values()
+            }
+        },
+    )
+
+
+@stage(
+    "surface_water",
+    inputs=("hydrology_pass2", "climate", "geology", "basin_refinement"),
+    outputs=(
+        "SurfaceWaterCandidateCatalog",
+        "SeasonalSurfaceWaterCellCatalog",
+        "SurfaceWaterMonthlyStateCatalog",
+        "SurfaceWaterMetadata",
+    ),
+    version="v1",
+    native_libraries=("surface_water_native",),
+    visualizer=_cube_net_visualizer,
+)
+def surface_water_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = SurfaceWaterConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("surface-water balance requires topology: cubed_sphere")
+    cells = _artifact_table(deps["hydrology_pass2"], "StabilizedBasinCellCatalog")
+    candidates = _artifact_table(deps["hydrology_pass2"], "LocalDepressionCandidateCatalog")
+    parents = _artifact_table(deps["basin_refinement"], "RefinedBasinParentCatalog")
+    refinement_metadata = deps["basin_refinement"].artifact_records["BasinRefinementMetadata"].value
+    pass2_metadata = deps["hydrology_pass2"].artifact_records["HydrologyPass2Metadata"].value
+    if candidates.num_rows == 0:
+        raise RuntimeError("surface-water balance requires at least one local candidate")
+
+    cell_ids = _column(cells, "fine_cell_id", np.dtype(np.int32))
+    parent_ids = _column(cells, "parent_cell_id", np.dtype(np.int32))
+    depression_ids = _column(cells, "stabilized_depression_id", np.dtype(np.int32))
+    candidate_mask = depression_ids >= 0
+    anchor_kind = np.asarray(cells["routing_anchor_kind"].to_pylist())
+    source_active_bool = np.asarray(cells["source_active"])
+    process_excluded = np.asarray(cells["process_excluded"])
+    if (
+        np.any(anchor_kind[candidate_mask] != "ordinary")
+        or np.any(~source_active_bool[candidate_mask])
+        or np.any(process_excluded[candidate_mask])
+    ):
+        raise RuntimeError("local surface-water candidates must use active ordinary child support")
+
+    monthly_runoff_parent = np.asarray(
+        _artifact_array(deps["climate"], "MonthlyRunoffPotentialMm"), dtype=np.float32
+    ).reshape(MONTHS, -1)
+    monthly_evaporation_parent = np.asarray(
+        _artifact_array(deps["climate"], "MonthlyEvaporationMm"), dtype=np.float32
+    ).reshape(MONTHS, -1)
+    accommodation_parent = np.asarray(
+        _artifact_array(deps["geology"], "SedimentAccommodation"), dtype=np.float32
+    ).reshape(-1)
+    rock_strength_parent = np.asarray(
+        _artifact_array(deps["geology"], "RockStrength"), dtype=np.float32
+    ).reshape(-1)
+    if np.any(parent_ids < 0) or np.any(parent_ids >= monthly_runoff_parent.shape[1]):
+        raise RuntimeError("refined child references climate outside the coarse cubed sphere")
+    monthly_runoff = np.ascontiguousarray(monthly_runoff_parent[:, parent_ids], dtype=np.float32)
+    monthly_evaporation = np.ascontiguousarray(
+        monthly_evaporation_parent[:, parent_ids], dtype=np.float32
+    )
+    accommodation = np.ascontiguousarray(accommodation_parent[parent_ids], dtype=np.float32)
+    rock_strength = np.ascontiguousarray(rock_strength_parent[parent_ids], dtype=np.float32)
+
+    candidate_ids = _column(candidates, "depression_id", np.dtype(np.int32))
+    controls = {
+        key: value
+        for key, value in asdict(config).items()
+        if key
+        not in {
+            "maximum_water_balance_relative_error",
+            "maximum_area_reconstruction_relative_error",
+            "outlet_erosion_score_threshold",
+            "outlet_erosion_depth_scale_m",
+            "minimum_outlet_erosion_discharge_m3s",
+        }
+    }
+    controls["refinement_factor"] = int(refinement_metadata["refinement_factor"])
+    with context.timed("refined_monthly_surface_water_kernel"):
+        candidate_records, cell_records, metadata = run_surface_water_balance(
+            controls=controls,
+            cell_ids=cell_ids,
+            receiver_ids=_column(cells, "stabilized_receiver_id", np.dtype(np.int32)),
+            depression_ids=depression_ids,
+            source_active=np.ascontiguousarray(source_active_bool, dtype=np.uint8),
+            area_km2=_column(cells, "area_km2", np.dtype(np.float64)),
+            terrain_elevation_m=_column(cells, "routing_surface_after_m", np.dtype(np.float64)),
+            hydrologic_elevation_m=_column(
+                cells, "stabilized_hydrologic_elevation_m", np.dtype(np.float64)
+            ),
+            parent_relief_m=_column(cells, "parent_relief_m", np.dtype(np.float32)),
+            monthly_runoff_mm=monthly_runoff,
+            monthly_evaporation_mm=monthly_evaporation,
+            sediment_accommodation=accommodation,
+            candidate_ids=candidate_ids,
+            spill_receiver_ids=_column(candidates, "spill_receiver_id", np.dtype(np.int32)),
+        )
+    (
+        final_class_codes,
+        erosion_score,
+        erosion_required,
+        recommended_incision_m,
+        feedback_metadata,
+        classification_reason,
+    ) = _outlet_erosion_feedback(
+        config,
+        cells,
+        candidates,
+        candidate_records,
+        cell_records,
+        rock_strength,
+        accommodation,
+    )
+    candidate_table = _candidate_table(
+        candidates,
+        candidate_records,
+        final_class_codes,
+        erosion_score,
+        erosion_required,
+        recommended_incision_m,
+        classification_reason,
+    )
+    cell_table = _cell_table(cell_records, candidate_ids, final_class_codes)
+    monthly_table = _monthly_table(candidate_records)
+
+    parent_catalog_ids = _column(parents, "parent_cell_id", np.dtype(np.int32))
+    parent_rows = _lookup_rows(
+        parent_catalog_ids, np.unique(parent_ids), label="represented parent"
+    )
+    represented_parent_ids = parent_catalog_ids[parent_rows]
+    represented_parent_area = np.asarray(parents["restricted_child_area_km2"], dtype=np.float64)[
+        parent_rows
+    ]
+    child_area = np.asarray(cells["area_km2"], dtype=np.float64)
+    parent_inverse = _lookup_rows(
+        represented_parent_ids, parent_ids, label="child represented parent"
+    )
+    reconstructed_parent_area = np.zeros(len(represented_parent_ids), dtype=np.float64)
+    np.add.at(reconstructed_parent_area, parent_inverse, child_area)
+    parent_area_relative_error = np.max(
+        np.abs(reconstructed_parent_area - represented_parent_area)
+        / np.maximum(represented_parent_area, 1e-12)
+    )
+    expected_runoff_volume = float(
+        np.sum(
+            monthly_runoff_parent[:, represented_parent_ids]
+            * represented_parent_area[None, :]
+            / 1_000_000.0
+        )
+    )
+    inherited_runoff_volume = float(np.sum(monthly_runoff * child_area[None, :] / 1_000_000.0))
+    runoff_inheritance_relative_error = abs(inherited_runoff_volume - expected_runoff_volume) / max(
+        expected_runoff_volume, 1e-12
+    )
+
+    catchment_metadata = _catchment_audit(cells, candidate_table, monthly_runoff)
+    area_metadata = _area_audit(cells, candidate_table, cell_table)
+    independent_residual = float(
+        np.sum(candidate_records["annual_direct_inflow_km3"])
+        - np.sum(candidate_records["annual_evaporation_km3"])
+        - np.sum(candidate_records["annual_seepage_km3"])
+        - np.sum(candidate_records["annual_terminal_overflow_km3"])
+        - np.sum(candidate_records["annual_storage_change_km3"])
+    )
+    independent_scale = max(float(np.sum(candidate_records["annual_direct_inflow_km3"])), 1e-12)
+    independent_relative_error = abs(independent_residual) / independent_scale
+    pre_adjustment_class_counts = {
+        name: int(np.count_nonzero(candidate_records["class_code"] == code))
+        for code, name in SURFACE_WATER_CLASSES.items()
+    }
+    published_class_counts = {
+        name: int(np.count_nonzero(final_class_codes == code))
+        for code, name in SURFACE_WATER_CLASSES.items()
+    }
+    mean_water_area = candidate_records["mean_water_area_km2"]
+    published_class_areas = {
+        name: float(np.sum(mean_water_area[final_class_codes == code]))
+        for code, name in SURFACE_WATER_CLASSES.items()
+    }
+    native_count_fields = {
+        "dry_depression": "dry_count",
+        "transient_storage": "transient_count",
+        "seasonal_lake": "seasonal_lake_count",
+        "permanent_lake": "permanent_lake_count",
+        "hydrologic_wetland": "hydrologic_wetland_count",
+    }
+    pre_adjustment_native_counts = {
+        f"pre_adjustment_{field}": int(metadata[field]) for field in native_count_fields.values()
+    }
+    native_area_fields = {
+        "dry_depression": "dry_mean_water_area_km2",
+        "transient_storage": "transient_mean_water_area_km2",
+        "seasonal_lake": "seasonal_lake_mean_water_area_km2",
+        "permanent_lake": "permanent_lake_mean_water_area_km2",
+        "hydrologic_wetland": "hydrologic_wetland_mean_water_area_km2",
+    }
+    pre_adjustment_native_areas = {
+        f"pre_adjustment_{field}": float(metadata[field]) for field in native_area_fields.values()
+    }
+    metadata.update(
+        {
+            **asdict(config),
+            **catchment_metadata,
+            **area_metadata,
+            **feedback_metadata,
+            **pre_adjustment_native_counts,
+            **pre_adjustment_native_areas,
+            **{
+                field: published_class_counts[class_name]
+                for class_name, field in native_count_fields.items()
+            },
+            **{
+                field: published_class_areas[class_name]
+                for class_name, field in native_area_fields.items()
+            },
+            "selected_basin_id": int(pass2_metadata["selected_basin_id"]),
+            "fine_resolution": int(pass2_metadata["fine_resolution"]),
+            "refinement_factor": int(refinement_metadata["refinement_factor"]),
+            "maximum_parent_area_relative_error": float(parent_area_relative_error),
+            "represented_parent_runoff_volume_km3": expected_runoff_volume,
+            "inherited_child_runoff_volume_km3": inherited_runoff_volume,
+            "runoff_inheritance_relative_error": runoff_inheritance_relative_error,
+            "independent_water_balance_residual_km3": independent_residual,
+            "independent_water_balance_relative_error": independent_relative_error,
+            "surface_water_classes": {
+                str(code): name for code, name in SURFACE_WATER_CLASSES.items()
+            },
+            "published_class_counts": published_class_counts,
+            "pre_adjustment_class_counts": pre_adjustment_class_counts,
+            "published_class_mean_water_area_km2": published_class_areas,
+            "accepted_standing_water_mean_area_km2": float(
+                np.sum(mean_water_area[np.isin(final_class_codes, [2, 3, 4])])
+            ),
+            "surface_water_ready_for_soils": int(not np.any(erosion_required)),
+            "climate_semantics": "coarse_parent_monthly_depth_inherited_by_area",
+            "hypsometry_semantics": "fractional_uniform_subcell_relief_at_pass2_spill_level",
+            "wetland_semantics": "hydrologic_candidate_pending_soil_and_vegetation_confirmation",
+            "model": "refined_candidate_dag_monthly_fill_spill_balance_v1",
+        }
+    )
+    if metadata["graph_valid"] != 1 or catchment_metadata["independent_cell_graph_valid"] != 1:
+        raise RuntimeError("surface-water balance received a cyclic cell or candidate graph")
+    if metadata["convergence_valid"] != 1 or not np.all(candidate_records["converged"] != 0):
+        raise RuntimeError("surface-water monthly storage did not reach a periodic state")
+    if metadata["fraction_valid"] != 1 or not (
+        0.0
+        <= metadata["minimum_inundation_fraction"]
+        <= metadata["maximum_inundation_fraction"]
+        <= 1.0
+    ):
+        raise RuntimeError("surface-water inundation fractions are invalid")
+    if metadata["storage_valid"] != 1 or metadata["direct_catchment_valid"] != 1:
+        raise RuntimeError("surface-water storage or direct catchment ownership is invalid")
+    if any(
+        pre_adjustment_class_counts[class_name] != int(metadata[f"pre_adjustment_{field}"])
+        for class_name, field in native_count_fields.items()
+    ):
+        raise RuntimeError("native surface-water class counts disagree with emitted candidates")
+    if any(
+        published_class_counts[class_name] != int(metadata[field])
+        for class_name, field in native_count_fields.items()
+    ):
+        raise RuntimeError("accepted surface-water class counts disagree with emitted candidates")
+    if catchment_metadata["maximum_direct_inflow_error_km3"] > 1e-10:
+        raise RuntimeError("surface-water direct catchment inflow disagrees with emitted records")
+    if catchment_metadata["maximum_upstream_inflow_error_km3"] > 1e-10:
+        raise RuntimeError(
+            "surface-water upstream overflow transfer disagrees with emitted records"
+        )
+    if (
+        catchment_metadata["maximum_catchment_area_error_km2"] > 1e-8
+        or catchment_metadata["maximum_catchment_cell_count_error"] != 0
+        or catchment_metadata["downstream_candidate_mismatch_count"] != 0
+    ):
+        raise RuntimeError("surface-water catchment or candidate topology audit failed")
+    if parent_area_relative_error > 1e-9 or runoff_inheritance_relative_error > 1e-12:
+        raise RuntimeError("surface-water climate inheritance does not conserve parent support")
+    if (
+        metadata["water_balance_relative_error"] > config.maximum_water_balance_relative_error
+        or independent_relative_error > config.maximum_water_balance_relative_error
+    ):
+        raise RuntimeError("surface-water candidate network does not conserve water")
+    if (
+        area_metadata["maximum_area_reconstruction_relative_error"]
+        > config.maximum_area_reconstruction_relative_error
+    ):
+        raise RuntimeError("surface-water cell fractions do not reconstruct candidate area")
+    context.logger.log_event(
+        {"type": "surface_water_summary", "stage": "surface_water", **metadata}
+    )
+    return {
+        "SurfaceWaterCandidateCatalog": candidate_table,
+        "SeasonalSurfaceWaterCellCatalog": cell_table,
+        "SurfaceWaterMonthlyStateCatalog": monthly_table,
+        "SurfaceWaterMetadata": metadata,
+    }
+
+
+__all__ = ["SurfaceWaterConfig", "surface_water_stage"]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -274,6 +274,7 @@ def main(args: Iterable[str] | None = None) -> int:
             "basin_refinement",
             "basin_erosion",
             "hydrology_pass2",
+            "surface_water",
         ],
         default="topology",
     )
@@ -346,8 +347,10 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = "basin_refinement"
         elif parsed.stage == "basin_erosion":
             stage_name = "basin_erosion"
-        else:
+        elif parsed.stage == "hydrology_pass2":
             stage_name = "hydrology_pass2"
+        else:
+            stage_name = "surface_water"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -374,6 +377,7 @@ def main(args: Iterable[str] | None = None) -> int:
         "basin_refinement",
         "basin_erosion",
         "hydrology_pass2",
+        "surface_water",
     }:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":

--- a/tests/test_hydrology_pass2.py
+++ b/tests/test_hydrology_pass2.py
@@ -10,7 +10,7 @@ import pytest
 from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
 from map_maker.pipeline import _hydrology_pass2_native as native
 from map_maker.pipeline.cubed_sphere import CubedSphereGrid
-from map_maker.pipeline.stages.hydrology_pass2 import HydrologyPass2Config
+from map_maker.pipeline.stages.hydrology_pass2 import HydrologyPass2Config, _depression_catalog
 
 
 @pytest.fixture(autouse=True)
@@ -164,6 +164,28 @@ def test_native_pass2_rejects_nonadjacent_fixed_trunk_edge():
         native.run_hydrology_pass2(**fixture)
 
 
+def test_depression_catalog_uses_final_exit_after_reentry():
+    cells = pa.table(
+        {
+            "fine_cell_id": pa.array([0, 1, 2, 3], type=pa.int32()),
+            "stabilized_receiver_id": pa.array([1, 2, 3, -1], type=pa.int32()),
+            "baseline_depression_id": pa.array([-1, -1, -1, -1], type=pa.int32()),
+            "stabilized_depression_id": pa.array([7, -1, 7, -1], type=pa.int32()),
+            "area_km2": pa.array([1.0, 1.0, 1.0, 1.0], type=pa.float64()),
+            "stabilized_fill_depth_m": pa.array([5.0, 0.0, 4.0, 0.0], type=pa.float64()),
+            "stabilized_hydrologic_elevation_m": pa.array(
+                [10.0, 8.0, 10.0, 7.0], type=pa.float64()
+            ),
+        }
+    )
+
+    catalog, _ = _depression_catalog(cells)
+
+    assert catalog.num_rows == 1
+    assert catalog["spill_cell_id"][0].as_py() == 2
+    assert catalog["spill_receiver_id"][0].as_py() == 3
+
+
 def test_hydrology_pass2_stabilizes_real_connector_basin(tmp_path: Path):
     engine = ExecutionEngine(_config(tmp_path, "pass2"), generate_visuals=True)
     results = engine.run(["basin_erosion", "hydrology_pass2"])
@@ -298,5 +320,7 @@ def test_hydrology_pass2_config_rejects_unknown_and_invalid_controls():
         HydrologyPass2Config.from_mapping({"magic": 1})
     with pytest.raises(ValueError, match="minimum_depression_depth_m"):
         HydrologyPass2Config.from_mapping({"minimum_depression_depth_m": -1.0})
+    with pytest.raises(ValueError, match="minimum_depression_depth_m"):
+        HydrologyPass2Config.from_mapping({"minimum_depression_depth_m": 0.0})
     with pytest.raises(ValueError, match="maximum_receiver_change_fraction"):
         HydrologyPass2Config.from_mapping({"maximum_receiver_change_fraction": 1.1})

--- a/tests/test_native_loader.py
+++ b/tests/test_native_loader.py
@@ -57,3 +57,6 @@ def test_built_library_exposes_expected_abi_and_fingerprint() -> None:
 
     hydrology_pass2 = native_library_info("hydrology_pass2_native")
     assert hydrology_pass2["abi_version"] == 1
+
+    surface_water = native_library_info("surface_water_native")
+    assert surface_water["abi_version"] == 2

--- a/tests/test_pipeline_generate.py
+++ b/tests/test_pipeline_generate.py
@@ -60,6 +60,7 @@ def test_generate_world_writes_preview_manifest_and_reuses_cache(tmp_path: Path)
         "hydrology_pass2_native",
         "planet_native",
         "refinement_native",
+        "surface_water_native",
         "tectonics_native",
         "topology_native",
         "world_age_native",

--- a/tests/test_surface_water.py
+++ b/tests/test_surface_water.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline import _surface_water_native as native
+from map_maker.pipeline.stages.surface_water import SurfaceWaterConfig
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+        "hydrology",
+        "basin_refinement",
+        "basin_erosion",
+        "hydrology_pass2",
+        "surface_water",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(tmp_path: Path, run_id: str, *, root: str = "primary") -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 16}],
+            "rng_seed": 22,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / root / "out"),
+            "cache_dir": str(tmp_path / root / "cache"),
+            "log_dir": str(tmp_path / root / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 10,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+                "basin_refinement": {
+                    "refinement_factor": 4,
+                    "terrain_noise_fraction": 0.4,
+                },
+                "basin_erosion": {
+                    "minimum_bed_slope": 1e-5,
+                    "maximum_deposition_fraction": 0.35,
+                    "deposition_slope_scale": 0.001,
+                    "maximum_deposition_depth_m": 10.0,
+                },
+                "hydrology_pass2": {
+                    "minimum_depression_depth_m": 5.0,
+                    "maximum_receiver_change_fraction": 0.15,
+                    "maximum_receiver_change_cell_fraction": 0.15,
+                    "maximum_new_depression_area_fraction": 0.02,
+                },
+                "surface_water": {
+                    "minimum_solver_iterations": 8,
+                    "maximum_solver_iterations": 64,
+                    "maximum_connected_inundation_fraction": 0.25,
+                    "outlet_erosion_score_threshold": 0.30,
+                    "outlet_erosion_depth_scale_m": 200.0,
+                    "minimum_outlet_erosion_discharge_m3s": 0.10,
+                },
+            },
+        }
+    )
+
+
+def _table(result, name: str) -> pa.Table:
+    value = result.artifact_records[name].value
+    assert isinstance(value, pa.Table)
+    return value
+
+
+def _native_fixture() -> dict[str, object]:
+    return {
+        "controls": {
+            "refinement_factor": 4,
+            "minimum_solver_iterations": 4,
+            "maximum_solver_iterations": 64,
+            "transient_max_months": 3,
+            "permanent_min_months": 12,
+            "convergence_tolerance_fraction": 1e-8,
+            "open_water_evaporation_factor": 1.0,
+            "seepage_mm_year": 0.0,
+            "subgrid_relief_scale": 1.0,
+            "minimum_subgrid_relief_m": 10.0,
+            "maximum_connected_inundation_fraction": 1.0,
+            "minimum_wet_area_fraction": 0.01,
+            "wetland_max_mean_depth_m": 3.0,
+        },
+        "cell_ids": np.array([0, 1, 2], dtype=np.int32),
+        "receiver_ids": np.array([1, 2, -1], dtype=np.int32),
+        "depression_ids": np.array([-1, 1, -1], dtype=np.int32),
+        "source_active": np.ones(3, dtype=np.uint8),
+        "area_km2": np.ones(3, dtype=np.float64),
+        "terrain_elevation_m": np.array([2.0, -10.0, 2.0], dtype=np.float64),
+        "hydrologic_elevation_m": np.array([2.0, 0.0, 2.0], dtype=np.float64),
+        "parent_relief_m": np.full(3, 20.0, dtype=np.float32),
+        "monthly_runoff_mm": np.full((12, 3), 100.0, dtype=np.float32),
+        "monthly_evaporation_mm": np.zeros((12, 3), dtype=np.float32),
+        "sediment_accommodation": np.full(3, 0.5, dtype=np.float32),
+        "candidate_ids": np.array([1], dtype=np.int32),
+        "spill_receiver_ids": np.array([2], dtype=np.int32),
+    }
+
+
+def test_native_surface_water_solves_periodic_fill_spill_across_cffi():
+    candidates, cells, metadata = native.run_surface_water_balance(**_native_fixture())
+
+    assert metadata["graph_valid"] == 1
+    assert metadata["convergence_valid"] == 1
+    assert metadata["water_balance_relative_error"] < 1e-12
+    assert candidates["class_code"].tolist() == [3]
+    assert candidates["wet_month_count"].tolist() == [12]
+    assert candidates["annual_overflow_km3"][0] > 0.0
+    assert candidates["solver_iterations"][0] <= 64
+    assert cells["fine_cell_id"].tolist() == [1]
+    assert np.all((cells["monthly_inundation_fraction"] >= 0.0))
+    assert np.all((cells["monthly_inundation_fraction"] <= 1.0))
+
+
+def test_native_surface_water_layout_and_sentinels_match_cffi():
+    for kind, c_name in enumerate(
+        (
+            "SurfaceWaterConfig",
+            "SurfaceWaterCandidateRecord",
+            "SurfaceWaterCellRecord",
+            "SurfaceWaterStats",
+        )
+    ):
+        assert native._lib.surface_water_native_struct_size(kind) == native._ffi.sizeof(c_name)
+
+    candidate = native._ffi.new("SurfaceWaterCandidateRecord*")
+    candidate.depression_id = 17
+    candidate.downstream_depression_id = 23
+    candidate.annual_total_inflow_km3 = 1234.5
+    candidate.monthly_water_area_km2[11] = 987.25
+    candidate_view = native._ffi.buffer(
+        candidate, native._ffi.sizeof("SurfaceWaterCandidateRecord")
+    )
+    parsed_candidate = np.frombuffer(candidate_view, dtype=native.CANDIDATE_DTYPE, count=1)[0]
+    assert parsed_candidate["depression_id"] == 17
+    assert parsed_candidate["downstream_depression_id"] == 23
+    assert parsed_candidate["annual_total_inflow_km3"] == 1234.5
+    assert parsed_candidate["monthly_water_area_km2"][11] == 987.25
+
+    cell = native._ffi.new("SurfaceWaterCellRecord*")
+    cell.fine_cell_id = 31
+    cell.depression_id = 17
+    cell.mean_inundation_fraction = 0.375
+    cell.monthly_inundation_fraction[11] = 0.625
+    cell_view = native._ffi.buffer(cell, native._ffi.sizeof("SurfaceWaterCellRecord"))
+    parsed_cell = np.frombuffer(cell_view, dtype=native.CELL_DTYPE, count=1)[0]
+    assert parsed_cell["fine_cell_id"] == 31
+    assert parsed_cell["depression_id"] == 17
+    assert parsed_cell["mean_inundation_fraction"] == 0.375
+    assert parsed_cell["monthly_inundation_fraction"][11] == 0.625
+
+
+def test_native_surface_water_rejects_zero_material_wet_area_threshold():
+    fixture = _native_fixture()
+    fixture["controls"] = {**fixture["controls"], "minimum_wet_area_fraction": 0.0}
+
+    with pytest.raises(RuntimeError, match="invalid controls"):
+        native.run_surface_water_balance(**fixture)
+
+
+def test_zero_overflow_never_requests_outlet_erosion():
+    module = importlib.import_module("map_maker.pipeline.stages.surface_water")
+    config = SurfaceWaterConfig.from_mapping(
+        {
+            "outlet_erosion_score_threshold": 0.0,
+            "minimum_outlet_erosion_discharge_m3s": 0.0,
+        }
+    )
+    cells = pa.table(
+        {
+            "fine_cell_id": pa.array([1], type=pa.int32()),
+            "area_km2": pa.array([1.0], type=pa.float64()),
+        }
+    )
+    candidates = pa.table(
+        {
+            "depression_id": pa.array([7], type=pa.int32()),
+            "maximum_fill_depth_m": pa.array([100.0], type=pa.float64()),
+        }
+    )
+    candidate_records = np.zeros(1, dtype=native.CANDIDATE_DTYPE)
+    candidate_records["class_code"] = 3
+    candidate_records["mean_water_area_km2"] = 1.0
+    cell_records = np.zeros(1, dtype=native.CELL_DTYPE)
+    cell_records["fine_cell_id"] = 1
+    cell_records["depression_id"] = 7
+    cell_records["potential_inundation_fraction"] = 1.0
+
+    _, _, erosion_required, recommended_incision, _, _ = module._outlet_erosion_feedback(
+        config,
+        cells,
+        candidates,
+        candidate_records,
+        cell_records,
+        np.array([0.0], dtype=np.float32),
+        np.array([0.0], dtype=np.float32),
+    )
+
+    assert not erosion_required[0]
+    assert recommended_incision[0] == 0.0
+
+
+def test_surface_water_persists_fractional_monthly_state_and_feedback(tmp_path: Path):
+    engine = ExecutionEngine(_config(tmp_path, "surface-water"), generate_visuals=True)
+    results = engine.run(["surface_water"])
+    result = results["surface_water"]
+    pass2 = results["hydrology_pass2"]
+    metadata = result.artifact_records["SurfaceWaterMetadata"].value
+    candidates = _table(result, "SurfaceWaterCandidateCatalog")
+    cells = _table(result, "SeasonalSurfaceWaterCellCatalog")
+    monthly = _table(result, "SurfaceWaterMonthlyStateCatalog")
+    pass2_cells = _table(pass2, "StabilizedBasinCellCatalog")
+    pass2_candidates = _table(pass2, "LocalDepressionCandidateCatalog")
+
+    assert candidates.num_rows == pass2_candidates.num_rows == metadata["candidate_count"]
+    assert monthly.num_rows == 12 * candidates.num_rows
+    assert cells.num_rows == int(
+        np.count_nonzero(np.asarray(pass2_cells["stabilized_depression_id"]) >= 0)
+    )
+    assert metadata["graph_valid"] == 1
+    assert metadata["convergence_valid"] == 1
+    assert metadata["direct_catchment_valid"] == 1
+    assert metadata["runoff_inheritance_relative_error"] < 1e-12
+    assert metadata["water_balance_relative_error"] < 1e-9
+    assert metadata["independent_water_balance_relative_error"] < 1e-9
+    assert metadata["maximum_area_reconstruction_relative_error"] < 1e-6
+    assert metadata["downstream_candidate_mismatch_count"] == 0
+    assert sum(metadata["published_class_counts"].values()) == candidates.num_rows
+    assert metadata["surface_water_ready_for_soils"] == int(
+        metadata["outlet_erosion_required_count"] == 0
+    )
+
+    fractions = np.asarray(
+        cells["monthly_inundation_fraction"].combine_chunks().values, dtype=np.float32
+    ).reshape(cells.num_rows, 12)
+    assert np.all(np.isfinite(fractions))
+    assert np.all((fractions >= 0.0) & (fractions <= 1.0))
+    assert np.max(np.asarray(cells["potential_inundation_fraction"])) <= 0.25 + 1e-6
+    assert set(candidates["surface_water_class"].to_pylist()) <= set(
+        native.SURFACE_WATER_CLASSES.values()
+    )
+    required = np.asarray(candidates["outlet_erosion_required"])
+    assert np.all(np.asarray(candidates["class_code"])[required] == 1)
+    assert np.all(np.asarray(candidates["recommended_outlet_incision_m"])[~required] == 0.0)
+    residual = (
+        np.asarray(candidates["annual_total_inflow_km3"])
+        - np.asarray(candidates["annual_evaporation_km3"])
+        - np.asarray(candidates["annual_seepage_km3"])
+        - np.asarray(candidates["annual_overflow_km3"])
+        - np.asarray(candidates["annual_storage_change_km3"])
+    )
+    assert np.max(np.abs(residual)) < 1e-10
+    visual = engine.context.config.run_visual_dir() / "surface_water"
+    assert (visual / "seasonal_surface_water.png").is_file()
+
+
+def test_surface_water_is_deterministic_and_cacheable(tmp_path: Path):
+    first = ExecutionEngine(_config(tmp_path, "first", root="first")).run(["surface_water"])[
+        "surface_water"
+    ]
+    second = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["surface_water"])[
+        "surface_water"
+    ]
+    for artifact in (
+        "SurfaceWaterCandidateCatalog",
+        "SeasonalSurfaceWaterCellCatalog",
+        "SurfaceWaterMonthlyStateCatalog",
+    ):
+        assert _table(first, artifact).equals(_table(second, artifact))
+    assert (
+        first.artifact_records["SurfaceWaterMetadata"].value
+        == second.artifact_records["SurfaceWaterMetadata"].value
+    )
+    cached = ExecutionEngine(_config(tmp_path, "second", root="second")).run(["surface_water"])[
+        "surface_water"
+    ]
+    assert cached.stats is not None and cached.stats.cache_hit
+
+
+def test_stage_rejects_corrupted_native_direct_inflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = importlib.import_module("map_maker.pipeline.stages.surface_water")
+    native_run = module.run_surface_water_balance
+
+    def corrupted_native_run(**kwargs):
+        candidates, cells, metadata = native_run(**kwargs)
+        candidates = candidates.copy()
+        candidates["monthly_direct_inflow_km3"][0, 0] += 1.0
+        return candidates, cells, metadata
+
+    monkeypatch.setattr(module, "run_surface_water_balance", corrupted_native_run)
+    with pytest.raises(RuntimeError, match="direct catchment inflow"):
+        ExecutionEngine(_config(tmp_path, "corrupt")).run(["surface_water"])
+
+
+def test_stage_rejects_corrupted_native_upstream_inflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = importlib.import_module("map_maker.pipeline.stages.surface_water")
+    native_run = module.run_surface_water_balance
+
+    def corrupted_native_run(**kwargs):
+        candidates, cells, metadata = native_run(**kwargs)
+        candidates = candidates.copy()
+        candidates["monthly_upstream_inflow_km3"][0, 0] += 1.0
+        return candidates, cells, metadata
+
+    monkeypatch.setattr(module, "run_surface_water_balance", corrupted_native_run)
+    with pytest.raises(RuntimeError, match="upstream overflow transfer"):
+        ExecutionEngine(_config(tmp_path, "corrupt-upstream")).run(["surface_water"])
+
+
+def test_surface_water_config_rejects_unknown_and_invalid_controls():
+    with pytest.raises(ValueError, match="Unknown surface-water controls"):
+        SurfaceWaterConfig.from_mapping({"magic": 1})
+    with pytest.raises(ValueError, match="solver iterations"):
+        SurfaceWaterConfig.from_mapping({"maximum_solver_iterations": 0})
+    with pytest.raises(ValueError, match="month thresholds"):
+        SurfaceWaterConfig.from_mapping({"transient_max_months": 12})
+    with pytest.raises(ValueError, match="month thresholds"):
+        SurfaceWaterConfig.from_mapping({"permanent_min_months": 11})
+    with pytest.raises(ValueError, match="maximum_connected_inundation_fraction"):
+        SurfaceWaterConfig.from_mapping({"maximum_connected_inundation_fraction": 1.1})
+    with pytest.raises(ValueError, match="minimum_wet_area_fraction"):
+        SurfaceWaterConfig.from_mapping({"minimum_wet_area_fraction": 0.0})


### PR DESCRIPTION
## What changed

- Add a Rust-backed monthly fill/spill solver over Hydrology Pass 2 depression candidates.
- Persist candidate, monthly, and fractional child-cell surface-water catalogs plus a cube-net diagnostic.
- Add disjoint first-downstream catchments, exact candidate-DAG overflow propagation, periodic storage solving, and independent conservation/edge-flow audits.
- Classify dry, transient, seasonal, permanent, and hydrologic-wetland states without making refined cells atomic water pixels.
- Publish bounded outlet-incision feedback and block soils while 3,125 unresolved outlet corrections remain.
- Correct Pass-2 flat-component spill selection to use the final downstream exit, preventing candidate self-edges and cycles.

## Canonical result

- 8,944 candidates and 77,525 candidate-support children.
- 120,063 km2 accepted standing-water mean area (1.885% of active basin area).
- 3,125 sustained-overflow systems retained as pre-incision transient storage.
- Independent annual balance error: 2.49e-15.
- Maximum immediate-edge monthly transfer error: 2.22e-16 km3.

## Validation

- `pytest -q`: 126 passed.
- `cargo test --workspace`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `ruff check src tests`: passed.
- Targeted Black check: passed (two unrelated legacy files remain pre-existing repository-wide Black failures).
- `uv build -q`: passed.
- Release-native build and `map-maker doctor`: passed.
- Final uncached canonical surface-water generation: passed.
