### PR TITLE
Add bounded outlet incision feedback

### DIFF
--- a/configs/cubed_sphere_crust_state.yaml
+++ b/configs/cubed_sphere_crust_state.yaml
@@ -107,3 +107,22 @@ stage_overrides:
     minimum_outlet_erosion_discharge_m3s: 0.10
     maximum_water_balance_relative_error: 0.000000001
     maximum_area_reconstruction_relative_error: 0.000001
+  outlet_incision:
+    minimum_outlet_width_m: 5.0
+    outlet_width_coefficient: 8.0
+    outlet_width_exponent: 0.5
+    maximum_outlet_width_m: 500.0
+    minimum_outlet_bed_slope: 0.00001
+    maximum_outlet_path_cells: 64
+    maximum_reroute_repair_rounds: 64
+    maximum_incision_depth_m: 250.0
+    maximum_cell_mean_lowering_m: 5.0
+    minimum_depression_depth_m: 5.0
+    maximum_corrected_area_fraction: 0.10
+    maximum_receiver_change_area_fraction: 0.15
+    maximum_receiver_change_cell_fraction: 0.15
+    maximum_reroute_constraint_cell_fraction: 0.15
+    maximum_volume_relative_error: 0.0000000001
+  surface_water_final:
+    maximum_outlet_incision_rounds: 8
+    require_soil_readiness: true

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1450,3 +1450,71 @@ Failure conditions:
 - Candidate-network water imbalance above the configured tolerance.
 - Treating provisional land evaporation as calibrated open-water potential
   evaporation.
+
+## Decision 028: Bounded Subgrid Outlet Incision
+
+Status: implemented, provisional
+
+Decision:
+Surface-water candidates that request outlet erosion receive one bounded
+subgrid incision and local-routing correction before soils or biomes may run.
+The correction follows the accepted Pass-2 receiver graph from each candidate's
+final spill cell to the first downstream candidate, lower ordinary cell, fixed
+trunk, preserved handoff, or terminal. It does not search globally for a more
+convenient outlet.
+
+Cascade contract:
+- Candidate outlets are planned downstream-to-upstream. An upstream candidate
+  may connect to the corrected level of a downstream candidate in the same
+  bounded pass, which permits linked lake chains to drain coherently.
+- The requested start level is the old spill level minus the published
+  recommended incision. It is raised when necessary to retain a positive
+  downstream bed slope into fixed or uncorrected support.
+- A path that cannot reach valid downstream support within the configured cell
+  bound is reported as blocked. It is not carved speculatively.
+- A candidate whose requested bed cannot descend into its downstream water
+  level is grade-limited, not an unresolved erosion failure. After that bounded
+  feasibility proof it may retain its lake class without blocking soils.
+- Shared path cells receive the lowest compatible requested bed and the widest
+  contributing outlet, while their physical erosion volume is counted once.
+
+Subgrid and terrain contract:
+- Outlet beds are subgrid channel elevations. A 10-100 metre outlet does not
+  lower an entire approximately five-kilometre child by its incision depth.
+- Channel width is a bounded function of pre-incision mean overflow discharge.
+  Eroded volume is incision depth times channel width times the child's
+  representative linear length (`sqrt(area)`); exact channel geometry remains
+  a regional-refinement responsibility.
+- Cell-mean terrain feedback is eroded volume divided by child area. Parent
+  aggregates must reconstruct the exact emitted child volume.
+- Existing physical trunk beds and receivers remain fixed. Outlet paths may
+  join them but may not rewrite them.
+- Applied outlet-path cells remain ordinary terrain cells and persist their
+  accepted downstream receiver as a separate subgrid constraint. They are not
+  promoted to full-cell physical channels, but later priority-flood passes
+  exclude the constrained bed support from depression membership.
+- If local priority flooding would route an unconstrained neighbor back into a
+  fixed outlet and form a cycle, only the cyclic ordinary support is restored
+  to its previously accepted receiver. Repair rounds and total constrained
+  support are bounded explicitly.
+
+Post-correction contract:
+- The Rust Hydrology Pass-2 kernel reruns over the corrected routing surface and
+  must publish an acyclic, conservative receiver graph with valid process
+  exclusions and unchanged physical trunks.
+- Monthly surface-water balance then reruns over the corrected candidates,
+  followed by further bounded incision/balance rounds up to the configured
+  limit.
+- Soils become ready only when that post-incision solve requests no further
+  outlet correction. Grade-limited paths and paths whose persisted bed already
+  satisfies the requested cut are retained as explicit accepted standing-water
+  reasons across rounds. Other residual feedback remains a hard blocker.
+
+Failure conditions:
+- Unknown or cyclic source routing, a mismatched downstream candidate, or a
+  correction through excluded/outside support.
+- A path longer than the configured bound, excessive corrected area or receiver
+  change, or a non-descending emitted outlet bed.
+- Any mismatch among cell, parent, and total eroded volume.
+- A changed physical trunk receiver or bed, invalid terminal, uncovered active
+  cell, or contributing-area conservation failure after rerouting.

--- a/docs/PLANET_ENGINE_SPEC.md
+++ b/docs/PLANET_ENGINE_SPEC.md
@@ -96,6 +96,14 @@ Current approved/provisional decisions:
 - Decision 018: Truth And Atlas Rendering.
 - Decision 019: Gate Then Score Realism Evaluation.
 - Decision 020: Rust Computational Core With Python Orchestration.
+- Decision 021: Causal Pre-Erosion Elevation Components.
+- Decision 022: Fractional Coarse Surface Coverage.
+- Decision 023: Hierarchical Rivers And Subgrid Fluvial Incision.
+- Decision 024: Hydrologic Connectors And Conservative Corridor Support.
+- Decision 025: Junction Beds And Conservative First-Pass Fluvial Budgets.
+- Decision 026: Bounded Sparse Hydrology Pass 2.
+- Decision 027: Refined Seasonal Surface-Water Balance.
+- Decision 028: Bounded Subgrid Outlet Incision.
 
 Accepted only as tentative prototype hypotheses:
 - Decision 010: Explicit History Window And Adaptive Nested Sweeps.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -334,6 +334,46 @@ false until a bounded outlet-incision and local reroute pass consumes all 3,125
 feedback records. The current class and area distribution is provisional; it
 has not passed a multi-seed Earth-derived lake and wetland calibration.
 
+## Bounded Outlet Incision And Final Surface Water
+
+The canonical correction follows the accepted receiver graph with narrow
+subgrid beds. It changes cell-mean terrain only by reconstructed eroded volume,
+keeps physical channel anchors unchanged, and retains corrected ordinary cells
+through explicit receiver constraints. The first correction pass reports:
+
+| Metric | Canonical result |
+| --- | ---: |
+| Requested candidates | `3,125` |
+| Applied / bounded-accepted | `2,942 / 183` |
+| Corrected cells | `8,885` |
+| Corrected active area | `167,290 km2` (`2.627%`) |
+| Subgrid eroded volume | `13.918 km3` |
+| Maximum bed incision | `160.65 m` |
+| Maximum cell-mean lowering | `4.04 m` |
+| Receiver-change area | `359,457 km2` (`5.644%`) |
+| Cycle repair | `1` round, `1` ordinary cell |
+| Physical trunk anchors preserved | `2,434 / 2,434` |
+
+Monthly balance and correction then converge in seven rounds. Residual feedback
+counts are `2,181, 671, 109, 22, 3, 1, 0`; cumulative outlet erosion is about
+`16.491 km3`. The final graph retains 10,857 ordinary routing constraints and
+publishes `surface_water_ready_for_soils = 1`. Annual candidate-network water
+balance closes to `2.8e-16` relative error.
+
+Final accepted standing-water mean area is `238,049 km2`, or `3.74%` of the
+selected basin's active area. The area fraction is inside the earlier
+provisional Earth-like lake-area envelope, but morphology is not calibrated:
+10,062 candidates are permanent lakes, seven are hydrologic wetlands, and none
+are seasonal. Multi-seed and multi-resolution comparison must test candidate
+count, size distribution, hydroperiod, and bathymetry before these labels are
+treated as Earth-like.
+
+The original Python depression-catalog builder scaled as cells times
+candidates. Grouped aggregation preserves byte-identical canonical output and
+measured `4.77 s` before versus `0.17 s` after on the development machine
+(approximately 28x for that operation). This is a local benchmark, not a
+cross-platform performance guarantee.
+
 ## Calibration Rule
 
 Do not tighten or loosen a threshold solely to make the current gallery pass.

--- a/docs/specs/00_pipeline_overview.md
+++ b/docs/specs/00_pipeline_overview.md
@@ -43,19 +43,26 @@
 11. Refined seasonal surface-water balance.
     - Local candidates receive monthly catchment inflow, fractional inundation,
       fill/spill propagation, and provisional lake or hydrologic-wetland classes.
-12. Soils and biomes.
-13. Mineral and energy systems.
-14. Selected-region refinement and map export.
+12. Bounded subgrid outlet incision and final surface-water balance.
+    - Narrow outlet beds modify terrain by physical eroded volume, retain
+      ordinary-cell semantics, rerun conservative routing in Rust, and iterate
+      monthly balance until outlet feedback is resolved or the hard round bound
+      is reached.
+13. Soils and biomes.
+14. Mineral and energy systems.
+15. Selected-region refinement and map export.
 
-The current canonical cubed-sphere implementation reaches the refined seasonal
-surface-water balance after erosion, sedimentation, and bounded Hydrology Pass
-2. It includes a causal, pre-erosion bedrock surface; separate crustal,
+The current canonical cubed-sphere implementation reaches converged bounded
+outlet incision and final seasonal surface-water balance after erosion,
+sedimentation, and Hydrology Pass 2. It includes a causal, pre-erosion bedrock
+surface; separate crustal,
 orogenic, basin, and relief-prior artifacts; persisted monthly orbital forcing;
 and a first seasonal climate/orography pass. Bed-profile and sediment budgets
 are conservative but remain uncalibrated. Pass 2 audits their local routing
 consequences without replacing the accepted coarse trunk graph; the
-surface-water stage then solves periodic monthly storage and publishes explicit
-outlet-erosion feedback. The older rectangular compatibility path runs directly
+surface-water stage solves periodic monthly storage, and the outlet stage
+consumes its explicit erosion feedback through bounded persistent corrections.
+The older rectangular compatibility path runs directly
 from world age into provisional erosion and final rendering; it is reference
 behavior, not the canonical stage order.
 

--- a/docs/specs/08d_surface_water_balance.md
+++ b/docs/specs/08d_surface_water_balance.md
@@ -116,3 +116,5 @@ stabilization.
   do not yet exist.
 - Hydrologic wetland output is an input to future soils and biomes, not their
   final classification.
+- Candidate classes are provisional until `surface_water_final` consumes outlet
+  feedback through bounded incision and publishes a zero residual count.

--- a/docs/specs/08e_outlet_incision.md
+++ b/docs/specs/08e_outlet_incision.md
@@ -1,0 +1,133 @@
+# Bounded Subgrid Outlet Incision
+
+## Status
+
+Implemented, provisional milestone following the first refined surface-water
+balance.
+
+## Objective
+
+Consume every explicit outlet-erosion feedback record, cut a physically narrow
+and topologically bounded drainage path, rerun local hydrology, and then rerun
+monthly surface-water balance. This pass resolves false standing water caused
+by erodible local sills without lowering whole refined cells by channel depth.
+
+## Inputs
+
+- `surface_water`: requested candidates, discharge, erosion score, recommended
+  incision, and candidate DAG.
+- `hydrology_pass2`: accepted receiver graph, subgrid routing surface, physical
+  trunk anchors, child area, terrain means, and topology coordinates.
+- `planet`: radius for path length and slope calculations.
+
+## Outlet Paths
+
+Each requested candidate begins at its persisted final spill cell and follows
+the accepted receiver graph. The path stops at the first downstream candidate,
+ordinary cell already below the requested bed, fixed physical channel,
+preserved handoff, or terminal. Candidate cascades are planned
+downstream-to-upstream so an upstream outlet may connect to a downstream
+candidate's corrected level.
+
+No unconstrained least-cost search is performed. The accepted graph supplies
+the causal overflow route, and the configured path-cell bound limits the blast
+radius of one correction pass.
+
+## Bed And Volume Model
+
+The requested spill bed is the old spill elevation minus recommended incision.
+Where downstream support is higher, the applied incision is reduced enough to
+retain the configured positive bed slope. Path-cell bed requests are linearly
+graded downstream and combined by minimum elevation on shared support.
+
+Outlet width is a bounded power-law function of mean overflow discharge.
+Physical eroded volume is integrated from bed lowering, width, and the child's
+representative linear length (`sqrt(area)`). Dividing volume by cell area
+produces a small cell-mean terrain change while preserving the much deeper
+subgrid outlet bed. Parent aggregates must exactly reproduce child volume. The
+representative length is a structural approximation until regional refinement
+resolves exact channel geometry.
+
+## Local Reroute
+
+The Hydrology Pass-2 native kernel runs again with corrected ordinary routing
+support and the original fixed channel anchors. Applied outlet cells remain
+ordinary terrain cells but persist an `outlet_fixed_receiver_id`; they are
+excluded from depression membership without claiming that a narrow outlet fills
+the whole child. The kernel recomputes all remaining receivers, priority-fill
+candidates, contributing area, slopes, and direction vectors.
+
+If a newly free neighbor routes back into a constrained outlet, a bounded repair
+loop identifies the cyclic component and restores only its unconstrained
+ordinary cells to their previously accepted receivers. These repair constraints
+persist across later rounds but count as outlet termination support only when
+the cell also carries measurable incision. Independent audits repeat all graph,
+exclusion, trunk, fixed-receiver, and area-conservation checks.
+
+## Post-Incision Balance
+
+The monthly surface-water solver runs over the corrected cells and candidate
+catalog with the same climate, geology, and fractional-water controls as the
+first pass. Incision and monthly balance repeat up to a configured bound. A
+candidate whose requested outlet cannot descend into fixed or downstream water
+support is grade-limited; a candidate whose existing persisted bed already
+satisfies the requested profile is already-satisfied. These accepted spill
+identities accumulate monotonically across the loop so alternating candidate
+sets cannot oscillate by forgetting the previous feasibility result. Other
+residual records remain an explicit blocker for soils and biomes.
+
+## Persistent Outputs
+
+- `OutletIncisionCandidateCatalog`: one record per requested candidate with
+  requested/applied depth, path termination, width, and status.
+- `OutletIncisionCellCatalog`: unique corrected support with old/new bed,
+  channel width, contributing-candidate count, and eroded volume.
+- `OutletIncisionParentCatalog`: parent-level eroded-volume reconstruction.
+- `OutletCorrectedBasinCellCatalog`: corrected mean terrain, subgrid routing
+  surface, cumulative outlet state, fixed receiver constraints, and rerun
+  hydrology fields.
+- `PostIncisionDepressionCandidateCatalog`: candidates discovered after local
+  rerouting.
+- `OutletIncisionMetadata`: bounds, topology, volume, and trunk diagnostics.
+- `OutletIncisionIterationCatalog`: correction and residual counts, volume, and
+  standing-water area for each bounded round.
+- Final post-incision candidate, cell, monthly, correction, and metadata
+  surface-water catalogs.
+
+## Hard Gates
+
+- Every requested feedback record is applied or explicitly blocked.
+- Corrected paths are finite, bounded, and downstream-descending.
+- Corrected support excludes outside, preserved, and fixed-channel cells except
+  as unmodified termination targets.
+- Child, parent, and total erosion volumes agree within floating-point
+  tolerance.
+- Corrected area and rerouted area remain inside configured bounds.
+- Cycle-repair rounds and total constrained ordinary support remain inside
+  configured bounds.
+- Physical trunk identities and beds are unchanged.
+- The corrected receiver graph is acyclic and conserves active area.
+- Post-incision monthly water balance and immediate-edge transfer audits pass.
+- Soil readiness requires a zero residual feedback count, not merely exhaustion
+  of the configured round count.
+
+## Canonical Provisional Result
+
+The fixed-seed face-128 world converges in seven rounds with residual feedback
+counts `2181, 671, 109, 22, 3, 1, 0`. Across all rounds it removes about
+`1.65e10 m3` from narrow outlet channels. Final accepted standing-water mean
+area is about `238,049 km2`, or `3.74%` of the selected basin's active area.
+The corrected graph conserves contributing area and preserves all 2,434
+physical trunk cells.
+
+This is a structural milestone, not lake calibration. The canonical result has
+10,062 permanent candidates, seven hydrologic-wetland candidates, and no
+seasonal candidates. Candidate count, size distribution, hydroperiod, and
+bathymetry still require multi-seed and multi-resolution Earth comparison.
+
+The depression-catalog aggregation is grouped by candidate rather than scanning
+the complete sparse basin once per candidate. On the canonical catalog this
+preserves byte-identical Arrow output while reducing that operation from about
+`4.77 s` to `0.17 s` on the development machine. Outlet path planning remains
+in Python; routing, fill, contributing area, and monthly balance remain native
+Rust kernels.

--- a/docs/specs/09_soils_biomes.md
+++ b/docs/specs/09_soils_biomes.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Planned. Execution is blocked while `surface_water_ready_for_soils` is false.
+Planned. The canonical fixed-seed outlet-incision run now publishes
+`surface_water_ready_for_soils = 1`; future soil execution must still refuse any
+world whose final surface-water artifact leaves this gate false.
 
 ## Objectives
 - Translate geology + climate into soil properties.

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,10 @@ trunk and connector identities, reroutes local child drainage, and persists
 before/after depression candidates without labeling them all as lakes. The
 refined seasonal surface-water stage now conserves inherited monthly runoff,
 solves fractional fill/spill states, and separates accepted standing water from
-systems requiring another outlet-incision pass. The current output is a
+systems requiring outlet incision. The bounded outlet stage cuts narrow subgrid
+beds by physical volume, preserves ordinary-cell and physical-trunk identities,
+reruns routing in Rust, and repeats monthly balance to a zero-feedback gate. The
+canonical seed currently converges in seven rounds. The current output is a
 functional prototype rather than an atlas-grade world.
 
 Run the fixed six-seed integration gallery and provisional hard gates:
@@ -165,6 +168,12 @@ uv run map-maker-pipeline --stage hydrology_pass2 --config configs/cubed_sphere_
 
 # Monthly fractional lakes, wetlands, transient storage, and outlet feedback
 uv run map-maker-pipeline --stage surface_water --config configs/cubed_sphere_crust_state.yaml
+
+# One bounded outlet-incision and local-reroute pass
+uv run map-maker-pipeline --stage outlet_incision --config configs/cubed_sphere_crust_state.yaml
+
+# Iterative incision plus final zero-feedback monthly surface-water balance
+uv run map-maker-pipeline --stage surface_water_final --config configs/cubed_sphere_crust_state.yaml
 ```
 
 Built wheels currently contain the Python orchestration package only. Until native

--- a/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
+++ b/src/map_maker/pipeline/native/hydrology_pass2/src/lib.rs
@@ -225,6 +225,13 @@ fn validate_inputs(
                     return Err(3);
                 }
             }
+            ANCHOR_NORMAL => {
+                if inputs.fixed_receiver_ids[row] != NO_FIXED_RECEIVER
+                    && inputs.fixed_receiver_ids[row] < TERMINAL_HANDOFF
+                {
+                    return Err(3);
+                }
+            }
             _ if inputs.fixed_receiver_ids[row] != NO_FIXED_RECEIVER => return Err(3),
             _ => {}
         }
@@ -238,15 +245,21 @@ fn validate_inputs(
     }
     let adjacency = build_adjacency(resolution, inputs.cell_ids, &row_by_id);
     for (row, neighbors) in adjacency.iter().enumerate() {
-        if inputs.anchor_kinds[row] != ANCHOR_CHANNEL || inputs.fixed_receiver_ids[row] < 0 {
+        if inputs.fixed_receiver_ids[row] < 0 {
             continue;
         }
         let target_id = inputs.fixed_receiver_ids[row];
-        let Some(&target_row) = row_by_id.get(&target_id) else {
+        if !row_by_id.contains_key(&target_id) {
             return Err(3);
-        };
-        if inputs.anchor_kinds[target_row] != ANCHOR_CHANNEL || !neighbors.contains(&target_id) {
+        }
+        if !neighbors.contains(&target_id) {
             return Err(3);
+        }
+        if inputs.anchor_kinds[row] == ANCHOR_CHANNEL {
+            let target_row = row_by_id[&target_id];
+            if inputs.anchor_kinds[target_row] != ANCHOR_CHANNEL {
+                return Err(3);
+            }
         }
     }
     Ok(RoutingDomain {
@@ -308,6 +321,42 @@ fn route_surface(
         }
     }
 
+    for row in 0..cell_count {
+        if inputs.anchor_kinds[row] == ANCHOR_NORMAL
+            && inputs.fixed_receiver_ids[row] != NO_FIXED_RECEIVER
+        {
+            receiver[row] = inputs.fixed_receiver_ids[row];
+        }
+    }
+    let mut upstream_count = vec![0usize; cell_count];
+    for &receiver_id in &receiver {
+        if let Some(&target) = row_by_id.get(&receiver_id) {
+            upstream_count[target] += 1;
+        }
+    }
+    let mut ready = (0..cell_count)
+        .filter(|row| upstream_count[*row] == 0)
+        .collect::<VecDeque<_>>();
+    let mut order = Vec::with_capacity(cell_count);
+    while let Some(row) = ready.pop_front() {
+        order.push(row);
+        if let Some(&target) = row_by_id.get(&receiver[row]) {
+            upstream_count[target] -= 1;
+            if upstream_count[target] == 0 {
+                ready.push_back(target);
+            }
+        }
+    }
+    if order.len() == cell_count {
+        for &row in order.iter().rev() {
+            if let Some(&target) = row_by_id.get(&receiver[row]) {
+                hydrologic_elevation_m[row] = surface[row].max(hydrologic_elevation_m[target]);
+            } else {
+                hydrologic_elevation_m[row] = surface[row];
+            }
+        }
+    }
+
     let uncovered_count = visited.iter().filter(|value| !**value).count();
     let fill_depth_m = hydrologic_elevation_m
         .iter()
@@ -319,6 +368,7 @@ fn route_surface(
         .map(|row| {
             visited[row]
                 && inputs.anchor_kinds[row] == ANCHOR_NORMAL
+                && inputs.fixed_receiver_ids[row] == NO_FIXED_RECEIVER
                 && fill_depth_m[row] >= config.minimum_depression_depth_m
         })
         .collect::<Vec<_>>();
@@ -756,6 +806,41 @@ mod tests {
         assert_eq!(outcome.cells[1].stabilized_receiver_id, ids[4]);
         assert_eq!(outcome.cells[4].stabilized_receiver_id, ids[7]);
         assert_eq!(outcome.cells[7].stabilized_receiver_id, TERMINAL_OCEAN);
+    }
+
+    #[test]
+    fn constrained_subgrid_outlet_may_discharge_to_an_ordinary_cell() {
+        let (ids, xyz) = grid_fixture();
+        let terrain = vec![6.0, 5.0, 6.0, 5.0, 4.0, 5.0, 6.0, 3.0, 6.0];
+        let mut anchors = vec![ANCHOR_NORMAL; 9];
+        let mut fixed = vec![NO_FIXED_RECEIVER; 9];
+        anchors[7] = ANCHOR_CHANNEL;
+        fixed[1] = ids[4];
+        fixed[7] = TERMINAL_OCEAN;
+        let inputs = Inputs {
+            cell_ids: &ids,
+            terrain_before_m: &terrain,
+            routing_surface_after_m: &terrain,
+            cell_areas_km2: &[1.0; 9],
+            cell_xyz: &xyz,
+            anchor_kinds: &anchors,
+            source_active: &[1; 9],
+            fixed_receiver_ids: &fixed,
+        };
+        let outcome = run_pass(
+            HydrologyPass2Config {
+                fine_resolution: 4,
+                minimum_depression_depth_m: 0.5,
+                planet_radius_m: 6_371_000.0,
+            },
+            &inputs,
+        )
+        .expect("valid outlet-to-terrain handoff");
+        assert_eq!(outcome.stats.graph_valid, 1);
+        assert_eq!(outcome.cells[1].stabilized_receiver_id, ids[4]);
+        assert_eq!(outcome.cells[1].anchor_kind, ANCHOR_NORMAL);
+        assert_eq!(outcome.cells[4].anchor_kind, ANCHOR_NORMAL);
+        assert!(outcome.cells[1].stabilized_depression_id < 0);
     }
 
     #[test]

--- a/src/map_maker/pipeline/stages/__init__.py
+++ b/src/map_maker/pipeline/stages/__init__.py
@@ -10,6 +10,7 @@ from . import basin_refinement  # noqa: F401
 from . import basin_erosion  # noqa: F401
 from . import hydrology_pass2  # noqa: F401
 from . import surface_water  # noqa: F401
+from . import outlet_incision  # noqa: F401
 from . import tectonics  # noqa: F401
 from . import world_age  # noqa: F401
 from . import geology  # noqa: F401
@@ -31,6 +32,7 @@ def ensure_builtin_stages() -> None:
         "basin_erosion": basin_erosion,
         "hydrology_pass2": hydrology_pass2,
         "surface_water": surface_water,
+        "outlet_incision": outlet_incision,
         "tectonics": tectonics,
         "world_age": world_age,
         "geology": geology,

--- a/src/map_maker/pipeline/stages/hydrology_pass2.py
+++ b/src/map_maker/pipeline/stages/hydrology_pass2.py
@@ -191,6 +191,21 @@ def _cell_table(source: pa.Table, records: np.ndarray, routing_surface: np.ndarr
 
 
 def _depression_catalog(cells: pa.Table) -> tuple[pa.Table, dict[str, float | int]]:
+    schema = pa.schema(
+        [
+            ("depression_id", pa.int32()),
+            ("spill_cell_id", pa.int32()),
+            ("spill_receiver_id", pa.int32()),
+            ("cell_count", pa.int32()),
+            ("area_km2", pa.float64()),
+            ("potential_fill_volume_km3", pa.float64()),
+            ("maximum_fill_depth_m", pa.float64()),
+            ("spill_elevation_m", pa.float64()),
+            ("dominant_baseline_depression_id", pa.int32()),
+            ("baseline_overlap_fraction", pa.float64()),
+            ("status", pa.string()),
+        ]
+    )
     cell_ids = np.asarray(cells["fine_cell_id"], dtype=np.int32)
     receiver_ids = np.asarray(cells["stabilized_receiver_id"], dtype=np.int32)
     baseline_ids = np.asarray(cells["baseline_depression_id"], dtype=np.int32)
@@ -223,73 +238,136 @@ def _depression_catalog(cells: pa.Table) -> tuple[pa.Table, dict[str, float | in
     if processed != len(cells):
         raise RuntimeError("local depression candidates use a cyclic receiver graph")
 
-    rows: list[dict[str, object]] = []
     new_area = float(np.sum(area[(stabilized_ids >= 0) & (baseline_ids < 0)]))
-    for depression_id in np.unique(stabilized_ids[stabilized_ids >= 0]):
-        mask = stabilized_ids == depression_id
-        boundary = mask & (receiver_depression != depression_id)
-        boundary_rows = np.flatnonzero(boundary)
-        if len(boundary_rows) == 0:
-            raise RuntimeError("local depression candidate has no spill receiver")
-        if float(np.ptp(level[mask])) > 1e-6:
-            raise RuntimeError("local depression candidate does not have a level spill surface")
-        spill_row = max(
-            boundary_rows,
-            key=lambda row: (int(downstream_rank[row]), -int(cell_ids[row])),
+    candidate_rows = np.flatnonzero(stabilized_ids >= 0)
+    if not len(candidate_rows):
+        removed_area = float(np.sum(area[baseline_ids >= 0]))
+        return pa.Table.from_pylist([], schema=schema), {
+            "new_depression_area_km2": new_area,
+            "removed_depression_area_km2": removed_area,
+            "new_depression_count": 0,
+            "changed_depression_count": 0,
+            "stable_depression_count": 0,
+        }
+    grouped_rows = candidate_rows[np.argsort(stabilized_ids[candidate_rows], kind="stable")]
+    group_ids, group_starts, group_counts = np.unique(
+        stabilized_ids[grouped_rows], return_index=True, return_counts=True
+    )
+    group_ends = group_starts + group_counts
+    group_slices = [grouped_rows[start:end] for start, end in zip(group_starts, group_ends)]
+    candidate_area = np.array([np.sum(area[rows]) for rows in group_slices], dtype=np.float64)
+    candidate_volume = np.array(
+        [np.sum(area[rows] * depth[rows]) / 1_000.0 for rows in group_slices],
+        dtype=np.float64,
+    )
+    candidate_maximum_depth = np.array(
+        [np.max(depth[rows]) for rows in group_slices], dtype=np.float64
+    )
+    group_level_minimum = np.array([np.min(level[rows]) for rows in group_slices], dtype=np.float64)
+    group_level_maximum = np.array([np.max(level[rows]) for rows in group_slices], dtype=np.float64)
+    if np.any(group_level_maximum - group_level_minimum > 1e-6):
+        raise RuntimeError("local depression candidate does not have a level spill surface")
+
+    boundary_rows = candidate_rows[
+        receiver_depression[candidate_rows] != stabilized_ids[candidate_rows]
+    ]
+    boundary_order = np.lexsort(
+        (
+            cell_ids[boundary_rows],
+            -downstream_rank[boundary_rows],
+            stabilized_ids[boundary_rows],
         )
-        overlaps = baseline_ids[mask]
-        overlap_area = area[mask]
-        valid_overlap = overlaps >= 0
-        dominant_baseline = -1
-        dominant_overlap_area = 0.0
-        if np.any(valid_overlap):
-            overlap_totals: dict[int, float] = defaultdict(float)
-            for inherited_id, cell_area in zip(
-                overlaps[valid_overlap], overlap_area[valid_overlap], strict=True
-            ):
-                overlap_totals[int(inherited_id)] += float(cell_area)
-            dominant_baseline, dominant_overlap_area = max(
-                overlap_totals.items(), key=lambda item: (item[1], -item[0])
+    )
+    ordered_boundary_rows = boundary_rows[boundary_order]
+    ordered_boundary_ids = stabilized_ids[ordered_boundary_rows]
+    first_boundary = np.r_[True, ordered_boundary_ids[1:] != ordered_boundary_ids[:-1]]
+    spill_rows = ordered_boundary_rows[first_boundary]
+    if not np.array_equal(stabilized_ids[spill_rows], group_ids):
+        raise RuntimeError("local depression candidate has no spill receiver")
+
+    dominant_baseline = np.full(len(group_ids), -1, dtype=np.int32)
+    dominant_overlap_area = np.zeros(len(group_ids), dtype=np.float64)
+    overlap_rows = candidate_rows[baseline_ids[candidate_rows] >= 0]
+    if len(overlap_rows):
+        overlap_order = np.lexsort(
+            (
+                overlap_rows,
+                baseline_ids[overlap_rows],
+                stabilized_ids[overlap_rows],
             )
-        candidate_area = float(np.sum(area[mask]))
-        if dominant_baseline < 0:
+        )
+        ordered_overlap_rows = overlap_rows[overlap_order]
+        overlap_pairs = np.column_stack(
+            (
+                stabilized_ids[ordered_overlap_rows],
+                baseline_ids[ordered_overlap_rows],
+            )
+        )
+        first_pair = np.r_[True, np.any(overlap_pairs[1:] != overlap_pairs[:-1], axis=1)]
+        pair_starts = np.flatnonzero(first_pair)
+        pair_candidate_ids = overlap_pairs[pair_starts, 0]
+        pair_baseline_ids = overlap_pairs[pair_starts, 1]
+        pair_ends = np.r_[pair_starts[1:], len(ordered_overlap_rows)]
+        pair_areas = np.zeros(len(pair_starts), dtype=np.float64)
+        for pair_row, (start, end) in enumerate(zip(pair_starts, pair_ends, strict=True)):
+            for cell_row in ordered_overlap_rows[start:end]:
+                pair_areas[pair_row] += float(area[cell_row])
+        best_pair_order = np.lexsort((pair_baseline_ids, -pair_areas, pair_candidate_ids))
+        ordered_pair_candidate_ids = pair_candidate_ids[best_pair_order]
+        first_best_pair = np.r_[
+            True,
+            ordered_pair_candidate_ids[1:] != ordered_pair_candidate_ids[:-1],
+        ]
+        best_pairs = best_pair_order[first_best_pair]
+        best_group_rows = np.searchsorted(group_ids, pair_candidate_ids[best_pairs])
+        dominant_baseline[best_group_rows] = pair_baseline_ids[best_pairs]
+        dominant_overlap_area[best_group_rows] = pair_areas[best_pairs]
+
+    forward_stable = np.logical_and.reduceat(
+        baseline_ids[grouped_rows] == stabilized_ids[grouped_rows], group_starts
+    )
+    baseline_rows = np.flatnonzero(baseline_ids >= 0)
+    ordered_baseline_rows = baseline_rows[np.argsort(baseline_ids[baseline_rows], kind="stable")]
+    baseline_group_ids, baseline_group_starts = np.unique(
+        baseline_ids[ordered_baseline_rows], return_index=True
+    )
+    baseline_group_stable = np.logical_and.reduceat(
+        stabilized_ids[ordered_baseline_rows] == baseline_ids[ordered_baseline_rows],
+        baseline_group_starts,
+    )
+    reverse_stable = np.zeros(len(group_ids), dtype=bool)
+    baseline_positions = np.searchsorted(baseline_group_ids, group_ids)
+    baseline_present = baseline_positions < len(baseline_group_ids)
+    baseline_present[baseline_present] &= (
+        baseline_group_ids[baseline_positions[baseline_present]] == group_ids[baseline_present]
+    )
+    reverse_stable[baseline_present] = baseline_group_stable[baseline_positions[baseline_present]]
+
+    rows: list[dict[str, object]] = []
+    for group_row, depression_id in enumerate(group_ids):
+        if dominant_baseline[group_row] < 0:
             status = "new"
-        elif np.all(baseline_ids[mask] == depression_id) and np.all(
-            stabilized_ids[baseline_ids == depression_id] == depression_id
-        ):
+        elif forward_stable[group_row] and reverse_stable[group_row]:
             status = "stable"
         else:
             status = "changed"
+        spill_row = spill_rows[group_row]
         rows.append(
             {
                 "depression_id": int(depression_id),
                 "spill_cell_id": int(cell_ids[spill_row]),
                 "spill_receiver_id": int(receiver_ids[spill_row]),
-                "cell_count": int(np.count_nonzero(mask)),
-                "area_km2": candidate_area,
-                "potential_fill_volume_km3": float(np.sum(area[mask] * depth[mask]) / 1_000.0),
-                "maximum_fill_depth_m": float(np.max(depth[mask])),
+                "cell_count": int(group_counts[group_row]),
+                "area_km2": float(candidate_area[group_row]),
+                "potential_fill_volume_km3": float(candidate_volume[group_row]),
+                "maximum_fill_depth_m": float(candidate_maximum_depth[group_row]),
                 "spill_elevation_m": float(level[spill_row]),
-                "dominant_baseline_depression_id": dominant_baseline,
-                "baseline_overlap_fraction": dominant_overlap_area / max(candidate_area, 1e-12),
+                "dominant_baseline_depression_id": int(dominant_baseline[group_row]),
+                "baseline_overlap_fraction": float(dominant_overlap_area[group_row])
+                / max(float(candidate_area[group_row]), 1e-12),
                 "status": status,
             }
         )
-    schema = pa.schema(
-        [
-            ("depression_id", pa.int32()),
-            ("spill_cell_id", pa.int32()),
-            ("spill_receiver_id", pa.int32()),
-            ("cell_count", pa.int32()),
-            ("area_km2", pa.float64()),
-            ("potential_fill_volume_km3", pa.float64()),
-            ("maximum_fill_depth_m", pa.float64()),
-            ("spill_elevation_m", pa.float64()),
-            ("dominant_baseline_depression_id", pa.int32()),
-            ("baseline_overlap_fraction", pa.float64()),
-            ("status", pa.string()),
-        ]
-    )
     catalog = pa.Table.from_pylist(rows, schema=schema)
     removed_area = float(np.sum(area[(baseline_ids >= 0) & (stabilized_ids < 0)]))
     return catalog, {

--- a/src/map_maker/pipeline/stages/outlet_incision.py
+++ b/src/map_maker/pipeline/stages/outlet_incision.py
@@ -1,0 +1,955 @@
+"""Bounded subgrid outlet incision and local hydrology rerouting."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+import numpy as np
+import pyarrow as pa
+from PIL import Image
+
+from .._hydrology_pass2_native import run_hydrology_pass2
+from ..cubed_sphere import CubedSphereGrid
+from ..registry import stage
+from ..visualization import VisualizationRequest, VisualizationResult
+from . import hydrology_pass2 as pass2
+
+
+@dataclass(frozen=True)
+class OutletIncisionConfig:
+    minimum_outlet_width_m: float = 5.0
+    outlet_width_coefficient: float = 8.0
+    outlet_width_exponent: float = 0.5
+    maximum_outlet_width_m: float = 500.0
+    minimum_outlet_bed_slope: float = 1e-5
+    maximum_outlet_path_cells: int = 64
+    maximum_reroute_repair_rounds: int = 64
+    maximum_incision_depth_m: float = 250.0
+    maximum_cell_mean_lowering_m: float = 5.0
+    minimum_depression_depth_m: float = 5.0
+    maximum_corrected_area_fraction: float = 0.10
+    maximum_receiver_change_area_fraction: float = 0.15
+    maximum_receiver_change_cell_fraction: float = 0.15
+    maximum_reroute_constraint_cell_fraction: float = 0.15
+    maximum_volume_relative_error: float = 1e-10
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "OutletIncisionConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown outlet-incision controls: {', '.join(sorted(unknown))}")
+        values = {
+            name: (
+                int(mapping.get(name, field.default))
+                if name in {"maximum_outlet_path_cells", "maximum_reroute_repair_rounds"}
+                else float(mapping.get(name, field.default))
+            )
+            for name, field in cls.__dataclass_fields__.items()
+        }
+        config = cls(**values)
+        if not 1 <= config.maximum_outlet_path_cells <= 4096:
+            raise ValueError("maximum_outlet_path_cells must be in [1, 4096]")
+        if not 1 <= config.maximum_reroute_repair_rounds <= 4096:
+            raise ValueError("maximum_reroute_repair_rounds must be in [1, 4096]")
+        positive = (
+            "minimum_outlet_width_m",
+            "outlet_width_coefficient",
+            "outlet_width_exponent",
+            "maximum_outlet_width_m",
+            "minimum_outlet_bed_slope",
+            "maximum_incision_depth_m",
+            "maximum_cell_mean_lowering_m",
+            "minimum_depression_depth_m",
+            "maximum_volume_relative_error",
+        )
+        for name in positive:
+            value = getattr(config, name)
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+        if config.minimum_outlet_width_m > config.maximum_outlet_width_m:
+            raise ValueError("minimum_outlet_width_m must not exceed maximum_outlet_width_m")
+        for name in (
+            "maximum_corrected_area_fraction",
+            "maximum_receiver_change_area_fraction",
+            "maximum_receiver_change_cell_fraction",
+            "maximum_reroute_constraint_cell_fraction",
+        ):
+            value = getattr(config, name)
+            if not np.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be finite and in [0, 1]")
+        return config
+
+
+def _artifact_table(result, name: str) -> pa.Table:
+    record = result.artifact_records.get(name)
+    if record is None or not isinstance(record.value, pa.Table):
+        raise KeyError(f"Missing dependency table '{name}'")
+    return record.value
+
+
+def _column(table: pa.Table, name: str, dtype: np.dtype) -> np.ndarray:
+    return np.ascontiguousarray(
+        table[name].combine_chunks().to_numpy(zero_copy_only=False), dtype=dtype
+    )
+
+
+def _fixed_list_column(table: pa.Table, name: str, width: int) -> np.ndarray:
+    values = np.asarray(table[name].combine_chunks().values, dtype=np.float32)
+    return np.ascontiguousarray(values.reshape(table.num_rows, width), dtype=np.float32)
+
+
+def _lookup_rows(ids: np.ndarray, query: np.ndarray, *, label: str) -> np.ndarray:
+    order = np.argsort(ids)
+    sorted_ids = ids[order]
+    positions = np.searchsorted(sorted_ids, query)
+    if np.any(positions >= len(sorted_ids)) or np.any(sorted_ids[positions] != query):
+        raise RuntimeError(f"{label} references an unknown identifier")
+    return order[positions]
+
+
+def _cyclic_rows(cell_ids: np.ndarray, receiver_ids: np.ndarray) -> np.ndarray:
+    routed = receiver_ids >= 0
+    target_rows = np.full(len(cell_ids), -1, dtype=np.int64)
+    if np.any(routed):
+        target_rows[routed] = _lookup_rows(cell_ids, receiver_ids[routed], label="cyclic receiver")
+    upstream_count = np.zeros(len(cell_ids), dtype=np.int32)
+    np.add.at(upstream_count, target_rows[routed], 1)
+    ready = deque(np.flatnonzero(upstream_count == 0).tolist())
+    removed = np.zeros(len(cell_ids), dtype=bool)
+    while ready:
+        row = ready.popleft()
+        removed[row] = True
+        target = target_rows[row]
+        if target >= 0:
+            upstream_count[target] -= 1
+            if upstream_count[target] == 0:
+                ready.append(int(target))
+    return np.flatnonzero(~removed)
+
+
+def _candidate_order(candidate_ids: np.ndarray, downstream_ids: np.ndarray) -> list[int]:
+    row_by_id = {int(value): row for row, value in enumerate(candidate_ids)}
+    downstream = np.full(len(candidate_ids), -1, dtype=np.int32)
+    indegree = np.zeros(len(candidate_ids), dtype=np.int32)
+    for row, downstream_id in enumerate(downstream_ids):
+        if downstream_id < 0:
+            continue
+        target = row_by_id.get(int(downstream_id))
+        if target is None or target == row:
+            raise RuntimeError("outlet-incision candidate graph has an invalid edge")
+        downstream[row] = target
+        indegree[target] += 1
+    ready = deque(np.flatnonzero(indegree == 0).tolist())
+    order: list[int] = []
+    while ready:
+        row = ready.popleft()
+        order.append(row)
+        target = downstream[row]
+        if target >= 0:
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(int(target))
+    if len(order) != len(candidate_ids):
+        raise RuntimeError("outlet-incision candidate graph is cyclic")
+    return order
+
+
+def _edge_length_m(xyz: np.ndarray, source: int, target: int, radius_m: float) -> float:
+    cosine = float(np.clip(np.dot(xyz[source], xyz[target]), -1.0, 1.0))
+    return float(np.arccos(cosine) * radius_m)
+
+
+def _trace_path(
+    *,
+    start_row: int,
+    candidate_id: int,
+    requested_bed_m: float,
+    receiver_rows: np.ndarray,
+    depression_ids: np.ndarray,
+    anchor_kind: np.ndarray,
+    routing_surface_m: np.ndarray,
+    xyz: np.ndarray,
+    radius_m: float,
+    maximum_cells: int,
+) -> tuple[list[int], list[float], int, str, int]:
+    path = [start_row]
+    distance = [0.0]
+    current = start_row
+    for _ in range(maximum_cells - 1):
+        target = int(receiver_rows[current])
+        if target < 0:
+            return path, distance, -1, "terminal", -1
+        edge_length = _edge_length_m(xyz, current, target, radius_m)
+        target_kind = str(anchor_kind[target])
+        target_depression = int(depression_ids[target])
+        if target_kind != "ordinary":
+            return path, distance, target, target_kind, target_depression
+        if target_depression >= 0 and target_depression != candidate_id:
+            return path, distance, target, "candidate", target_depression
+        if routing_surface_m[target] <= requested_bed_m:
+            return path, distance, target, "lower_terrain", target_depression
+        path.append(target)
+        distance.append(distance[-1] + edge_length)
+        current = target
+    target = int(receiver_rows[current])
+    if target < 0:
+        return path, distance, -1, "terminal", -1
+    return path, distance, target, "path_limit", int(depression_ids[target])
+
+
+def _plan_outlets(
+    config: OutletIncisionConfig,
+    cells: pa.Table,
+    candidates: pa.Table,
+    *,
+    radius_m: float,
+) -> tuple[pa.Table, pa.Table, np.ndarray, np.ndarray, dict[str, object]]:
+    cell_ids = _column(cells, "fine_cell_id", np.dtype(np.int32))
+    receiver_ids = _column(cells, "stabilized_receiver_id", np.dtype(np.int32))
+    depression_ids = _column(cells, "stabilized_depression_id", np.dtype(np.int32))
+    routing_surface = _column(cells, "routing_surface_after_m", np.dtype(np.float64))
+    area_km2 = _column(cells, "area_km2", np.dtype(np.float64))
+    xyz = _fixed_list_column(cells, "xyz", 3).astype(np.float64)
+    anchor_kind = np.asarray(cells["routing_anchor_kind"].to_pylist(), dtype=object)
+    routing_support_kind = anchor_kind.copy()
+    if "outlet_fixed_receiver_id" in cells.column_names:
+        prior_fixed_receivers = _column(cells, "outlet_fixed_receiver_id", np.dtype(np.int32))
+        prior_depth = (
+            _column(cells, "outlet_incision_depth_m", np.dtype(np.float64))
+            if "outlet_incision_depth_m" in cells.column_names
+            else np.zeros(cells.num_rows, dtype=np.float64)
+        )
+        prior_outlet_support = (
+            (prior_fixed_receivers != pass2.NO_FIXED_RECEIVER)
+            & (anchor_kind == "ordinary")
+            & (prior_depth > 0.0)
+        )
+        routing_support_kind[prior_outlet_support] = "outlet_constraint"
+    routed = receiver_ids >= 0
+    receiver_rows = np.full(len(cells), -1, dtype=np.int64)
+    if np.any(routed):
+        receiver_rows[routed] = _lookup_rows(
+            cell_ids, receiver_ids[routed], label="outlet receiver"
+        )
+
+    candidate_ids = _column(candidates, "depression_id", np.dtype(np.int32))
+    downstream_ids = _column(candidates, "downstream_depression_id", np.dtype(np.int32))
+    required = np.asarray(candidates["outlet_erosion_required"], dtype=bool)
+    spill_rows = _lookup_rows(
+        cell_ids,
+        _column(candidates, "spill_cell_id", np.dtype(np.int32)),
+        label="outlet spill cell",
+    )
+    spill_level = _column(candidates, "spill_elevation_m", np.dtype(np.float64))
+    recommended = np.minimum(
+        _column(candidates, "recommended_outlet_incision_m", np.dtype(np.float64)),
+        config.maximum_incision_depth_m,
+    )
+    annual_overflow = _column(candidates, "annual_overflow_km3", np.dtype(np.float64))
+    overflow_m3s = annual_overflow * 1e9 / (365.2422 * 86_400.0)
+    width_m = np.clip(
+        config.outlet_width_coefficient
+        * np.power(np.maximum(overflow_m3s, 0.0), config.outlet_width_exponent),
+        config.minimum_outlet_width_m,
+        config.maximum_outlet_width_m,
+    )
+    order = _candidate_order(candidate_ids, downstream_ids)
+    candidate_row_by_id = {int(value): row for row, value in enumerate(candidate_ids)}
+    planned_level = spill_level.copy()
+    requested_bed_by_cell = routing_surface.copy()
+    width_by_cell = np.zeros(len(cells), dtype=np.float64)
+    contributors: dict[int, set[int]] = {}
+    requested_beds_by_candidate: dict[int, list[tuple[int, float]]] = {}
+    plan_rows: list[dict[str, object]] = []
+
+    for candidate_row in reversed(order):
+        if not required[candidate_row]:
+            continue
+        candidate_id = int(candidate_ids[candidate_row])
+        start_row = int(spill_rows[candidate_row])
+        if anchor_kind[start_row] != "ordinary" or depression_ids[start_row] != candidate_id:
+            raise RuntimeError("outlet incision starts outside active ordinary candidate support")
+        requested_bed = spill_level[candidate_row] - recommended[candidate_row]
+        path, distance, boundary_row, termination, boundary_depression = _trace_path(
+            start_row=start_row,
+            candidate_id=candidate_id,
+            requested_bed_m=float(requested_bed),
+            receiver_rows=receiver_rows,
+            depression_ids=depression_ids,
+            anchor_kind=routing_support_kind,
+            routing_surface_m=routing_surface,
+            xyz=xyz,
+            radius_m=radius_m,
+            maximum_cells=config.maximum_outlet_path_cells,
+        )
+        expected_downstream = int(downstream_ids[candidate_row])
+        if termination == "candidate" and boundary_depression != expected_downstream:
+            raise RuntimeError("outlet path reaches a different downstream candidate")
+        if termination == "path_limit":
+            applied_depth = 0.0
+            start_bed = spill_level[candidate_row]
+            status = "blocked_path_limit"
+        else:
+            distance_to_boundary = distance[-1]
+            if boundary_row >= 0:
+                distance_to_boundary += _edge_length_m(xyz, path[-1], boundary_row, radius_m)
+                if termination == "candidate":
+                    boundary_candidate_row = candidate_row_by_id[boundary_depression]
+                    boundary_elevation = planned_level[boundary_candidate_row]
+                elif termination == "preserved_handoff":
+                    boundary_elevation = float(
+                        np.asarray(cells["stabilized_hydrologic_elevation_m"], dtype=np.float64)[
+                            boundary_row
+                        ]
+                    )
+                else:
+                    boundary_elevation = routing_surface[boundary_row]
+                minimum_start_bed = (
+                    boundary_elevation + config.minimum_outlet_bed_slope * distance_to_boundary
+                )
+                start_bed = max(float(requested_bed), float(minimum_start_bed))
+            else:
+                distance_to_boundary = distance[-1]
+                start_bed = float(requested_bed)
+            start_bed = min(start_bed, float(spill_level[candidate_row]))
+            applied_depth = max(float(spill_level[candidate_row] - start_bed), 0.0)
+            status = "applied" if applied_depth > 1e-9 else "blocked_downstream_grade"
+        planned_level[candidate_row] = start_bed
+        if applied_depth > 1e-9:
+            candidate_requests: list[tuple[int, float]] = []
+            for row, downstream_distance in zip(path, distance, strict=True):
+                bed = start_bed - config.minimum_outlet_bed_slope * downstream_distance
+                requested_bed_by_cell[row] = min(requested_bed_by_cell[row], bed)
+                width_by_cell[row] = max(width_by_cell[row], width_m[candidate_row])
+                contributors.setdefault(row, set()).add(candidate_id)
+                candidate_requests.append((row, bed))
+            requested_beds_by_candidate[candidate_id] = candidate_requests
+        plan_rows.append(
+            {
+                "depression_id": candidate_id,
+                "downstream_depression_id": expected_downstream,
+                "spill_cell_id": int(cell_ids[start_row]),
+                "termination_kind": termination,
+                "termination_cell_id": int(cell_ids[boundary_row]) if boundary_row >= 0 else -1,
+                "termination_depression_id": boundary_depression,
+                "status": status,
+                "path_cell_count": len(path),
+                "path_distance_m": float(distance_to_boundary),
+                "mean_overflow_discharge_m3s": float(overflow_m3s[candidate_row]),
+                "outlet_width_m": float(width_m[candidate_row]),
+                "old_spill_elevation_m": float(spill_level[candidate_row]),
+                "requested_incision_m": float(recommended[candidate_row]),
+                "planned_incision_m": applied_depth,
+                "planned_spill_bed_m": float(start_bed),
+            }
+        )
+
+    corrected_bed = np.minimum(routing_surface, requested_bed_by_cell)
+    incision_depth = routing_surface - corrected_bed
+    corrected = incision_depth > 1e-9
+    for plan in plan_rows:
+        if plan["status"] != "applied":
+            continue
+        requests = requested_beds_by_candidate[int(plan["depression_id"])]
+        if not any(routing_surface[cell_row] - bed > 1e-9 for cell_row, bed in requests):
+            plan["status"] = "already_satisfied"
+    representative_length_m = np.sqrt(area_km2 * 1e6)
+    eroded_volume_m3 = incision_depth * width_by_cell * representative_length_m
+    maximum_volume = config.maximum_cell_mean_lowering_m * area_km2 * 1e6
+    eroded_volume_m3 = np.minimum(eroded_volume_m3, maximum_volume)
+    mean_lowering_m = eroded_volume_m3 / (area_km2 * 1e6)
+    corrected_rows = np.flatnonzero(corrected)
+    cell_catalog = pa.table(
+        {
+            "fine_cell_id": pa.array(cell_ids[corrected_rows], type=pa.int32()),
+            "parent_cell_id": pa.array(
+                _column(cells, "parent_cell_id", np.dtype(np.int32))[corrected_rows],
+                type=pa.int32(),
+            ),
+            "area_km2": pa.array(area_km2[corrected_rows], type=pa.float64()),
+            "old_routing_bed_m": pa.array(routing_surface[corrected_rows], type=pa.float64()),
+            "corrected_routing_bed_m": pa.array(corrected_bed[corrected_rows], type=pa.float64()),
+            "incision_depth_m": pa.array(incision_depth[corrected_rows], type=pa.float64()),
+            "outlet_width_m": pa.array(width_by_cell[corrected_rows], type=pa.float64()),
+            "representative_length_m": pa.array(
+                representative_length_m[corrected_rows], type=pa.float64()
+            ),
+            "eroded_volume_m3": pa.array(eroded_volume_m3[corrected_rows], type=pa.float64()),
+            "terrain_mean_lowering_m": pa.array(mean_lowering_m[corrected_rows], type=pa.float64()),
+            "contributing_candidate_count": pa.array(
+                [len(contributors[int(row)]) for row in corrected_rows], type=pa.int32()
+            ),
+            "minimum_contributing_depression_id": pa.array(
+                [min(contributors[int(row)]) for row in corrected_rows], type=pa.int32()
+            ),
+        }
+    )
+    candidate_schema = pa.schema(
+        [
+            ("depression_id", pa.int32()),
+            ("downstream_depression_id", pa.int32()),
+            ("spill_cell_id", pa.int32()),
+            ("termination_kind", pa.string()),
+            ("termination_cell_id", pa.int32()),
+            ("termination_depression_id", pa.int32()),
+            ("status", pa.string()),
+            ("path_cell_count", pa.int32()),
+            ("path_distance_m", pa.float64()),
+            ("mean_overflow_discharge_m3s", pa.float64()),
+            ("outlet_width_m", pa.float64()),
+            ("old_spill_elevation_m", pa.float64()),
+            ("requested_incision_m", pa.float64()),
+            ("planned_incision_m", pa.float64()),
+            ("planned_spill_bed_m", pa.float64()),
+        ]
+    )
+    candidate_catalog = pa.Table.from_pylist(plan_rows, schema=candidate_schema)
+    active = np.asarray(cells["source_active"], dtype=bool)
+    metadata = {
+        "requested_candidate_count": int(np.count_nonzero(required)),
+        "applied_candidate_count": sum(plan["status"] == "applied" for plan in plan_rows),
+        "blocked_candidate_count": sum(plan["status"] != "applied" for plan in plan_rows),
+        "path_limit_candidate_count": sum(
+            plan["status"] == "blocked_path_limit" for plan in plan_rows
+        ),
+        "already_satisfied_candidate_count": sum(
+            plan["status"] == "already_satisfied" for plan in plan_rows
+        ),
+        "corrected_cell_count": int(np.count_nonzero(corrected)),
+        "corrected_area_km2": float(np.sum(area_km2[corrected])),
+        "corrected_area_fraction": float(np.sum(area_km2[corrected]))
+        / max(float(np.sum(area_km2[active])), 1e-12),
+        "total_eroded_volume_m3": float(np.sum(eroded_volume_m3)),
+        "maximum_incision_depth_m": float(np.max(incision_depth, initial=0.0)),
+        "maximum_terrain_mean_lowering_m": float(np.max(mean_lowering_m, initial=0.0)),
+        "maximum_path_cell_count": 0,
+        "grade_blocked_spill_cell_ids": [
+            int(plan["spill_cell_id"])
+            for plan in plan_rows
+            if plan["status"] == "blocked_downstream_grade"
+        ],
+        "outlet_feedback_suppressed_spill_cell_ids": [
+            int(plan["spill_cell_id"])
+            for plan in plan_rows
+            if plan["status"] in {"blocked_downstream_grade", "already_satisfied"}
+        ],
+    }
+    if plan_rows:
+        metadata["maximum_path_cell_count"] = max(
+            int(plan["path_cell_count"]) for plan in plan_rows
+        )
+        metadata["maximum_path_distance_m"] = max(
+            float(plan["path_distance_m"]) for plan in plan_rows
+        )
+    else:
+        metadata["maximum_path_distance_m"] = 0.0
+    return candidate_catalog, cell_catalog, corrected_bed, mean_lowering_m, metadata
+
+
+def _replace_column(table: pa.Table, name: str, values: pa.Array) -> pa.Table:
+    index = table.schema.get_field_index(name)
+    if index < 0:
+        raise KeyError(f"Missing column '{name}'")
+    return table.set_column(index, name, values)
+
+
+def _corrected_cell_table(
+    source: pa.Table,
+    records: np.ndarray,
+    corrected_routing_surface: np.ndarray,
+    mean_lowering_m: np.ndarray,
+    outlet_cells: pa.Table,
+    outlet_fixed_receivers: np.ndarray,
+) -> pa.Table:
+    old_receiver = _column(source, "stabilized_receiver_id", np.dtype(np.int32))
+    old_depression = _column(source, "stabilized_depression_id", np.dtype(np.int32))
+    old_hydrologic = _column(source, "stabilized_hydrologic_elevation_m", np.dtype(np.float64))
+    old_routing = _column(source, "routing_surface_after_m", np.dtype(np.float64))
+    replaceable_fields = (
+        "pre_outlet_receiver_id",
+        "pre_outlet_depression_id",
+        "pre_outlet_hydrologic_elevation_m",
+        "pre_outlet_routing_surface_m",
+        "outlet_terrain_mean_lowering_m",
+        "outlet_incision_depth_m",
+        "outlet_width_m",
+        "outlet_contributing_candidate_count",
+        "outlet_fixed_receiver_id",
+    )
+    existing_replaceable = [name for name in replaceable_fields if name in source.column_names]
+    table = source.drop_columns(existing_replaceable) if existing_replaceable else source
+    table = table.append_column("pre_outlet_receiver_id", pa.array(old_receiver, type=pa.int32()))
+    table = table.append_column(
+        "pre_outlet_depression_id", pa.array(old_depression, type=pa.int32())
+    )
+    table = table.append_column(
+        "pre_outlet_hydrologic_elevation_m", pa.array(old_hydrologic, type=pa.float64())
+    )
+    table = table.append_column(
+        "pre_outlet_routing_surface_m", pa.array(old_routing, type=pa.float64())
+    )
+    rerun_fields = (
+        "routing_surface_after_m",
+        "baseline_receiver_id",
+        "stabilized_receiver_id",
+        "baseline_anchor_cell_id",
+        "stabilized_anchor_cell_id",
+        "baseline_depression_id",
+        "stabilized_depression_id",
+        "routing_anchor_kind",
+        "terminal_kind_pass2",
+        "receiver_changed",
+        "depression_changed",
+        "baseline_hydrologic_elevation_m",
+        "stabilized_hydrologic_elevation_m",
+        "baseline_fill_depth_m",
+        "stabilized_fill_depth_m",
+        "stabilized_flow_slope",
+        "contributing_area_km2",
+        "stabilized_flow_direction_xyz",
+    )
+    table = table.drop_columns(rerun_fields)
+    terrain_after = _column(source, "terrain_elevation_after_m", np.dtype(np.float64))
+    table = _replace_column(
+        table,
+        "terrain_elevation_after_m",
+        pa.array(terrain_after - mean_lowering_m, type=pa.float64()),
+    )
+    previous_mean_lowering = (
+        _column(source, "outlet_terrain_mean_lowering_m", np.dtype(np.float64))
+        if "outlet_terrain_mean_lowering_m" in source.column_names
+        else np.zeros(source.num_rows, dtype=np.float64)
+    )
+    table = table.append_column(
+        "outlet_terrain_mean_lowering_m",
+        pa.array(previous_mean_lowering + mean_lowering_m, type=pa.float64()),
+    )
+    outlet_depth = np.zeros(source.num_rows, dtype=np.float64)
+    outlet_width = np.zeros(source.num_rows, dtype=np.float64)
+    outlet_contributors = np.zeros(source.num_rows, dtype=np.int32)
+    if outlet_cells.num_rows:
+        source_ids = _column(source, "fine_cell_id", np.dtype(np.int32))
+        rows = _lookup_rows(
+            source_ids,
+            _column(outlet_cells, "fine_cell_id", np.dtype(np.int32)),
+            label="outlet correction cell",
+        )
+        outlet_depth[rows] = _column(outlet_cells, "incision_depth_m", np.dtype(np.float64))
+        outlet_width[rows] = _column(outlet_cells, "outlet_width_m", np.dtype(np.float64))
+        outlet_contributors[rows] = _column(
+            outlet_cells, "contributing_candidate_count", np.dtype(np.int32)
+        )
+    previous_depth = (
+        _column(source, "outlet_incision_depth_m", np.dtype(np.float64))
+        if "outlet_incision_depth_m" in source.column_names
+        else np.zeros(source.num_rows, dtype=np.float64)
+    )
+    previous_width = (
+        _column(source, "outlet_width_m", np.dtype(np.float64))
+        if "outlet_width_m" in source.column_names
+        else np.zeros(source.num_rows, dtype=np.float64)
+    )
+    previous_contributors = (
+        _column(source, "outlet_contributing_candidate_count", np.dtype(np.int32))
+        if "outlet_contributing_candidate_count" in source.column_names
+        else np.zeros(source.num_rows, dtype=np.int32)
+    )
+    table = table.append_column(
+        "outlet_incision_depth_m", pa.array(previous_depth + outlet_depth, type=pa.float64())
+    )
+    table = table.append_column(
+        "outlet_width_m", pa.array(np.maximum(previous_width, outlet_width), type=pa.float64())
+    )
+    table = table.append_column(
+        "outlet_contributing_candidate_count",
+        pa.array(previous_contributors + outlet_contributors, type=pa.int32()),
+    )
+    table = table.append_column(
+        "outlet_fixed_receiver_id", pa.array(outlet_fixed_receivers, type=pa.int32())
+    )
+    return pass2._cell_table(table, records, corrected_routing_surface)
+
+
+def _parent_catalog(cells: pa.Table, outlet_cells: pa.Table) -> tuple[pa.Table, float]:
+    parent_ids = np.unique(_column(cells, "parent_cell_id", np.dtype(np.int32)))
+    volume = np.zeros(len(parent_ids), dtype=np.float64)
+    corrected_count = np.zeros(len(parent_ids), dtype=np.int32)
+    corrected_area = np.zeros(len(parent_ids), dtype=np.float64)
+    if outlet_cells.num_rows:
+        outlet_parent = _column(outlet_cells, "parent_cell_id", np.dtype(np.int32))
+        parent_rows = _lookup_rows(parent_ids, outlet_parent, label="outlet correction parent")
+        np.add.at(
+            volume,
+            parent_rows,
+            _column(outlet_cells, "eroded_volume_m3", np.dtype(np.float64)),
+        )
+        np.add.at(corrected_count, parent_rows, 1)
+        np.add.at(
+            corrected_area,
+            parent_rows,
+            _column(outlet_cells, "area_km2", np.dtype(np.float64)),
+        )
+    table = pa.table(
+        {
+            "parent_cell_id": pa.array(parent_ids, type=pa.int32()),
+            "outlet_eroded_volume_m3": pa.array(volume, type=pa.float64()),
+            "corrected_child_count": pa.array(corrected_count, type=pa.int32()),
+            "corrected_child_area_km2": pa.array(corrected_area, type=pa.float64()),
+        }
+    )
+    return table, float(np.sum(volume))
+
+
+def _cube_net_visualizer(result, request: VisualizationRequest) -> VisualizationResult | None:
+    cell_record = result.artifact_records.get("OutletCorrectedBasinCellCatalog")
+    metadata_record = result.artifact_records.get("OutletIncisionMetadata")
+    if (
+        cell_record is None
+        or metadata_record is None
+        or not isinstance(cell_record.value, pa.Table)
+    ):
+        return None
+    cells = cell_record.value
+    metadata = metadata_record.value
+    fine_resolution = int(metadata["fine_resolution"])
+    display_resolution = min(fine_resolution, 768)
+    placements = np.array([[1, 1], [1, 3], [1, 2], [1, 0], [0, 1], [2, 1]])
+    face = np.asarray(cells["face"], dtype=np.int32)
+    row = np.asarray(cells["row"], dtype=np.int32)
+    col = np.asarray(cells["col"], dtype=np.int32)
+    display_row = np.minimum(row * display_resolution // fine_resolution, display_resolution - 1)
+    display_col = np.minimum(col * display_resolution // fine_resolution, display_resolution - 1)
+    net_row = placements[face, 0] * display_resolution + display_row
+    net_col = placements[face, 1] * display_resolution + display_col
+    image = np.full((display_resolution * 3, display_resolution * 4, 3), 17, dtype=np.uint8)
+    active = np.asarray(cells["source_active"], dtype=bool)
+    image[net_row[active], net_col[active]] = (48, 64, 52)
+    incision = np.asarray(cells["outlet_incision_depth_m"], dtype=np.float64)
+    corrected = incision > 0.0
+    if np.any(corrected):
+        strength = np.clip(
+            np.log1p(incision[corrected])
+            / max(float(np.log1p(np.max(incision[corrected]))), 1e-12),
+            0.25,
+            1.0,
+        )
+        base = image[net_row[corrected], net_col[corrected]].astype(np.float64)
+        target = np.array([232.0, 146.0, 55.0])
+        image[net_row[corrected], net_col[corrected]] = (
+            base * (1.0 - strength[:, None]) + target * strength[:, None]
+        ).astype(np.uint8)
+    rendered = Image.fromarray(image, mode="RGB")
+    padding = max(12, display_resolution // 40)
+    left = max(0, int(np.min(net_col)) - padding)
+    upper = max(0, int(np.min(net_row)) - padding)
+    right = min(rendered.width, int(np.max(net_col)) + padding + 1)
+    lower = min(rendered.height, int(np.max(net_row)) + padding + 1)
+    rendered = rendered.crop((left, upper, right, lower))
+    scale = min(1600 / rendered.width, 1000 / rendered.height)
+    if scale > 1.0:
+        rendered = rendered.resize(
+            (max(1, round(rendered.width * scale)), max(1, round(rendered.height * scale))),
+            Image.Resampling.NEAREST,
+        )
+    output = request.output_dir / "outlet_incision.png"
+    rendered.save(output)
+    return VisualizationResult(
+        output,
+        "OutletCorrectedBasinCellCatalog",
+        {
+            "requested_candidate_count": metadata["requested_candidate_count"],
+            "corrected_cell_count": metadata["corrected_cell_count"],
+        },
+    )
+
+
+@stage(
+    "outlet_incision",
+    inputs=("surface_water", "hydrology_pass2", "planet"),
+    outputs=(
+        "OutletIncisionCandidateCatalog",
+        "OutletIncisionCellCatalog",
+        "OutletIncisionParentCatalog",
+        "OutletCorrectedBasinCellCatalog",
+        "PostIncisionDepressionCandidateCatalog",
+        "StabilizedBasinCellCatalog",
+        "StabilizedRiverReachCatalog",
+        "LocalDepressionCandidateCatalog",
+        "HydrologyCorrectionCatalog",
+        "HydrologyPass2Metadata",
+        "OutletIncisionMetadata",
+    ),
+    version="v5",
+    native_libraries=("hydrology_pass2_native",),
+    visualizer=_cube_net_visualizer,
+)
+def outlet_incision_stage(context, deps, config_mapping: Mapping[str, object]):
+    config = OutletIncisionConfig.from_mapping(config_mapping)
+    if not isinstance(context.topology, CubedSphereGrid):
+        raise NotImplementedError("outlet incision requires topology: cubed_sphere")
+    pass2_result = deps["hydrology_pass2"]
+    surface_result = deps["surface_water"]
+    cells = _artifact_table(pass2_result, "StabilizedBasinCellCatalog")
+    candidates = _artifact_table(surface_result, "SurfaceWaterCandidateCatalog")
+    reaches = _artifact_table(pass2_result, "StabilizedRiverReachCatalog")
+    pass2_metadata = pass2_result.artifact_records["HydrologyPass2Metadata"].value
+    surface_metadata = surface_result.artifact_records["SurfaceWaterMetadata"].value
+    required_count = int(np.count_nonzero(np.asarray(candidates["outlet_erosion_required"])))
+    if required_count != int(surface_metadata["outlet_erosion_required_count"]):
+        raise RuntimeError("outlet feedback count disagrees with surface-water metadata")
+    planet = deps["planet"].artifact_records["PlanetMetadata"].value
+    radius_m = float(planet["planet_radius_earth"]) * pass2.EARTH_RADIUS_M
+
+    with context.timed("bounded_outlet_path_planning"):
+        (
+            candidate_catalog,
+            cell_catalog,
+            corrected_routing_surface,
+            mean_lowering_m,
+            path_metadata,
+        ) = _plan_outlets(config, cells, candidates, radius_m=radius_m)
+
+    prior_suppressed_spill_ids = {
+        int(value)
+        for value in pass2_metadata.get(
+            "outlet_feedback_suppressed_spill_cell_ids",
+            pass2_metadata.get("grade_blocked_spill_cell_ids", []),
+        )
+    }
+    suppressed_spill_values = path_metadata["outlet_feedback_suppressed_spill_cell_ids"]
+    if not isinstance(suppressed_spill_values, list):
+        raise RuntimeError("outlet planner emitted invalid suppressed-spill metadata")
+    current_suppressed_spill_ids = {int(value) for value in suppressed_spill_values}
+    path_metadata["prior_suppressed_outlet_spill_cell_count"] = len(prior_suppressed_spill_ids)
+    combined_suppressed_spill_ids = sorted(
+        prior_suppressed_spill_ids | current_suppressed_spill_ids
+    )
+    path_metadata["outlet_feedback_suppressed_spill_cell_ids"] = combined_suppressed_spill_ids
+    path_metadata["suppressed_outlet_spill_cell_count"] = len(combined_suppressed_spill_ids)
+
+    cell_ids = _column(cells, "fine_cell_id", np.dtype(np.int32))
+    old_receivers = _column(cells, "stabilized_receiver_id", np.dtype(np.int32))
+    anchor_names = np.asarray(cells["routing_anchor_kind"].to_pylist(), dtype=object)
+    anchor_code_by_name = {
+        "ordinary": pass2.ANCHOR_NORMAL,
+        "channel": pass2.ANCHOR_CHANNEL,
+        "preserved_handoff": pass2.ANCHOR_EXCLUDED,
+        "outside_terminal": pass2.ANCHOR_OUTSIDE,
+    }
+    try:
+        anchor_kinds = np.array(
+            [anchor_code_by_name[str(value)] for value in anchor_names], dtype=np.uint8
+        )
+    except KeyError as exc:
+        raise RuntimeError("outlet incision received an unknown routing anchor kind") from exc
+    channel_rows = np.flatnonzero(anchor_kinds == pass2.ANCHOR_CHANNEL)
+    fixed_receivers = np.full(len(cells), pass2.NO_FIXED_RECEIVER, dtype=np.int32)
+    fixed_receivers[channel_rows] = old_receivers[channel_rows]
+    if "outlet_fixed_receiver_id" in cells.column_names:
+        prior_fixed_receivers = _column(cells, "outlet_fixed_receiver_id", np.dtype(np.int32))
+        prior_constraint_rows = np.flatnonzero(prior_fixed_receivers != pass2.NO_FIXED_RECEIVER)
+        if np.any(anchor_kinds[prior_constraint_rows] != pass2.ANCHOR_NORMAL):
+            raise RuntimeError("prior outlet constraints overlap a non-ordinary routing anchor")
+        fixed_receivers[prior_constraint_rows] = prior_fixed_receivers[prior_constraint_rows]
+    else:
+        prior_constraint_rows = np.empty(0, dtype=np.int64)
+    if cell_catalog.num_rows:
+        new_constraint_rows = _lookup_rows(
+            cell_ids,
+            _column(cell_catalog, "fine_cell_id", np.dtype(np.int32)),
+            label="outlet constraint cell",
+        )
+        if np.any(anchor_kinds[new_constraint_rows] != pass2.ANCHOR_NORMAL):
+            raise RuntimeError("outlet constraints overlap a non-ordinary routing anchor")
+        fixed_receivers[new_constraint_rows] = old_receivers[new_constraint_rows]
+    else:
+        new_constraint_rows = np.empty(0, dtype=np.int64)
+    ordinary_fixed_receivers = np.full(len(cells), pass2.NO_FIXED_RECEIVER, dtype=np.int32)
+    ordinary_constraint_rows = np.flatnonzero(
+        (fixed_receivers != pass2.NO_FIXED_RECEIVER) & (anchor_kinds == pass2.ANCHOR_NORMAL)
+    )
+    ordinary_fixed_receivers[ordinary_constraint_rows] = fixed_receivers[ordinary_constraint_rows]
+    source_active = np.ascontiguousarray(np.asarray(cells["source_active"]), dtype=np.uint8)
+    old_routing_surface = _column(cells, "routing_surface_after_m", np.dtype(np.float64))
+    controls = {
+        "fine_resolution": int(pass2_metadata["fine_resolution"]),
+        "minimum_depression_depth_m": config.minimum_depression_depth_m,
+        "planet_radius_m": radius_m,
+    }
+    repair_round = 0
+    repair_cell_count = 0
+    active_count = int(np.count_nonzero(source_active))
+    constrained_active_count = int(
+        np.count_nonzero(
+            (ordinary_fixed_receivers != pass2.NO_FIXED_RECEIVER) & (source_active != 0)
+        )
+    )
+    if (
+        constrained_active_count / max(active_count, 1)
+        > config.maximum_reroute_constraint_cell_fraction
+    ):
+        raise RuntimeError("post-outlet reroute constraint scope exceeds its bound")
+    with context.timed("post_outlet_hydrology_kernel"):
+        while True:
+            records, native_metadata = run_hydrology_pass2(
+                controls=controls,
+                cell_ids=cell_ids,
+                terrain_before_m=old_routing_surface,
+                routing_surface_after_m=corrected_routing_surface,
+                cell_areas_km2=_column(cells, "area_km2", np.dtype(np.float64)),
+                cell_xyz=_fixed_list_column(cells, "xyz", 3),
+                anchor_kinds=anchor_kinds,
+                source_active=source_active,
+                fixed_receiver_ids=fixed_receivers,
+            )
+            if native_metadata["graph_valid"] == 1:
+                break
+            if repair_round >= config.maximum_reroute_repair_rounds:
+                raise RuntimeError("post-outlet reroute exceeded its cycle-repair round bound")
+            cyclic_rows = _cyclic_rows(
+                cell_ids,
+                np.ascontiguousarray(records["stabilized_receiver_id"], dtype=np.int32),
+            )
+            repair_rows = cyclic_rows[
+                (anchor_kinds[cyclic_rows] == pass2.ANCHOR_NORMAL)
+                & (fixed_receivers[cyclic_rows] == pass2.NO_FIXED_RECEIVER)
+            ]
+            if not len(repair_rows):
+                raise RuntimeError("post-outlet reroute has an irreparable fixed-receiver cycle")
+            fixed_receivers[repair_rows] = old_receivers[repair_rows]
+            ordinary_fixed_receivers[repair_rows] = old_receivers[repair_rows]
+            repair_cell_count += len(repair_rows)
+            repair_round += 1
+            constrained_active_count = int(
+                np.count_nonzero(
+                    (ordinary_fixed_receivers != pass2.NO_FIXED_RECEIVER) & (source_active != 0)
+                )
+            )
+            if (
+                constrained_active_count / max(active_count, 1)
+                > config.maximum_reroute_constraint_cell_fraction
+            ):
+                raise RuntimeError("post-outlet reroute constraint scope exceeds its bound")
+    if native_metadata["trunk_preserved_valid"] != 1:
+        raise RuntimeError("post-outlet hydrology changed the accepted physical trunk")
+    if native_metadata["process_exclusion_valid"] != 1:
+        raise RuntimeError("post-outlet hydrology violated process-excluded support")
+    constrained_rows = np.flatnonzero(fixed_receivers != pass2.NO_FIXED_RECEIVER)
+    if np.any(
+        records["stabilized_receiver_id"][constrained_rows] != fixed_receivers[constrained_rows]
+    ):
+        raise RuntimeError("post-outlet hydrology changed a fixed receiver")
+    corrected_cells = _corrected_cell_table(
+        cells,
+        records,
+        corrected_routing_surface,
+        mean_lowering_m,
+        cell_catalog,
+        ordinary_fixed_receivers,
+    )
+    post_candidates, depression_metadata = pass2._depression_catalog(corrected_cells)
+    hydrology_corrections = pass2._correction_catalog(corrected_cells)
+    graph_metadata = pass2._graph_audit(
+        corrected_cells, fixed_receivers, channel_rows, radius_m=radius_m
+    )
+    parent_catalog, parent_total_volume_m3 = _parent_catalog(cells, cell_catalog)
+    cell_total_volume_m3 = float(
+        np.sum(_column(cell_catalog, "eroded_volume_m3", np.dtype(np.float64)))
+    )
+    volume_relative_error = abs(parent_total_volume_m3 - cell_total_volume_m3) / max(
+        cell_total_volume_m3, 1e-12
+    )
+    receiver_change_cell_fraction = int(
+        graph_metadata["independent_receiver_changed_cell_count"]
+    ) / max(active_count, 1)
+    active_area_km2 = float(graph_metadata["independent_active_area_km2"])
+    area_tolerance = 1e-8 * max(active_area_km2, 1.0)
+    metadata = {
+        **asdict(config),
+        **path_metadata,
+        **depression_metadata,
+        **native_metadata,
+        **graph_metadata,
+        "selected_basin_id": int(pass2_metadata["selected_basin_id"]),
+        "fine_resolution": int(pass2_metadata["fine_resolution"]),
+        "pre_incision_candidate_count": candidates.num_rows,
+        "post_incision_candidate_count": post_candidates.num_rows,
+        "cell_total_eroded_volume_m3": cell_total_volume_m3,
+        "parent_total_eroded_volume_m3": parent_total_volume_m3,
+        "volume_reconstruction_relative_error": volume_relative_error,
+        "receiver_change_cell_fraction": receiver_change_cell_fraction,
+        "new_outlet_constraint_cell_count": int(len(new_constraint_rows)),
+        "prior_outlet_constraint_cell_count": int(len(prior_constraint_rows)),
+        "reroute_cycle_repair_round_count": repair_round,
+        "new_reroute_repair_cell_count": repair_cell_count,
+        "total_outlet_routing_constraint_cell_count": int(
+            np.count_nonzero(ordinary_fixed_receivers != pass2.NO_FIXED_RECEIVER)
+        ),
+        "total_fixed_receiver_cell_count": int(len(constrained_rows)),
+        "total_fixed_channel_cell_count": int(len(channel_rows)),
+        "surface_water_stage_name": "surface_water_final",
+        "routing_semantics": "bounded_subgrid_outlet_beds_with_constrained_receivers",
+        "terrain_semantics": "channel_volume_divided_by_child_area",
+    }
+    if path_metadata["requested_candidate_count"] != candidate_catalog.num_rows:
+        raise RuntimeError("outlet-incision candidate catalog does not cover every request")
+    if path_metadata["path_limit_candidate_count"]:
+        raise RuntimeError("outlet-incision path exceeds the configured cell bound")
+    if path_metadata["corrected_area_fraction"] > config.maximum_corrected_area_fraction:
+        raise RuntimeError("outlet-incision corrected area exceeds the configured bound")
+    if volume_relative_error > config.maximum_volume_relative_error:
+        raise RuntimeError("outlet-incision parent and cell volumes do not agree")
+    if native_metadata["graph_valid"] != 1 or graph_metadata["independent_graph_valid"] != 1:
+        raise RuntimeError("post-outlet hydrology produced a cyclic or uncovered graph")
+    if (
+        native_metadata["trunk_preserved_valid"] != 1
+        or graph_metadata["trunk_receiver_mismatch_count"]
+    ):
+        raise RuntimeError("outlet incision changed the accepted physical trunk")
+    if (
+        native_metadata["process_exclusion_valid"] != 1
+        or graph_metadata["independent_process_exclusion_valid"] != 1
+    ):
+        raise RuntimeError("outlet incision routed through process-excluded support")
+    if graph_metadata["invalid_terminal_receiver_count"]:
+        raise RuntimeError("outlet incision emitted an invalid terminal receiver")
+    if (
+        abs(float(native_metadata["contributing_area_residual_km2"])) > area_tolerance
+        or abs(float(graph_metadata["independent_contributing_area_residual_km2"])) > area_tolerance
+        or float(graph_metadata["maximum_downstream_contributing_area_error_km2"]) > area_tolerance
+    ):
+        raise RuntimeError("post-outlet hydrology does not conserve contributing area")
+    if (
+        graph_metadata["independent_receiver_changed_area_fraction"]
+        > config.maximum_receiver_change_area_fraction
+        or receiver_change_cell_fraction > config.maximum_receiver_change_cell_fraction
+    ):
+        raise RuntimeError("post-outlet receiver change exceeds the configured bound")
+    if (
+        float(graph_metadata["maximum_flow_direction_norm_error"]) > 1e-5
+        or float(graph_metadata["maximum_flow_direction_tangent_error"]) > 1e-5
+        or float(graph_metadata["maximum_flow_slope_relation_error"]) > 1e-12
+    ):
+        raise RuntimeError("post-outlet flow vectors or slopes are inconsistent")
+    context.logger.log_event(
+        {"type": "outlet_incision_summary", "stage": "outlet_incision", **metadata}
+    )
+    return {
+        "OutletIncisionCandidateCatalog": candidate_catalog,
+        "OutletIncisionCellCatalog": cell_catalog,
+        "OutletIncisionParentCatalog": parent_catalog,
+        "OutletCorrectedBasinCellCatalog": corrected_cells,
+        "PostIncisionDepressionCandidateCatalog": post_candidates,
+        "StabilizedBasinCellCatalog": corrected_cells,
+        "StabilizedRiverReachCatalog": reaches,
+        "LocalDepressionCandidateCatalog": post_candidates,
+        "HydrologyCorrectionCatalog": hydrology_corrections,
+        "HydrologyPass2Metadata": metadata,
+        "OutletIncisionMetadata": metadata,
+    }
+
+
+__all__ = ["OutletIncisionConfig", "outlet_incision_stage"]

--- a/src/map_maker/pipeline/stages/surface_water.py
+++ b/src/map_maker/pipeline/stages/surface_water.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import asdict, dataclass
+from types import SimpleNamespace
 from typing import Mapping
 
 import numpy as np
@@ -91,6 +92,34 @@ class SurfaceWaterConfig:
         ):
             raise ValueError("minimum_wet_area_fraction must be finite and in (0, 1]")
         return config
+
+
+@dataclass(frozen=True)
+class SurfaceWaterFinalConfig:
+    maximum_outlet_incision_rounds: int = 8
+    require_soil_readiness: bool = False
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "SurfaceWaterFinalConfig":
+        known = set(cls.__dataclass_fields__)
+        unknown = set(mapping) - known
+        if unknown:
+            raise ValueError(f"Unknown final surface-water controls: {', '.join(sorted(unknown))}")
+        maximum_rounds = int(
+            mapping.get(
+                "maximum_outlet_incision_rounds",
+                cls.__dataclass_fields__["maximum_outlet_incision_rounds"].default,
+            )
+        )
+        raw_required = mapping.get(
+            "require_soil_readiness",
+            cls.__dataclass_fields__["require_soil_readiness"].default,
+        )
+        if not isinstance(raw_required, bool):
+            raise ValueError("require_soil_readiness must be a boolean")
+        if not 1 <= maximum_rounds <= 32:
+            raise ValueError("maximum_outlet_incision_rounds must be in [1, 32]")
+        return cls(maximum_rounds, raw_required)
 
 
 def _artifact_table(result, name: str) -> pa.Table:
@@ -294,6 +323,7 @@ def _outlet_erosion_feedback(
     cell_records: np.ndarray,
     rock_strength: np.ndarray,
     accommodation: np.ndarray,
+    suppressed_outlet_spill_cell_ids: set[int] | None = None,
 ) -> tuple[
     np.ndarray,
     np.ndarray,
@@ -340,8 +370,17 @@ def _outlet_erosion_feedback(
     )
     pre_adjustment_codes = candidate_records["class_code"]
     lake_like = (pre_adjustment_codes == 2) | (pre_adjustment_codes == 3)
+    suppressed_spill_ids = suppressed_outlet_spill_cell_ids or set()
+    if suppressed_spill_ids:
+        bounded_outlet_resolved = lake_like & np.isin(
+            np.asarray(candidates["spill_cell_id"], dtype=np.int32),
+            np.fromiter(suppressed_spill_ids, dtype=np.int32),
+        )
+    else:
+        bounded_outlet_resolved = np.zeros(len(candidates), dtype=bool)
     erosion_required = (
         lake_like
+        & ~bounded_outlet_resolved
         & (mean_overflow_m3s > 0.0)
         & (mean_overflow_m3s >= config.minimum_outlet_erosion_discharge_m3s)
         & (erosion_score >= config.outlet_erosion_score_threshold)
@@ -356,6 +395,7 @@ def _outlet_erosion_feedback(
     reasons = np.select(
         [
             erosion_required,
+            bounded_outlet_resolved,
             pre_adjustment_codes == 0,
             pre_adjustment_codes == 1,
             pre_adjustment_codes == 2,
@@ -364,6 +404,7 @@ def _outlet_erosion_feedback(
         ],
         [
             "outlet_erosion_feedback",
+            "bounded_outlet_feedback_resolved",
             "no_material_water",
             "short_hydroperiod",
             "seasonal_hydroperiod",
@@ -376,6 +417,10 @@ def _outlet_erosion_feedback(
     feedback_metadata: dict[str, object] = {
         "outlet_erosion_required_count": int(np.count_nonzero(erosion_required)),
         "outlet_erosion_required_mean_water_area_km2": float(np.sum(mean_area[erosion_required])),
+        "bounded_outlet_feedback_resolved_count": int(np.count_nonzero(bounded_outlet_resolved)),
+        "bounded_outlet_feedback_resolved_mean_water_area_km2": float(
+            np.sum(mean_area[bounded_outlet_resolved])
+        ),
         "maximum_outlet_erosion_score": float(np.max(erosion_score)),
         "maximum_recommended_outlet_incision_m": float(np.max(recommended_incision_m)),
         "outlet_erosion_score_semantics": ("head_weak_rock_low_accommodation_sustained_overflow"),
@@ -617,7 +662,7 @@ def _cube_net_visualizer(result, request: VisualizationRequest) -> Visualization
         "SurfaceWaterMonthlyStateCatalog",
         "SurfaceWaterMetadata",
     ),
-    version="v1",
+    version="v3",
     native_libraries=("surface_water_native",),
     visualizer=_cube_net_visualizer,
 )
@@ -716,6 +761,13 @@ def surface_water_stage(context, deps, config_mapping: Mapping[str, object]):
         cell_records,
         rock_strength,
         accommodation,
+        {
+            int(value)
+            for value in pass2_metadata.get(
+                "outlet_feedback_suppressed_spill_cell_ids",
+                pass2_metadata.get("grade_blocked_spill_cell_ids", []),
+            )
+        },
     )
     candidate_table = _candidate_table(
         candidates,
@@ -891,9 +943,8 @@ def surface_water_stage(context, deps, config_mapping: Mapping[str, object]):
         > config.maximum_area_reconstruction_relative_error
     ):
         raise RuntimeError("surface-water cell fractions do not reconstruct candidate area")
-    context.logger.log_event(
-        {"type": "surface_water_summary", "stage": "surface_water", **metadata}
-    )
+    summary_stage = str(pass2_metadata.get("surface_water_stage_name", "surface_water"))
+    context.logger.log_event({"type": "surface_water_summary", "stage": summary_stage, **metadata})
     return {
         "SurfaceWaterCandidateCatalog": candidate_table,
         "SeasonalSurfaceWaterCellCatalog": cell_table,
@@ -902,4 +953,195 @@ def surface_water_stage(context, deps, config_mapping: Mapping[str, object]):
     }
 
 
-__all__ = ["SurfaceWaterConfig", "surface_water_stage"]
+@stage(
+    "surface_water_final",
+    inputs=("outlet_incision", "climate", "geology", "basin_refinement", "planet"),
+    outputs=(
+        "SurfaceWaterCandidateCatalog",
+        "SeasonalSurfaceWaterCellCatalog",
+        "SurfaceWaterMonthlyStateCatalog",
+        "SurfaceWaterMetadata",
+        "OutletIncisionIterationCatalog",
+        "FinalOutletIncisionCandidateCatalog",
+        "FinalOutletIncisionCellCatalog",
+        "FinalOutletCorrectedBasinCellCatalog",
+        "FinalPostIncisionDepressionCandidateCatalog",
+        "FinalOutletIncisionMetadata",
+    ),
+    version="v3",
+    native_libraries=("surface_water_native",),
+    visualizer=_cube_net_visualizer,
+)
+def surface_water_final_stage(context, deps, config_mapping: Mapping[str, object]):
+    final_config = SurfaceWaterFinalConfig.from_mapping(config_mapping)
+    surface_controls = dict(context.config.stage_config("surface_water"))
+    outlet_controls = dict(context.config.stage_config("outlet_incision"))
+
+    def memory_result(output: Mapping[str, object]):
+        return SimpleNamespace(
+            artifact_records={name: SimpleNamespace(value=value) for name, value in output.items()}
+        )
+
+    def with_iteration(table: pa.Table, iteration: int) -> pa.Table:
+        return table.append_column(
+            "outlet_incision_iteration",
+            pa.array(np.full(table.num_rows, iteration, dtype=np.int32), type=pa.int32()),
+        )
+
+    current_hydrology = deps["outlet_incision"]
+    output = dict(
+        surface_water_stage(
+            context,
+            {
+                "hydrology_pass2": current_hydrology,
+                "climate": deps["climate"],
+                "geology": deps["geology"],
+                "basin_refinement": deps["basin_refinement"],
+            },
+            surface_controls,
+        )
+    )
+    candidate_corrections = [
+        with_iteration(
+            _artifact_table(deps["outlet_incision"], "OutletIncisionCandidateCatalog"), 1
+        )
+    ]
+    cell_corrections = [
+        with_iteration(_artifact_table(deps["outlet_incision"], "OutletIncisionCellCatalog"), 1)
+    ]
+    iteration_rows: list[dict[str, object]] = []
+    iteration = 1
+    outlet_metadata = deps["outlet_incision"].artifact_records["OutletIncisionMetadata"].value
+
+    def record_iteration(
+        iteration_number: int,
+        correction_metadata: Mapping[str, object],
+        balance_metadata: Mapping[str, object],
+    ) -> None:
+        iteration_rows.append(
+            {
+                "iteration": iteration_number,
+                "requested_candidate_count": int(correction_metadata["requested_candidate_count"]),
+                "applied_candidate_count": int(correction_metadata["applied_candidate_count"]),
+                "blocked_candidate_count": int(correction_metadata["blocked_candidate_count"]),
+                "corrected_cell_count": int(correction_metadata["corrected_cell_count"]),
+                "eroded_volume_m3": float(correction_metadata["total_eroded_volume_m3"]),
+                "post_correction_candidate_count": int(balance_metadata["candidate_count"]),
+                "residual_feedback_candidate_count": int(
+                    balance_metadata["outlet_erosion_required_count"]
+                ),
+                "accepted_standing_water_mean_area_km2": float(
+                    balance_metadata["accepted_standing_water_mean_area_km2"]
+                ),
+                "water_balance_relative_error": float(
+                    balance_metadata["independent_water_balance_relative_error"]
+                ),
+            }
+        )
+
+    record_iteration(iteration, outlet_metadata, output["SurfaceWaterMetadata"])
+    while (
+        int(output["SurfaceWaterMetadata"]["outlet_erosion_required_count"]) > 0
+        and iteration < final_config.maximum_outlet_incision_rounds
+    ):
+        from .outlet_incision import outlet_incision_stage
+
+        iteration += 1
+        correction_output = dict(
+            outlet_incision_stage(
+                context,
+                {
+                    "surface_water": memory_result(output),
+                    "hydrology_pass2": current_hydrology,
+                    "planet": deps["planet"],
+                },
+                outlet_controls,
+            )
+        )
+        current_hydrology = memory_result(correction_output)
+        outlet_metadata = correction_output["OutletIncisionMetadata"]
+        candidate_corrections.append(
+            with_iteration(correction_output["OutletIncisionCandidateCatalog"], iteration)
+        )
+        cell_corrections.append(
+            with_iteration(correction_output["OutletIncisionCellCatalog"], iteration)
+        )
+        output = dict(
+            surface_water_stage(
+                context,
+                {
+                    "hydrology_pass2": current_hydrology,
+                    "climate": deps["climate"],
+                    "geology": deps["geology"],
+                    "basin_refinement": deps["basin_refinement"],
+                },
+                surface_controls,
+            )
+        )
+        record_iteration(iteration, outlet_metadata, output["SurfaceWaterMetadata"])
+
+    metadata = dict(output["SurfaceWaterMetadata"])
+    metadata.update(
+        {
+            "surface_water_phase": "post_outlet_incision",
+            "outlet_incision_iteration_count": iteration,
+            "maximum_outlet_incision_rounds": final_config.maximum_outlet_incision_rounds,
+            "total_requested_outlet_corrections": int(
+                sum(row["requested_candidate_count"] for row in iteration_rows)
+            ),
+            "total_applied_outlet_corrections": int(
+                sum(row["applied_candidate_count"] for row in iteration_rows)
+            ),
+            "total_blocked_outlet_corrections": int(
+                sum(row["blocked_candidate_count"] for row in iteration_rows)
+            ),
+            "total_outlet_eroded_volume_m3": float(
+                sum(row["eroded_volume_m3"] for row in iteration_rows)
+            ),
+            "outlet_correction_converged": int(metadata["outlet_erosion_required_count"] == 0),
+            "model": "bounded_iterative_outlet_candidate_monthly_balance_v1",
+        }
+    )
+    output["SurfaceWaterMetadata"] = metadata
+    output["OutletIncisionIterationCatalog"] = pa.Table.from_pylist(
+        iteration_rows,
+        schema=pa.schema(
+            [
+                ("iteration", pa.int32()),
+                ("requested_candidate_count", pa.int32()),
+                ("applied_candidate_count", pa.int32()),
+                ("blocked_candidate_count", pa.int32()),
+                ("corrected_cell_count", pa.int32()),
+                ("eroded_volume_m3", pa.float64()),
+                ("post_correction_candidate_count", pa.int32()),
+                ("residual_feedback_candidate_count", pa.int32()),
+                ("accepted_standing_water_mean_area_km2", pa.float64()),
+                ("water_balance_relative_error", pa.float64()),
+            ]
+        ),
+    )
+    output["FinalOutletIncisionCandidateCatalog"] = pa.concat_tables(candidate_corrections)
+    output["FinalOutletIncisionCellCatalog"] = pa.concat_tables(cell_corrections)
+    output["FinalOutletCorrectedBasinCellCatalog"] = _artifact_table(
+        current_hydrology, "OutletCorrectedBasinCellCatalog"
+    )
+    output["FinalPostIncisionDepressionCandidateCatalog"] = _artifact_table(
+        current_hydrology, "PostIncisionDepressionCandidateCatalog"
+    )
+    output["FinalOutletIncisionMetadata"] = dict(outlet_metadata)
+    if final_config.require_soil_readiness and not metadata["surface_water_ready_for_soils"]:
+        raise RuntimeError(
+            "bounded outlet-incision rounds ended with residual surface-water feedback"
+        )
+    context.logger.log_event(
+        {"type": "surface_water_final_summary", "stage": "surface_water_final", **metadata}
+    )
+    return output
+
+
+__all__ = [
+    "SurfaceWaterConfig",
+    "SurfaceWaterFinalConfig",
+    "surface_water_stage",
+    "surface_water_final_stage",
+]

--- a/src/map_maker/pipeline/tools.py
+++ b/src/map_maker/pipeline/tools.py
@@ -275,6 +275,8 @@ def main(args: Iterable[str] | None = None) -> int:
             "basin_erosion",
             "hydrology_pass2",
             "surface_water",
+            "outlet_incision",
+            "surface_water_final",
         ],
         default="topology",
     )
@@ -349,8 +351,12 @@ def main(args: Iterable[str] | None = None) -> int:
             stage_name = "basin_erosion"
         elif parsed.stage == "hydrology_pass2":
             stage_name = "hydrology_pass2"
-        else:
+        elif parsed.stage == "surface_water":
             stage_name = "surface_water"
+        elif parsed.stage == "outlet_incision":
+            stage_name = "outlet_incision"
+        else:
+            stage_name = "surface_water_final"
         started = time.perf_counter()
         ExecutionEngine(config, generate_visuals=not parsed.skip_visuals).run([stage_name])
         elapsed_ms = (time.perf_counter() - started) * 1000.0
@@ -378,6 +384,8 @@ def main(args: Iterable[str] | None = None) -> int:
         "basin_erosion",
         "hydrology_pass2",
         "surface_water",
+        "outlet_incision",
+        "surface_water_final",
     }:
         parser.error(f"--stage {parsed.stage} requires --config")
     if parsed.stage == "topology":

--- a/tests/test_hydrology_pass2.py
+++ b/tests/test_hydrology_pass2.py
@@ -186,6 +186,31 @@ def test_depression_catalog_uses_final_exit_after_reentry():
     assert catalog["spill_receiver_id"][0].as_py() == 3
 
 
+def test_depression_catalog_accepts_an_empty_candidate_set():
+    cells = pa.table(
+        {
+            "fine_cell_id": pa.array([0, 1], type=pa.int32()),
+            "stabilized_receiver_id": pa.array([1, -1], type=pa.int32()),
+            "baseline_depression_id": pa.array([7, -1], type=pa.int32()),
+            "stabilized_depression_id": pa.array([-1, -1], type=pa.int32()),
+            "area_km2": pa.array([2.0, 3.0], type=pa.float64()),
+            "stabilized_fill_depth_m": pa.array([0.0, 0.0], type=pa.float64()),
+            "stabilized_hydrologic_elevation_m": pa.array([2.0, 1.0], type=pa.float64()),
+        }
+    )
+
+    catalog, metadata = _depression_catalog(cells)
+
+    assert catalog.num_rows == 0
+    assert metadata == {
+        "new_depression_area_km2": 0.0,
+        "removed_depression_area_km2": 2.0,
+        "new_depression_count": 0,
+        "changed_depression_count": 0,
+        "stable_depression_count": 0,
+    }
+
+
 def test_hydrology_pass2_stabilizes_real_connector_basin(tmp_path: Path):
     engine = ExecutionEngine(_config(tmp_path, "pass2"), generate_visuals=True)
     results = engine.run(["basin_erosion", "hydrology_pass2"])

--- a/tests/test_outlet_incision.py
+++ b/tests/test_outlet_incision.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from map_maker.pipeline import ExecutionEngine, PipelineConfig, registry
+from map_maker.pipeline.stages.hydrology_pass2 import NO_FIXED_RECEIVER
+from map_maker.pipeline.stages.outlet_incision import OutletIncisionConfig, _cyclic_rows
+
+
+@pytest.fixture(autouse=True)
+def _ensure_stages_registered():
+    registry().clear()
+    for module_name in (
+        "geometry",
+        "planet",
+        "tectonics",
+        "world_age",
+        "geology",
+        "elevation",
+        "climate",
+        "hydrology",
+        "basin_refinement",
+        "basin_erosion",
+        "hydrology_pass2",
+        "surface_water",
+        "outlet_incision",
+    ):
+        module = importlib.import_module(f"map_maker.pipeline.stages.{module_name}")
+        importlib.reload(module)
+    yield
+
+
+def _config(
+    tmp_path: Path, run_id: str, *, minimum_outlet_discharge_m3s: float = 0.10
+) -> PipelineConfig:
+    return PipelineConfig.from_mapping(
+        {
+            "topology": "cubed_sphere",
+            "resolutions": [{"face_resolution": 16}],
+            "rng_seed": 22,
+            "run_id": run_id,
+            "output_dir": str(tmp_path / "out"),
+            "cache_dir": str(tmp_path / "cache"),
+            "log_dir": str(tmp_path / "logs"),
+            "stage_overrides": {
+                "tectonics": {
+                    "num_plates": 14,
+                    "continental_fraction": 0.35,
+                    "lloyd_iterations": 3,
+                },
+                "world_age": {"world_age": 4.1},
+                "climate": {
+                    "spinup_years": 10,
+                    "moisture_spinup_years": 2,
+                    "moisture_steps_per_month_at_face_128": 16,
+                },
+                "basin_refinement": {
+                    "refinement_factor": 4,
+                    "terrain_noise_fraction": 0.4,
+                },
+                "basin_erosion": {
+                    "minimum_bed_slope": 1e-5,
+                    "maximum_deposition_fraction": 0.35,
+                    "deposition_slope_scale": 0.001,
+                    "maximum_deposition_depth_m": 10.0,
+                },
+                "hydrology_pass2": {
+                    "minimum_depression_depth_m": 5.0,
+                    "maximum_receiver_change_fraction": 0.15,
+                    "maximum_receiver_change_cell_fraction": 0.15,
+                    "maximum_new_depression_area_fraction": 0.02,
+                },
+                "surface_water": {
+                    "minimum_solver_iterations": 8,
+                    "maximum_solver_iterations": 64,
+                    "maximum_connected_inundation_fraction": 0.25,
+                    "outlet_erosion_score_threshold": 0.30,
+                    "outlet_erosion_depth_scale_m": 200.0,
+                    "minimum_outlet_erosion_discharge_m3s": minimum_outlet_discharge_m3s,
+                },
+                "outlet_incision": {
+                    "maximum_outlet_path_cells": 64,
+                    "maximum_reroute_repair_rounds": 64,
+                    "maximum_corrected_area_fraction": 0.10,
+                    "maximum_receiver_change_area_fraction": 0.15,
+                    "maximum_receiver_change_cell_fraction": 0.15,
+                    "maximum_reroute_constraint_cell_fraction": 0.15,
+                },
+                "surface_water_final": {
+                    "maximum_outlet_incision_rounds": 8,
+                    "require_soil_readiness": True,
+                },
+            },
+        }
+    )
+
+
+def _table(result, name: str) -> pa.Table:
+    value = result.artifact_records[name].value
+    assert isinstance(value, pa.Table)
+    return value
+
+
+def test_cycle_detector_returns_only_cyclic_support():
+    cell_ids = np.array([10, 11, 12, 13, 14], dtype=np.int32)
+    receivers = np.array([11, 12, 11, 12, -1], dtype=np.int32)
+
+    assert _cyclic_rows(cell_ids, receivers).tolist() == [1, 2]
+
+
+def test_outlet_config_rejects_invalid_bounds():
+    with pytest.raises(ValueError, match="Unknown outlet-incision controls"):
+        OutletIncisionConfig.from_mapping({"magic": 1})
+    with pytest.raises(ValueError, match="maximum_reroute_repair_rounds"):
+        OutletIncisionConfig.from_mapping({"maximum_reroute_repair_rounds": 0})
+    with pytest.raises(ValueError, match="maximum_reroute_constraint_cell_fraction"):
+        OutletIncisionConfig.from_mapping({"maximum_reroute_constraint_cell_fraction": 1.1})
+
+
+def test_final_surface_water_converges_with_bounded_persistent_outlets(tmp_path: Path):
+    config = _config(tmp_path, "outlet-final")
+    results = ExecutionEngine(config).run(["surface_water_final"])
+    outlet = results["outlet_incision"]
+    final = results["surface_water_final"]
+    outlet_metadata = outlet.artifact_records["OutletIncisionMetadata"].value
+    final_metadata = final.artifact_records["SurfaceWaterMetadata"].value
+    cells = _table(final, "FinalOutletCorrectedBasinCellCatalog")
+    iterations = _table(final, "OutletIncisionIterationCatalog")
+
+    assert outlet_metadata["graph_valid"] == 1
+    assert outlet_metadata["independent_graph_valid"] == 1
+    assert outlet_metadata["trunk_preserved_valid"] == 1
+    assert outlet_metadata["process_exclusion_valid"] == 1
+    assert outlet_metadata["corrected_area_fraction"] <= 0.10
+    assert outlet_metadata["independent_receiver_changed_area_fraction"] <= 0.15
+    assert final_metadata["outlet_erosion_required_count"] == 0
+    assert final_metadata["outlet_correction_converged"] == 1
+    assert final_metadata["surface_water_ready_for_soils"] == 1
+    assert iterations["residual_feedback_candidate_count"][-1].as_py() == 0
+    assert len(cells.column_names) == len(set(cells.column_names))
+
+    fixed = np.asarray(cells["outlet_fixed_receiver_id"], dtype=np.int32)
+    constrained = fixed != NO_FIXED_RECEIVER
+    anchors = np.asarray(cells["routing_anchor_kind"].to_pylist())
+    assert np.any(constrained)
+    assert np.all(anchors[constrained] == "ordinary")
+    assert np.all(
+        np.asarray(cells["stabilized_receiver_id"], dtype=np.int32)[constrained]
+        == fixed[constrained]
+    )
+
+    cached = ExecutionEngine(config).run(["surface_water_final"])["surface_water_final"]
+    assert cached.stats is not None and cached.stats.cache_hit
+
+
+def test_final_surface_water_accepts_a_zero_correction_world(tmp_path: Path):
+    config = _config(
+        tmp_path,
+        "outlet-noop",
+        minimum_outlet_discharge_m3s=100_000.0,
+    )
+
+    results = ExecutionEngine(config).run(["surface_water_final"])
+    outlet_metadata = results["outlet_incision"].artifact_records["OutletIncisionMetadata"].value
+    final = results["surface_water_final"]
+    final_metadata = final.artifact_records["SurfaceWaterMetadata"].value
+    iterations = _table(final, "OutletIncisionIterationCatalog")
+
+    assert outlet_metadata["requested_candidate_count"] == 0
+    assert outlet_metadata["corrected_cell_count"] == 0
+    assert final_metadata["outlet_incision_iteration_count"] == 1
+    assert final_metadata["outlet_erosion_required_count"] == 0
+    assert final_metadata["surface_water_ready_for_soils"] == 1
+    assert iterations["residual_feedback_candidate_count"].to_pylist() == [0]


### PR DESCRIPTION
## Summary
- add bounded subgrid outlet incision with persistent ordinary-cell receiver constraints and Rust hydrology reruns
- iterate incision and monthly surface-water balance to a hard zero-feedback soil-readiness gate
- preserve physical trunks, audit volume/area/graph invariants, and support naturally zero-correction worlds
- replace quadratic depression catalog scans with byte-identical grouped aggregation

## Canonical result
- converges in 7 rounds: 2181 -> 671 -> 109 -> 22 -> 3 -> 1 -> 0 residual requests
- final standing-water mean area: 238,049 km2 (3.74% of selected active basin)
- cumulative narrow-channel erosion: 16.491 km3
- contributing-area and monthly water balances pass; surface_water_ready_for_soils = 1

## Validation
- 131 Python tests pass
- all 55 Rust workspace tests pass
- Ruff lint and changed-file formatting pass
- canonical hard-gated run and cache replay pass
- depression catalog benchmark: 4.77 s -> 0.17 s with byte-identical Arrow output

## Remaining realism caveat
The final area is plausible as a provisional aggregate, but the render remains too speckled: 10,062 candidates classify as permanent lakes, 7 as hydrologic wetlands, and none as seasonal. Multi-seed/multi-resolution size-distribution, hydroperiod, and bathymetry calibration remains required.